### PR TITLE
Message rendered method added

### DIFF
--- a/docs/result.md
+++ b/docs/result.md
@@ -26,5 +26,15 @@ Message Sets provide details on why the external data has failed validation.
 
 They consist of two properties:
 
-* Fieldname: This specifies what part of the data was being validated when it failed.
-* Message: This specifies how the data failed validation. Message Sets can contain multiple messages.
+### FieldName
+
+This specifies what part of the data was being validated when it failed.
+
+### Message
+
+This specifies how the data failed validation. Message Sets can contain multiple messages.
+A message can be read using the rendered() method
+```php
+$message = new Message('this message is an %s', ['example']);
+echo $message->rendered(); // this message is an example
+```

--- a/src/Result/Message.php
+++ b/src/Result/Message.php
@@ -12,4 +12,9 @@ class Message
         public readonly array $vars
     ) {
     }
+
+    public function rendered(): string
+    {
+        return vsprintf($this->message, $this->vars);
+    }
 }

--- a/src/Validator/Array/Count.php
+++ b/src/Validator/Array/Count.php
@@ -32,7 +32,7 @@ class Count implements Validator
         }
 
         if ($this->max !== null && $count > $this->max) {
-            $message = new Message('Array is expected have a minimum of %d values', [$this->max]);
+            $message = new Message('Array is expected have a maximum of %d values', [$this->max]);
             return Result::invalid($value, new MessageSet(null, $message));
         }
 

--- a/tests/Result/MessageTest.php
+++ b/tests/Result/MessageTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Result;
+
+use Membrane\Result\Message;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Result\Message
+ */
+class MessageTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function renderedMessageTest(): void
+    {
+        $expected = 'This message is a test';
+        $message = new Message('This message is a %s', ['test']);
+
+        $output = $message->rendered();
+
+        self::assertEquals($expected, $output);
+    }
+}

--- a/tests/Validator/Array/CountTest.php
+++ b/tests/Validator/Array/CountTest.php
@@ -98,7 +98,7 @@ class CountTest extends TestCase
      */
     public function arraysWithMoreValuesThanMaximumReturnInvalid(array $input, int $max): void
     {
-        $expectedMessage = new Message('Array is expected have a minimum of %d values', [$max]);
+        $expectedMessage = new Message('Array is expected have a maximum of %d values', [$max]);
         $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
         $count = new Count(0, $max);
 


### PR DESCRIPTION
Message has new method:

    rendered(): string // returns the formatted message.

Also fixed a copy-paste error on Count.php when array exceeds maximum