### PR TITLE
fieldname tests covered

### DIFF
--- a/tests/Result/FieldnameTest.php
+++ b/tests/Result/FieldnameTest.php
@@ -11,93 +11,23 @@ use PHPUnit\Framework\TestCase;
  */
 class FieldnameTest extends TestCase
 {
-    public function dataSetsForStringRepresentation() : array
-    {
-        return [
-            [[''], ''],
-            [['test field'], 'test field'],
-            [['test field', 'this', 'is', 'a'], 'this->is->a->test field'],
-        ];
-    }
-
     /**
      * @test
-     * @dataProvider dataSetsForStringRepresentation
      */
-    public function StringRepresentationTest(array $input, string $expected) : void
+    public function PushTest(): void
     {
-        $fieldname = new Fieldname(...$input);
+        $expected = new Fieldname('new field', 'original field');
+        $fieldname = new Fieldname('original field');
 
-        $result = $fieldname->getStringRepresentation();
+        $result = $fieldname->push(new Fieldname('new field'));
 
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithEqualStringRepresentations() : array
-    {
-        return [
-            [
-                new Fieldname(''),
-                new Fieldname(''),
-                true
-            ],
-            [
-                new Fieldname('test field'),
-                new Fieldname('test field'),
-                true
-            ],
-            [
-                new Fieldname('test field', 'this', 'is', 'a'),
-                new Fieldname('test field', 'this', 'is', 'a'),
-                true
-            ],
-            [
-                new Fieldname('test field', 'this', 'is', 'a'),
-                new Fieldname('test field', 'this', 'is', 'a'),
-                true
-            ],
-        ];
-    }
-
-    public function dataSetsWithDifferentStringRepresentations() : array
-    {
-        return [
-            [
-                new Fieldname(''),
-                new Fieldname(' '),
-                false
-            ],
-            [
-                new Fieldname('test field'),
-                new Fieldname('field test'),
-                false
-            ],
-//            [
-//                new Fieldname('test field', 'this', 'is', 'a'),
-//                new Fieldname('test field', 'this->is->a'),
-//                false
-//            ],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider dataSetsWithEqualStringRepresentations
-     * @dataProvider dataSetsWithDifferentStringRepresentations
-     */
-    public function EqualPairsAreMergable(Fieldname $firstFieldname, Fieldname $secondFieldname, bool $expected) : void
-    {
-        $equals = $firstFieldname->equals($secondFieldname);
-        $mergable = $firstFieldname->mergable($secondFieldname);
-
-        self::assertEquals($expected, $equals);
-        self::assertEquals($expected, $mergable);
-    }
-    
     /**
      * @test
      */
-    public function FieldnameIsAlwaysMergableByItself () : void
+    public function FieldnameIsAlwaysMergableByItself(): void
     {
         $fieldname = new Fieldname('test field');
 
@@ -106,5 +36,82 @@ class FieldnameTest extends TestCase
         self::assertTrue($result);
     }
 
+    public function dataSetsWithEqualStringRepresentations(): array
+    {
+        return [
+            [
+                new Fieldname(''),
+                new Fieldname(''),
+                true,
+            ],
+            [
+                new Fieldname('test field'),
+                new Fieldname('test field'),
+                true,
+            ],
+            [
+                new Fieldname('test field', 'this', 'is', 'a'),
+                new Fieldname('test field', 'this', 'is', 'a'),
+                true,
+            ],
+            [
+                new Fieldname('test field', 'this', 'is', 'a'),
+                new Fieldname('test field', 'this', 'is', 'a'),
+                true,
+            ],
+        ];
+    }
 
+    public function dataSetsWithDifferentStringRepresentations(): array
+    {
+        return [
+            [
+                new Fieldname(''),
+                new Fieldname(' '),
+                false,
+            ],
+            [
+                new Fieldname('test field'),
+                new Fieldname('field test'),
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsWithEqualStringRepresentations
+     * @dataProvider dataSetsWithDifferentStringRepresentations
+     */
+    public function MergableTest(Fieldname $firstFieldname, Fieldname $secondFieldname, bool $expected): void
+    {
+        $equals = $firstFieldname->equals($secondFieldname);
+        $mergable = $firstFieldname->mergable($secondFieldname);
+
+        self::assertEquals($expected, $equals);
+        self::assertEquals($expected, $mergable);
+    }
+
+    public function dataSetsForStringRepresentation(): array
+    {
+        return [
+            [[''], ''],
+            [['test field'], 'test field'],
+            [['', ''], '->'],
+            [['test field', 'this', 'is', 'a'], 'this->is->a->test field'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsForStringRepresentation
+     */
+    public function StringRepresentationTest(array $input, string $expected): void
+    {
+        $fieldname = new Fieldname(...$input);
+
+        $result = $fieldname->getStringRepresentation();
+
+        self::assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
Added PushTest to get 100% coverage to Fieldnames.

(also noticed that Fieldnames can accept multiple empty strings, leading to string representations like '->->->')