### PR TITLE
Type filters

### DIFF
--- a/src/Filter/Type/ToBool.php
+++ b/src/Filter/Type/ToBool.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Type;
+
+use Membrane\Filter;
+use Membrane\Result\Result;
+
+class Boolean implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        // TODO: Implement filter() method.
+    }
+}

--- a/src/Filter/Type/ToBool.php
+++ b/src/Filter/Type/ToBool.php
@@ -5,12 +5,26 @@ declare(strict_types=1);
 namespace Membrane\Filter\Type;
 
 use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 
-class Boolean implements Filter
+class ToBool implements Filter
 {
     public function filter(mixed $value): Result
     {
-        // TODO: Implement filter() method.
+        if (!is_scalar($value)) {
+            $message = new Message('ToBool filter only accepts scalar values, %s given', [gettype($value)]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        $bool = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+
+        if ($bool === null) {
+            $message = new Message('ToBool filter failed to convert value to boolean', []);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        return Result::noResult($bool);
     }
 }

--- a/src/Filter/Type/ToDateTime.php
+++ b/src/Filter/Type/ToDateTime.php
@@ -4,7 +4,37 @@ declare(strict_types=1);
 
 namespace Membrane\Filter\Type;
 
-class ToDateTime
-{
+use DateTime;
+use DateTimeImmutable;
+use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
 
+class ToDateTime implements Filter
+{
+    public function __construct(
+        private readonly string $format,
+        private readonly bool   $immutable = true
+    )
+    {
+    }
+
+    public function filter(mixed $value): Result
+    {
+        $dateTime = $this->immutable === true ?
+            DateTimeImmutable::createFromFormat($this->format, $value)
+            :
+            DateTime::createFromFormat($this->format, $value);
+
+
+        if ($dateTime === false) {
+            $message = new Message(
+                'String does not match the required format',
+                [$this->immutable ? DateTimeImmutable::getLastErrors() : DateTime::getLastErrors()]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        return Result::noResult($dateTime);
+    }
 }

--- a/src/Filter/Type/ToDateTime.php
+++ b/src/Filter/Type/ToDateTime.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Type;
+
+class ToDateTime
+{
+
+}

--- a/src/Filter/Type/ToFloat.php
+++ b/src/Filter/Type/ToFloat.php
@@ -14,10 +14,9 @@ class ToFloat implements Filter
     public function filter(mixed $value): Result
     {
         $type = gettype($value);
-        $scalar = is_scalar($value);
 
-        if (!$scalar) {
-            $message = new Message('ToFloat filter only accepts scalar variables, %s is not scalar', [$type]);
+        if (!(is_scalar($value) || $value === null)) {
+            $message = new Message('ToFloat filter only accepts null or scalar values, %s given', [$type]);
             return Result::invalid($value, new MessageSet(null, $message));
         }
         if ($type === 'string' && !is_numeric($value)) {

--- a/src/Filter/Type/ToFloat.php
+++ b/src/Filter/Type/ToFloat.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Type;
+
+use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+
+class ToFloat implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        $type = gettype($value);
+        $scalar = is_scalar($value);
+
+        if (!$scalar) {
+            $message = new Message('ToFloat filter only accepts scalar variables, %s is not scalar', [$type]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+        if ($type === 'string' && !is_numeric($value)) {
+            $message = new Message('ToFloat filter only accepts numeric strings', []);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        return Result::noResult((float)$value);
+    }
+}

--- a/src/Filter/Type/ToInt.php
+++ b/src/Filter/Type/ToInt.php
@@ -14,10 +14,9 @@ class ToInt implements Filter
     public function filter(mixed $value): Result
     {
         $type = gettype($value);
-        $scalar = is_scalar($value);
 
-        if (!$scalar) {
-            $message = new Message('ToInt filter only accepts scalar variables, %s is not scalar', [$type]);
+        if (!(is_scalar($value) || $value === null)) {
+            $message = new Message('ToInt filter only accepts null or scalar values, %s given', [$type]);
             return Result::invalid($value, new MessageSet(null, $message));
         }
         if ($type === 'string' && !is_numeric($value)) {

--- a/src/Filter/Type/ToInt.php
+++ b/src/Filter/Type/ToInt.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Type;
+
+use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+
+class ToInt implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        $type = gettype($value);
+        $scalar = is_scalar($value);
+
+        if (!$scalar) {
+            $message = new Message('ToInt filter only accepts scalar variables, %s is not scalar', [$type]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+        if ($type === 'string' && !is_numeric($value)) {
+            $message = new Message('ToInt filter only accepts numeric strings', []);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        return Result::noResult((int)$value);
+    }
+}

--- a/src/Filter/Type/ToList.php
+++ b/src/Filter/Type/ToList.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Membrane\Filter\Type;
 
 use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 
-class ArrayToList implements Filter
+class ToList implements Filter
 {
     public function filter(mixed $value): Result
     {
-        // TODO: Implement filter() method.
+        if (!is_array($value)) {
+            $message = new Message('ToList filter only accepts arrays, %s given', [gettype($value)]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        return Result::noResult(array_values($value));
     }
 }

--- a/src/Filter/Type/ToList.php
+++ b/src/Filter/Type/ToList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Type;
+
+use Membrane\Filter;
+use Membrane\Result\Result;
+
+class ArrayToList implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        // TODO: Implement filter() method.
+    }
+}

--- a/src/Filter/Type/ToString.php
+++ b/src/Filter/Type/ToString.php
@@ -4,7 +4,25 @@ declare(strict_types=1);
 
 namespace Membrane\Filter\Type;
 
-class ToString
-{
+use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
 
+class ToString implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        $type = gettype($value);
+        if (!($type === 'object' || $value === null || is_scalar($value))) {
+            $message = new Message('ToString filter only accepts objects, null or scalar values, %s given', [$type]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+        if ($type === 'object' && !method_exists($value, '__toString')) {
+            $message = new Message('ToString Filter only accepts objects with __toString method', []);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        return Result::noResult((string)$value);
+    }
 }

--- a/src/Filter/Type/ToString.php
+++ b/src/Filter/Type/ToString.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Type;
+
+class ToString
+{
+
+}

--- a/tests/Filter/Type/ToBoolTest.php
+++ b/tests/Filter/Type/ToBoolTest.php
@@ -5,12 +5,102 @@ declare(strict_types=1);
 namespace Filter\Type;
 
 use Membrane\Filter\Type\ToBool;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Membrane\Filter\Type\ToBool
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
  */
 class ToBoolTest extends TestCase
 {
+    public function DataSetsWithAcceptableInputs(): array
+    {
+        return [
+            [1, true],
+            [1.0, true],
+            [true, true],
+            ['true', true],
+            ['on', true],
+            ['yes', true],
+            [0, false],
+            [0.0, false],
+            [false, false],
+            ['false', false],
+            ['off', false],
+            ['no', false],
+        ];
+    }
 
+    /**
+     * @test
+     * @dataProvider DataSetsWithAcceptableInputs
+     */
+    public function AcceptableTypesReturnBooleanValues($input, $expectedValue): void
+    {
+        $toBool = new ToBool();
+        $expected = Result::noResult($expectedValue);
+
+        $result = $toBool->filter($input);
+
+        self::assertSame($expected->value, $result->value);
+        self::assertEquals($expected->result, $result->result);
+    }
+
+    public function DataSetsWithUnacceptableInputs(): array
+    {
+        $unacceptableMessage = 'ToBool filter only accepts scalar values, %s given';
+        $failureMessage = 'ToBool filter failed to convert value to boolean';
+        $class = new class () {
+        };
+
+        return [
+            [
+                'string with true inside but it is not the only word',
+                new Message($failureMessage, [])
+            ],
+            [
+                2,
+                new Message($failureMessage, [])
+            ],
+            [
+                0.1,
+                new Message($failureMessage, [])
+            ],
+            [
+                ['an', 'array', 'with', 'true', 'inside'],
+                new Message($unacceptableMessage, ['array'])
+            ],
+            [
+                ['a' => 'list'],
+                new Message($unacceptableMessage, ['array'])
+            ],
+            [
+                $class,
+                new Message($unacceptableMessage, ['object'])
+            ],
+            [
+                null,
+                new Message($unacceptableMessage, ['NULL'])
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithUnacceptableInputs
+     */
+    public function UnacceptableTypesReturnInvalid($input, $expectedMessage): void
+    {
+        $toBool = new ToBool();
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+
+        $result = $toBool->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
 }

--- a/tests/Filter/Type/ToBoolTest.php
+++ b/tests/Filter/Type/ToBoolTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Type;
+
+use Membrane\Filter\Type\ToBool;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Filter\Type\ToBool
+ */
+class ToBoolTest extends TestCase
+{
+
+}

--- a/tests/Filter/Type/ToDateTimeTest.php
+++ b/tests/Filter/Type/ToDateTimeTest.php
@@ -4,7 +4,118 @@ declare(strict_types=1);
 
 namespace Filter\Type;
 
-class ToDateTimeTest
-{
+use DateTime;
+use DateTimeImmutable;
+use Membrane\Filter\Type\ToDateTime;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers ToDateTime
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
+ */
+class ToDateTimeTest extends TestCase
+{
+    public function DataSetsThatPass(): array
+    {
+        return [
+            ['', ''],
+            ['Y-m-d', '1970-01-01'],
+            ['d-M-y', '20-feb-22'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsThatPass
+     */
+    public function StringsThatMatchFormatReturnImmutableDateTimes(string $format, string $input): void
+    {
+        $toDateTime = new ToDateTime($format);
+        $expected = Result::noResult(DateTimeImmutable::createFromFormat($format, $input));
+
+        $result = $toDateTime->filter($input);
+
+        self::assertEquals($expected->result, $result->result);
+        self::assertEqualsWithDelta($expected->value, $result->value, 10);
+        self::assertTrue($result->value instanceof DateTimeImmutable);
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsThatPass
+     */
+    public function StringsThatMatchFormatReturnDateTimesIfImmutableSetToFalse(string $format, string $input,): void
+    {
+        $toDateTime = new ToDateTime($format, false);
+        $expected = Result::noResult(DateTime::createFromFormat($format, $input));
+
+        $result = $toDateTime->filter($input);
+
+        self::assertEquals($expected->result, $result->result);
+        self::assertEqualsWithDelta($expected->value, $result->value, 10);
+        self::assertTrue($result->value instanceof DateTime);
+    }
+
+    public function DataSetsThatFail(): array
+    {
+        return [
+            [
+                'Y-m-d',
+                '1990 June 15',
+                [
+                    'warning_count' => 0,
+                    'warnings' => [],
+                    'error_count' => 3,
+                    'errors' => [
+                        4 => 'Unexpected data found.',
+                        12 => 'Not enough data available to satisfy format'
+                    ]
+                ]
+            ],
+            [
+                'Y-m',
+                '01-April',
+                [
+                    'warning_count' => 0,
+                    'warnings' => [],
+                    'error_count' => 2,
+                    'errors' => [
+                        3 => 'A two digit month could not be found',
+                    ]
+                ]
+            ],
+            [
+                'Y',
+                '',
+                [
+                    'warning_count' => 0,
+                    'warnings' => [],
+                    'error_count' => 1,
+                    'errors' => [
+                        0 => 'Not enough data available to satisfy format',
+                    ]
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsThatFail
+     */
+    public function StringsThatDoNotMatchFormatReturnInvalid(string $format, string $input, array $expectedVars): void
+    {
+        $toDateTime = new ToDateTime($format);
+        $expectedMessage = new Message('String does not match the required format', [$expectedVars]);
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+
+        $result = $toDateTime->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
 }

--- a/tests/Filter/Type/ToDateTimeTest.php
+++ b/tests/Filter/Type/ToDateTimeTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Type;
+
+class ToDateTimeTest
+{
+
+}

--- a/tests/Filter/Type/ToDateTimeTest.php
+++ b/tests/Filter/Type/ToDateTimeTest.php
@@ -40,8 +40,7 @@ class ToDateTimeTest extends TestCase
 
         $result = $toDateTime->filter($input);
 
-        self::assertEquals($expected->result, $result->result);
-        self::assertEqualsWithDelta($expected->value, $result->value, 10);
+        self::assertEqualsWithDelta($expected, $result, 2);
         self::assertTrue($result->value instanceof DateTimeImmutable);
     }
 
@@ -56,8 +55,7 @@ class ToDateTimeTest extends TestCase
 
         $result = $toDateTime->filter($input);
 
-        self::assertEquals($expected->result, $result->result);
-        self::assertEqualsWithDelta($expected->value, $result->value, 10);
+        self::assertEqualsWithDelta($expected, $result, 2);
         self::assertTrue($result->value instanceof DateTime);
     }
 

--- a/tests/Filter/Type/ToFloatTest.php
+++ b/tests/Filter/Type/ToFloatTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Type;
+
+use Membrane\Filter\Type\ToFloat;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Filter\Type\ToFloat
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
+ */
+class ToFloatTest extends TestCase
+{
+    public function DataSetsWithAcceptableInputs(): array
+    {
+        return [
+            [1, 1.0],
+            [1.23, 1.23],
+            ['123', 123.0],
+            [true, 1.0],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithAcceptableInputs
+     */
+    public function AcceptableTypesReturnIntegerValues($input, $expectedValue): void
+    {
+        $toFloat = new ToFloat();
+        $expected = Result::noResult($expectedValue);
+
+        $result = $toFloat->filter($input);
+
+        self::assertSame($expected->value, $result->value);
+        self::assertEquals($expected->result, $result->result);
+    }
+
+    public function DataSetsWithUnacceptableInputs(): array
+    {
+        $class = new class () {
+        };
+
+        return [
+            [
+                'non-numeric string',
+                new Message('ToFloat filter only accepts numeric strings', [])
+            ],
+            [
+                ['an', 'array'],
+                new Message('ToFloat filter only accepts scalar variables, %s is not scalar', ['array'])
+            ],
+            [
+                ['a' => 'list'],
+                new Message('ToFloat filter only accepts scalar variables, %s is not scalar', ['array'])
+            ],
+            [
+                $class,
+                new Message('ToFloat filter only accepts scalar variables, %s is not scalar', ['object'])
+            ],
+            [
+                null,
+                new Message('ToFloat filter only accepts scalar variables, %s is not scalar', ['NULL'])
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithUnacceptableInputs
+     */
+    public function UnacceptableTypesReturnInvalid($input, $expectedMessage): void
+    {
+        $toFloat = new ToFloat();
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+
+        $result = $toFloat->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+}

--- a/tests/Filter/Type/ToFloatTest.php
+++ b/tests/Filter/Type/ToFloatTest.php
@@ -25,6 +25,7 @@ class ToFloatTest extends TestCase
             [1.23, 1.23],
             ['123', 123.0],
             [true, 1.0],
+            [null, 0.0],
         ];
     }
 
@@ -32,7 +33,7 @@ class ToFloatTest extends TestCase
      * @test
      * @dataProvider DataSetsWithAcceptableInputs
      */
-    public function AcceptableTypesReturnIntegerValues($input, $expectedValue): void
+    public function AcceptableTypesReturnFloatValues($input, $expectedValue): void
     {
         $toFloat = new ToFloat();
         $expected = Result::noResult($expectedValue);
@@ -45,6 +46,7 @@ class ToFloatTest extends TestCase
 
     public function DataSetsWithUnacceptableInputs(): array
     {
+        $message = 'ToFloat filter only accepts null or scalar values, %s given';
         $class = new class () {
         };
 
@@ -55,19 +57,15 @@ class ToFloatTest extends TestCase
             ],
             [
                 ['an', 'array'],
-                new Message('ToFloat filter only accepts scalar variables, %s is not scalar', ['array'])
+                new Message($message, ['array'])
             ],
             [
                 ['a' => 'list'],
-                new Message('ToFloat filter only accepts scalar variables, %s is not scalar', ['array'])
+                new Message($message, ['array'])
             ],
             [
                 $class,
-                new Message('ToFloat filter only accepts scalar variables, %s is not scalar', ['object'])
-            ],
-            [
-                null,
-                new Message('ToFloat filter only accepts scalar variables, %s is not scalar', ['NULL'])
+                new Message($message, ['object'])
             ],
         ];
     }

--- a/tests/Filter/Type/ToIntTest.php
+++ b/tests/Filter/Type/ToIntTest.php
@@ -22,6 +22,7 @@ class ToIntTest extends TestCase
             [1.23, 1],
             ['123', 123],
             [true, 1],
+            [null, 0],
         ];
     }
 
@@ -42,6 +43,7 @@ class ToIntTest extends TestCase
 
     public function DataSetsWithUnacceptableInputs(): array
     {
+        $message = 'ToInt filter only accepts null or scalar values, %s given';
         $class = new class () {
         };
 
@@ -52,19 +54,15 @@ class ToIntTest extends TestCase
             ],
             [
                 ['an', 'array'],
-                new Message('ToInt filter only accepts scalar variables, %s is not scalar', ['array'])
+                new Message($message, ['array'])
             ],
             [
                 ['a' => 'list'],
-                new Message('ToInt filter only accepts scalar variables, %s is not scalar', ['array'])
+                new Message($message, ['array'])
             ],
             [
                 $class,
-                new Message('ToInt filter only accepts scalar variables, %s is not scalar', ['object'])
-            ],
-            [
-                null,
-                new Message('ToInt filter only accepts scalar variables, %s is not scalar', ['NULL'])
+                new Message($message, ['object'])
             ],
         ];
     }

--- a/tests/Filter/Type/ToIntTest.php
+++ b/tests/Filter/Type/ToIntTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Type;
+
+use Membrane\Filter\Type\ToInt;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Filter\Type\ToInt
+ */
+class ToIntTest extends TestCase
+{
+    public function DataSetsWithAcceptableInputs(): array
+    {
+        return [
+            [1, 1],
+            [1.23, 1],
+            ['123', 123],
+            [true, 1],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithAcceptableInputs
+     */
+    public function AcceptableTypesReturnIntegerValues($input, $expectedValue): void
+    {
+        $toInt = new ToInt();
+        $expected = Result::noResult($expectedValue);
+
+        $result = $toInt->filter($input);
+
+        self::assertSame($expected->value, $result->value);
+        self::assertEquals($expected->result, $result->result);
+    }
+
+    public function DataSetsWithUnacceptableInputs(): array
+    {
+        $class = new class () {
+        };
+
+        return [
+            [
+                'non-numeric string',
+                new Message('ToInt filter only accepts numeric strings', [])
+            ],
+            [
+                ['an', 'array'],
+                new Message('ToInt filter only accepts scalar variables, %s is not scalar', ['array'])
+            ],
+            [
+                ['a' => 'list'],
+                new Message('ToInt filter only accepts scalar variables, %s is not scalar', ['array'])
+            ],
+            [
+                $class,
+                new Message('ToInt filter only accepts scalar variables, %s is not scalar', ['object'])
+            ],
+            [
+                null,
+                new Message('ToInt filter only accepts scalar variables, %s is not scalar', ['NULL'])
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithUnacceptableInputs
+     */
+    public function UnacceptableTypesReturnInvalid($input, $expectedMessage): void
+    {
+        $toInt = new ToInt();
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+
+        $result = $toInt->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+}

--- a/tests/Filter/Type/ToListTest.php
+++ b/tests/Filter/Type/ToListTest.php
@@ -4,7 +4,89 @@ declare(strict_types=1);
 
 namespace Filter\Type;
 
-class ToListTest
-{
+use Membrane\Filter\Type\ToList;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Membrane\Filter\Type\ToList
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
+ */
+class ToListTest extends TestCase
+{
+    public function DataSetsWithAcceptableInputs(): array
+    {
+        return [
+            [[], []],
+            [['this', 'is', 'a', 'list'], ['this', 'is', 'a', 'list']],
+            [['even' => 'this', 'array' => 'is', 'becomes' => 'a', 'simple' => 'list'], ['this', 'is', 'a', 'list']],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithAcceptableInputs
+     */
+    public function AcceptableTypesReturnListValues($input, $expectedValue): void
+    {
+        $toList = new ToList();
+        $expected = Result::noResult($expectedValue);
+
+        $result = $toList->filter($input);
+
+        self::assertSame($expected->value, $result->value);
+        self::assertEquals($expected->result, $result->result);
+    }
+
+    public function DataSetsWithUnacceptableInputs(): array
+    {
+        $message = 'ToList filter only accepts arrays, %s given';
+        $class = new class () {
+        };
+
+        return [
+            [
+                'string',
+                new Message($message, ['string'])
+            ],
+            [
+                123,
+                new Message($message, ['integer'])
+            ],
+            [
+                1.23,
+                new Message($message, ['double'])
+            ],
+            [
+                true,
+                new Message($message, ['boolean'])
+            ],
+            [
+                null,
+                new Message($message, ['NULL'])
+            ],
+            [
+                $class,
+                new Message($message, ['object'])
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithUnacceptableInputs
+     */
+    public function UnacceptableTypesReturnInvalid($input, $expectedMessage): void
+    {
+        $toList = new ToList();
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+
+        $result = $toList->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
 }

--- a/tests/Filter/Type/ToListTest.php
+++ b/tests/Filter/Type/ToListTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Type;
+
+class ToListTest
+{
+
+}

--- a/tests/Filter/Type/ToStringTest.php
+++ b/tests/Filter/Type/ToStringTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Type;
+
+class ToStringTest
+{
+
+}

--- a/tests/Filter/Type/ToStringTest.php
+++ b/tests/Filter/Type/ToStringTest.php
@@ -4,7 +4,87 @@ declare(strict_types=1);
 
 namespace Filter\Type;
 
-class ToStringTest
-{
+use Membrane\Filter\Type\ToString;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use PHPUnit\Framework\TestCase;
 
+
+/**
+ * @covers \Membrane\Filter\Type\ToString
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
+ */
+class ToStringTest extends TestCase
+{
+    public function DataSetsWithAcceptableInputs(): array
+    {
+        $classWithMethod = new class () {
+            public function __toString(): string
+            {
+                return 'toString method called';
+            }
+        };
+        return [
+            ['string', 'string'],
+            [123, '123'],
+            [1.23, '1.23'],
+            [true, '1'],
+            [$classWithMethod, 'toString method called'],
+            [null, ''],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithAcceptableInputs
+     */
+    public function AcceptableInputsReturnStrings($input, $expectedValue)
+    {
+        $toString = new ToString();
+        $expected = Result::noResult($expectedValue);
+
+        $result = $toString->filter($input);
+
+        self::assertSame($expected->value, $result->value);
+        self::assertEquals($expected->result, $result->result);
+    }
+
+    public function DataSetsWithUnacceptableInputs(): array
+    {
+        $message = 'ToString filter only accepts objects, null or scalar values, %s given';
+        $classWithoutMethod = new class () {
+        };
+
+        return [
+            [
+                ['an', 'array'],
+                new Message($message, ['array'])
+            ],
+            [
+                ['a' => 'list'],
+                new Message($message, ['array'])
+            ],
+            [
+                $classWithoutMethod,
+                new Message('ToString Filter only accepts objects with __toString method', [])
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithUnacceptableInputs
+     */
+    public function UnacceptableTypesReturnInvalid($input, $expectedMessage): void
+    {
+        $toString = new ToString();
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+
+        $result = $toString->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
resolves #3

String only converts null, scalar(int,float,string,bool) or objects with __toString

Bool(uses filter_var) only converts scalars. On top of this it only converts scalars that represent a boolean.

    - ints: only 1 or 0, anything else fails
    - floats: only 0.0 or 1.0, anything else fails
    - strings: 'true', '1', 'on', 'yes' etc. work, anything else fails
    - boolean: of course this was going to work

Int/Float converts null and scalars, if it's a string it has to be numeric or it fails.

List: converts arrays into lists, nothing else

DateTime converts strings into DateTimes or DateTimeImmutable 