### PR TITLE
Shape filters

### DIFF
--- a/src/Filter/Shape/Delete.php
+++ b/src/Filter/Shape/Delete.php
@@ -5,12 +5,36 @@ declare(strict_types=1);
 namespace Membrane\Filter\Shape;
 
 use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 
 class Delete implements Filter
 {
+    private readonly array $fieldNames;
+
+    public function __construct(string ...$fieldNames)
+    {
+        $this->fieldNames = $fieldNames;
+    }
+
     public function filter(mixed $value): Result
     {
-        // TODO: Implement filter() method.
+        if (!is_array($value)) {
+            $message = new Message('Delete filter requires arrays, %s given', [gettype($value)]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        if (array_is_list($value)) {
+            $message = new Message('Delete filter requires arrays, for lists use Truncate', []);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        $newValue = $value;
+        foreach ($this->fieldNames as $fieldName) {
+            unset($newValue[$fieldName]);
+        }
+
+        return Result::noResult($newValue);
     }
 }

--- a/src/Filter/Shape/Delete.php
+++ b/src/Filter/Shape/Delete.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Shape;
+
+use Membrane\Filter;
+use Membrane\Result\Result;
+
+class Delete implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        // TODO: Implement filter() method.
+    }
+}

--- a/src/Filter/Shape/Delete.php
+++ b/src/Filter/Shape/Delete.php
@@ -30,11 +30,10 @@ class Delete implements Filter
             return Result::invalid($value, new MessageSet(null, $message));
         }
 
-        $newValue = $value;
         foreach ($this->fieldNames as $fieldName) {
-            unset($newValue[$fieldName]);
+            unset($value[$fieldName]);
         }
 
-        return Result::noResult($newValue);
+        return Result::noResult($value);
     }
 }

--- a/src/Filter/Shape/Pluck.php
+++ b/src/Filter/Shape/Pluck.php
@@ -14,7 +14,7 @@ class Pluck implements Filter
     private readonly string $fieldSet;
     private readonly array $fieldNames;
 
-    public function __construct(mixed $fieldSet, mixed ...$fieldNames)
+    public function __construct(string $fieldSet, string ...$fieldNames)
     {
         $this->fieldSet = $fieldSet;
         $this->fieldNames = $fieldNames;
@@ -41,7 +41,7 @@ class Pluck implements Filter
                 }
             }
         }
-        
+
         return Result::noResult($value);
 
 

--- a/src/Filter/Shape/Pluck.php
+++ b/src/Filter/Shape/Pluck.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Shape;
+
+use Membrane\Filter;
+use Membrane\Result\Result;
+
+class Pluck implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        // TODO: Implement filter() method.
+    }
+}

--- a/src/Filter/Shape/Pluck.php
+++ b/src/Filter/Shape/Pluck.php
@@ -5,12 +5,45 @@ declare(strict_types=1);
 namespace Membrane\Filter\Shape;
 
 use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 
 class Pluck implements Filter
 {
+    private readonly string $fieldSet;
+    private readonly array $fieldNames;
+
+    public function __construct(mixed $fieldSet, mixed ...$fieldNames)
+    {
+        $this->fieldSet = $fieldSet;
+        $this->fieldNames = $fieldNames;
+    }
+
     public function filter(mixed $value): Result
     {
-        // TODO: Implement filter() method.
+        if (!is_array($value)) {
+            $message = new Message('Pluck filter requires arrays, %s given', [gettype($value)]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        if (array_is_list($value)) {
+            $message = new Message('Pluck filter requires arrays with key-value pairs', []);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        $from = $value[$this->fieldSet] ?? null;
+        if (is_array($from) && !array_is_list($from)) {
+            foreach ($this->fieldNames as $fieldName) {
+                if (isset($from[$fieldName])) {
+                    $fieldNameValue = $from[$fieldName];
+                    $value[$fieldName] = $fieldNameValue;
+                }
+            }
+        }
+        
+        return Result::noResult($value);
+
+
     }
 }

--- a/src/Filter/Shape/Pluck.php
+++ b/src/Filter/Shape/Pluck.php
@@ -32,7 +32,7 @@ class Pluck implements Filter
             return Result::invalid($value, new MessageSet(null, $message));
         }
 
-        $from = $value[$this->fieldSet] ?? null;
+        $from = $value[$this->fieldSet] ?? [];
         if (is_array($from) && !array_is_list($from)) {
             foreach ($this->fieldNames as $fieldName) {
                 if (isset($from[$fieldName])) {

--- a/src/Filter/Shape/Rename.php
+++ b/src/Filter/Shape/Rename.php
@@ -8,14 +8,20 @@ use Membrane\Filter;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use RuntimeException;
 
 class Rename implements Filter
 {
-    public function __construct(
-        private readonly string $old,
-        private readonly string $new
-    )
+    private readonly string $old;
+    private readonly string $new;
+
+    public function __construct(string $old, string $new)
     {
+        if ($old === $new) {
+            throw new RuntimeException('Rename filter does not accept two equal strings');
+        }
+        $this->old = $old;
+        $this->new = $new;
     }
 
     public function filter(mixed $value): Result

--- a/src/Filter/Shape/Rename.php
+++ b/src/Filter/Shape/Rename.php
@@ -12,8 +12,8 @@ use Membrane\Result\Result;
 class Rename implements Filter
 {
     public function __construct(
-        private readonly mixed $old,
-        private readonly mixed $new
+        private readonly string $old,
+        private readonly string $new
     )
     {
     }

--- a/src/Filter/Shape/Rename.php
+++ b/src/Filter/Shape/Rename.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Shape;
+
+use Membrane\Filter;
+use Membrane\Result\Result;
+
+class Rename implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        // TODO: Implement filter() method.
+    }
+}

--- a/src/Filter/Shape/Rename.php
+++ b/src/Filter/Shape/Rename.php
@@ -5,12 +5,36 @@ declare(strict_types=1);
 namespace Membrane\Filter\Shape;
 
 use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 
 class Rename implements Filter
 {
+    public function __construct(
+        private readonly mixed $old,
+        private readonly mixed $new
+    )
+    {
+    }
+
     public function filter(mixed $value): Result
     {
-        // TODO: Implement filter() method.
+        if (!is_array($value)) {
+            $message = new Message('Rename filter requires arrays, %s given', [gettype($value)]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        if (array_is_list($value)) {
+            $message = new Message('Rename filter requires arrays with key-value pairs', []);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        if (isset($value[$this->old])) {
+            $value[$this->new] = $value[$this->old];
+            unset($value[$this->old]);
+        }
+
+        return Result::noResult($value);
     }
 }

--- a/src/Filter/Shape/Truncate.php
+++ b/src/Filter/Shape/Truncate.php
@@ -21,8 +21,12 @@ class Truncate implements Filter
 
     public function filter(mixed $value): Result
     {
-        if (!is_array($value) || !array_is_list($value)) {
-            $message = new Message('Truncate filter only accepts lists, %s given', [gettype($value)]);
+        if (!is_array($value)) {
+            $message = new Message('Truncate filter requires lists, %s given', [gettype($value)]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+        if (!array_is_list($value)) {
+            $message = new Message('Truncate filter requires lists, for arrays use Delete', []);
             return Result::invalid($value, new MessageSet(null, $message));
         }
 

--- a/src/Filter/Shape/Truncate.php
+++ b/src/Filter/Shape/Truncate.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Shape;
+
+use Exception;
+use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+
+class Truncate implements Filter
+{
+    public function __construct(private readonly int $maxLength)
+    {
+        if ($this->maxLength < 0) {
+            throw new Exception('Truncate filter cannot take negative max lengths');
+        }
+    }
+
+    public function filter(mixed $value): Result
+    {
+        if (!is_array($value) || !array_is_list($value)) {
+            $message = new Message('Truncate filter only accepts lists, %s given', [gettype($value)]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        return Result::noResult(array_slice($value, 0, $this->maxLength));
+    }
+}

--- a/tests/Filter/Shape/DeleteTest.php
+++ b/tests/Filter/Shape/DeleteTest.php
@@ -5,12 +5,78 @@ declare(strict_types=1);
 namespace Filter\Shape;
 
 use Membrane\Filter\Shape\Delete;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Membrane\Filter\Shape\Delete
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
  */
 class DeleteTest extends TestCase
 {
+    public function DataSetsWithIncorrectInputs(): array
+    {
+        $notArrayMessage = 'Delete filter requires arrays, %s given';
+        $listMessage = 'Delete filter requires arrays, for lists use Truncate';
+        return [
+            [123, new Message($notArrayMessage, ['integer'])],
+            [1.23, new Message($notArrayMessage, ['double'])],
+            ['this is a string', new Message($notArrayMessage, ['string'])],
+            [true, new Message($notArrayMessage, ['boolean'])],
+            [['this', 'is', 'a', 'list'], new Message($listMessage, [])],
+        ];
+    }
 
+    /**
+     * @test
+     * @dataProvider DataSetsWithIncorrectInputs
+     */
+    public function IncorrectInputsReturnInvalid(mixed $input, Message $expectedMessage): void
+    {
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+        $delete = new Delete();
+
+        $result = $delete->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function DataSetsToFilter(): array
+    {
+        return [
+            [
+                ['this' => 'is', 'an' => 'array'],
+                ['non-existent-field-name'],
+                ['this' => 'is', 'an' => 'array']
+            ],
+            [
+                ['this' => 'is', 'an' => 'array'],
+                ['this'],
+                ['an' => 'array']
+            ],
+            [
+                ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4],
+                ['a', 'c', 'e'],
+                ['b' => 2, 'd' => 4]
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsToFilter
+     */
+    public function ListsAreTruncatedToMatchMaxLength(array $input, array $fieldNames, array $expectedValue): void
+    {
+        $expected = Result::noResult($expectedValue);
+        $delete = new Delete(...$fieldNames);
+
+        $result = $delete->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
 }

--- a/tests/Filter/Shape/DeleteTest.php
+++ b/tests/Filter/Shape/DeleteTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Shape;
+
+use Membrane\Filter\Shape\Delete;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Filter\Shape\Delete
+ */
+class DeleteTest extends TestCase
+{
+
+}

--- a/tests/Filter/Shape/PluckTest.php
+++ b/tests/Filter/Shape/PluckTest.php
@@ -5,12 +5,116 @@ declare(strict_types=1);
 namespace Filter\Shape;
 
 use Membrane\Filter\Shape\Pluck;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Membrane\Filter\Shape\Pluck
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
  */
 class PluckTest extends TestCase
 {
+    public function DataSetsWithIncorrectInputs(): array
+    {
+        $notArrayMessage = 'Pluck filter requires arrays, %s given';
+        $listMessage = 'Pluck filter requires arrays with key-value pairs';
+        return [
+            [123, new Message($notArrayMessage, ['integer'])],
+            [1.23, new Message($notArrayMessage, ['double'])],
+            ['this is a string', new Message($notArrayMessage, ['string'])],
+            [true, new Message($notArrayMessage, ['boolean'])],
+            [['this', 'is', 'a', 'list'], new Message($listMessage, [])],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithIncorrectInputs
+     */
+    public function IncorrectInputsReturnInvalid(mixed $input, Message $expectedMessage): void
+    {
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+        $pluck = new Pluck('from', 'a', 'b');
+
+        $result = $pluck->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function NonExistentFieldSetIsIgnored(): void
+    {
+        $input = ['not-from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4];
+        $expected = Result::noResult($input);
+        $pluck = new Pluck('from', 'a', 'b', 'c');
+
+        $result = $pluck->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function NonExistentFieldNamesAreIgnored(): void
+    {
+        $input = ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4];
+        $expected = Result::noResult($input);
+        $pluck = new Pluck('from', 'e', 'f', 'g');
+
+        $result = $pluck->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function DataSetsThatPass(): array
+    {
+        return [
+            [
+                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4],
+                'from',
+                'a',
+                'c',
+                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 1, 'c' => 3, 'd' => 4],
+            ],
+            [
+                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4],
+                'from',
+                'a',
+                'd',
+                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 1, 'd' => 4],
+            ],
+            [
+                ['from' => [1 => 'a', 2 => 'b', 3 => 'c'], 4 => 'd'],
+                'from',
+                1,
+                3,
+                4,
+                5,
+                ['from' => [1 => 'a', 2 => 'b', 3 => 'c'], 1 => 'a', 3 => 'c', 4 => 'd'],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsThatPass
+     */
+    public function CorrectInputsSuccessfullyPluckValue(): void
+    {
+        $input = ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4];
+        $expected = Result::noResult(['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 1, 'c' => 3, 'd' => 4]);
+        $pluck = new Pluck('from', 'a', 'c');
+
+        $result = $pluck->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
 
 }

--- a/tests/Filter/Shape/PluckTest.php
+++ b/tests/Filter/Shape/PluckTest.php
@@ -78,26 +78,24 @@ class PluckTest extends TestCase
         return [
             [
                 ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4],
+                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 1, 'c' => 3, 'd' => 4],
                 'from',
                 'a',
                 'c',
-                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 1, 'c' => 3, 'd' => 4],
             ],
             [
-                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4],
+                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 5, 'd' => 4],
+                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 1, 'd' => 4],
                 'from',
                 'a',
                 'd',
-                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 1, 'd' => 4],
             ],
             [
-                ['from' => [1 => 'a', 2 => 'b', 3 => 'c'], 4 => 'd'],
+                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4],
+                ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 1, 'd' => 4],
                 'from',
-                1,
-                3,
-                4,
-                5,
-                ['from' => [1 => 'a', 2 => 'b', 3 => 'c'], 1 => 'a', 3 => 'c', 4 => 'd'],
+                'a',
+                'd',
             ],
         ];
     }
@@ -106,11 +104,10 @@ class PluckTest extends TestCase
      * @test
      * @dataProvider DataSetsThatPass
      */
-    public function CorrectInputsSuccessfullyPluckValue(): void
+    public function CorrectInputsSuccessfullyPluckValue($input, $expectedValue, $fieldSet, ...$fieldNames): void
     {
-        $input = ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4];
-        $expected = Result::noResult(['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'a' => 1, 'c' => 3, 'd' => 4]);
-        $pluck = new Pluck('from', 'a', 'c');
+        $expected = Result::noResult($expectedValue);
+        $pluck = new Pluck($fieldSet, ...$fieldNames);
 
         $result = $pluck->filter($input);
 

--- a/tests/Filter/Shape/PluckTest.php
+++ b/tests/Filter/Shape/PluckTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Shape;
+
+use Membrane\Filter\Shape\Pluck;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Filter\Shape\Pluck
+ */
+class PluckTest extends TestCase
+{
+
+}

--- a/tests/Filter/Shape/RenameTest.php
+++ b/tests/Filter/Shape/RenameTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Filter\Shape;
 
 use Membrane\Filter\Shape\Rename;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,5 +15,82 @@ use PHPUnit\Framework\TestCase;
  */
 class RenameTest extends TestCase
 {
+    public function DataSetsWithIncorrectInputs(): array
+    {
+        $notArrayMessage = 'Rename filter requires arrays, %s given';
+        $listMessage = 'Rename filter requires arrays with key-value pairs';
+        return [
+            [123, new Message($notArrayMessage, ['integer'])],
+            [1.23, new Message($notArrayMessage, ['double'])],
+            ['this is a string', new Message($notArrayMessage, ['string'])],
+            [true, new Message($notArrayMessage, ['boolean'])],
+            [['this', 'is', 'a', 'list'], new Message($listMessage, [])],
+        ];
+    }
 
+    /**
+     * @test
+     * @dataProvider DataSetsWithIncorrectInputs
+     */
+    public function IncorrectInputsReturnInvalid(mixed $input, Message $expectedMessage): void
+    {
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+        $rename = new Rename('old key', 'new key');
+
+        $result = $rename->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function NonExistentKeysAreIgnored(): void
+    {
+        $input = [1 => 'a', 2 => 'b'];
+        $expected = Result::noResult($input);
+        $rename = new Rename(3, 4);
+
+        $result = $rename->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function DataSetsToFilter(): array
+    {
+        return [
+            [
+                ['this' => 'is', 'an' => 'array'],
+                'this',
+                'that',
+                ['that' => 'is', 'an' => 'array']
+            ],
+            [
+                [1 => 'a', 2 => 'b'],
+                1,
+                'one',
+                ['one' => 'a', 2 => 'b']
+            ],
+            [
+                ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4],
+                'b',
+                2,
+                ['a' => 1, 2.4 => 2, 'c' => 3, 'd' => 4]
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsToFilter
+     */
+    public function IfOldKeyExistsThenItIsRenamed(array $input, mixed $old, mixed $new, array $expectedValue): void
+    {
+        $expected = Result::noResult($expectedValue);
+        $rename = new Rename($old, $new);
+
+        $result = $rename->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
 }

--- a/tests/Filter/Shape/RenameTest.php
+++ b/tests/Filter/Shape/RenameTest.php
@@ -12,6 +12,9 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Membrane\Filter\Shape\Rename
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
  */
 class RenameTest extends TestCase
 {
@@ -72,10 +75,10 @@ class RenameTest extends TestCase
                 ['one' => 'a', 2 => 'b']
             ],
             [
-                ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4],
+                ['a' => 1, 'b' => 'two', 'c' => 3, 'd' => 4],
                 'b',
                 2,
-                ['a' => 1, 2.4 => 2, 'c' => 3, 'd' => 4]
+                ['a' => 1, 2 => 'two', 'c' => 3, 'd' => 4]
             ],
         ];
     }

--- a/tests/Filter/Shape/RenameTest.php
+++ b/tests/Filter/Shape/RenameTest.php
@@ -18,6 +18,18 @@ use PHPUnit\Framework\TestCase;
  */
 class RenameTest extends TestCase
 {
+
+    /**
+     * @test
+     */
+    public function OldAndNewCannotBeEqual(): void
+    {
+        self::expectException('RuntimeException');
+        self::expectExceptionMessage('Rename filter does not accept two equal strings');
+
+        new Rename('a', 'a');
+    }
+
     public function DataSetsWithIncorrectInputs(): array
     {
         $notArrayMessage = 'Rename filter requires arrays, %s given';
@@ -66,13 +78,13 @@ class RenameTest extends TestCase
                 ['this' => 'is', 'an' => 'array'],
                 'this',
                 'that',
-                ['that' => 'is', 'an' => 'array']
+                ['that' => 'is', 'an' => 'array'],
             ],
             [
                 ['this' => 'is', 'an' => 'array'],
                 'this',
                 'an',
-                ['an' => 'is']
+                ['an' => 'is'],
             ],
         ];
     }

--- a/tests/Filter/Shape/RenameTest.php
+++ b/tests/Filter/Shape/RenameTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Shape;
+
+use Membrane\Filter\Shape\Rename;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Filter\Shape\Rename
+ */
+class RenameTest extends TestCase
+{
+
+}

--- a/tests/Filter/Shape/RenameTest.php
+++ b/tests/Filter/Shape/RenameTest.php
@@ -50,9 +50,9 @@ class RenameTest extends TestCase
      */
     public function NonExistentKeysAreIgnored(): void
     {
-        $input = [1 => 'a', 2 => 'b'];
+        $input = ['a' => 1, 'b' => 2];
         $expected = Result::noResult($input);
-        $rename = new Rename(3, 4);
+        $rename = new Rename('c', 'd');
 
         $result = $rename->filter($input);
 
@@ -69,16 +69,10 @@ class RenameTest extends TestCase
                 ['that' => 'is', 'an' => 'array']
             ],
             [
-                [1 => 'a', 2 => 'b'],
-                1,
-                'one',
-                ['one' => 'a', 2 => 'b']
-            ],
-            [
-                ['a' => 1, 'b' => 'two', 'c' => 3, 'd' => 4],
-                'b',
-                2,
-                ['a' => 1, 2 => 'two', 'c' => 3, 'd' => 4]
+                ['this' => 'is', 'an' => 'array'],
+                'this',
+                'an',
+                ['an' => 'is']
             ],
         ];
     }

--- a/tests/Filter/Shape/TruncateTest.php
+++ b/tests/Filter/Shape/TruncateTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Shape;
+
+use Exception;
+use Membrane\Filter\Shape\Truncate;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Filter\Shape\Truncate
+ */
+class TruncateTest extends TestCase
+{
+    /**
+     * @test
+     * @throws Exception
+     */
+    public function NegativeMaxLengthThrowsError()
+    {
+        self::expectExceptionMessage('Truncate filter cannot take negative max lengths');
+
+        $truncate = new Truncate(-1);
+    }
+
+    public function DataSetsWithIncorrectInputs(): array
+    {
+        $message = 'Truncate filter only accepts lists, %s given';
+        return [
+            [123, new Message($message, ['integer'])],
+            [1.23, new Message($message, ['double'])],
+            ['this is a string', new Message($message, ['string'])],
+            [true, new Message($message, ['boolean'])],
+            [['an' => 'array', 'with' => 'key', 'value' => 'pairs'], new Message($message, ['array'])],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsWithIncorrectInputs
+     */
+    public function IncorrectInputsReturnInvalid(mixed $input, Message $expectedMessage): void
+    {
+        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
+        $truncate = new Truncate(3);
+
+        $result = $truncate->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function ReturnInputIfAlreadyBelowMaxLength(): void
+    {
+        $input = ['a', 'list'];
+        $expected = Result::noResult($input);
+        $truncate = new Truncate(3);
+
+        $result = $truncate->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function DataSetsToFilter(): array
+    {
+        return [
+            [
+                ['a', 'list'],
+                0,
+                []
+            ],
+            [
+                ['a', 'list', 'of', 'five', 'values'],
+                2,
+                ['a', 'list']
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider DataSetsToFilter
+     */
+    public function ListsAreTruncatedToMatchMaxLength(array $input, int $maxLength, array $expectedValue): void
+    {
+        $expected = Result::noResult($expectedValue);
+        $truncate = new Truncate($maxLength);
+
+        $result = $truncate->filter($input);
+
+        self::assertEquals($expected, $result);
+    }
+}

--- a/tests/Filter/Shape/TruncateTest.php
+++ b/tests/Filter/Shape/TruncateTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Membrane\Filter\Shape\Truncate
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
  */
 class TruncateTest extends TestCase
 {
@@ -29,13 +32,14 @@ class TruncateTest extends TestCase
 
     public function DataSetsWithIncorrectInputs(): array
     {
-        $message = 'Truncate filter only accepts lists, %s given';
+        $notArrayMessage = 'Truncate filter requires lists, %s given';
+        $arrayMessage = 'Truncate filter requires lists, for arrays use Delete';
         return [
-            [123, new Message($message, ['integer'])],
-            [1.23, new Message($message, ['double'])],
-            ['this is a string', new Message($message, ['string'])],
-            [true, new Message($message, ['boolean'])],
-            [['an' => 'array', 'with' => 'key', 'value' => 'pairs'], new Message($message, ['array'])],
+            [123, new Message($notArrayMessage, ['integer'])],
+            [1.23, new Message($notArrayMessage, ['double'])],
+            ['this is a string', new Message($notArrayMessage, ['string'])],
+            [true, new Message($notArrayMessage, ['boolean'])],
+            [['an' => 'array', 'with' => 'key', 'value' => 'pairs'], new Message($arrayMessage, [])],
         ];
     }
 


### PR DESCRIPTION
fixes #2 

Shape filters implemented

Truncate filter truncates lists only, making sure they are equal or below maxLength

Delete filter deletes a key from arrays only

Rename filter renames a key on arrays only

Pluck filter works on arrays only and achieves same result as example provided