### PR TITLE
APISpec classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,21 @@
 {
-    "name": "membrane/membrane",
-    "type": "library",
-    "autoload": {
-        "psr-4": {
-            "Membrane\\": "src/",
-            "Membrane\\Fixtures\\": "tests/fixtures/"
-        }
-    },
-    "require": {
-        "php": "^8.1.0",
-        "cebe/php-openapi": "^1.7",
-        "psr/http-message": "^1.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.8",
-        "squizlabs/php_codesniffer": "^3.7",
-        "guzzlehttp/psr7": "^2.4"
+  "name": "membrane/membrane",
+  "type": "library",
+  "autoload": {
+    "psr-4": {
+      "Membrane\\": "src/",
+      "Membrane\\Fixtures\\": "tests/fixtures/"
     }
+  },
+  "require": {
+    "php": "^8.1.0",
+    "cebe/php-openapi": "^1.7",
+    "psr/http-message": "^1.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5",
+    "phpstan/phpstan": "^1.8",
+    "squizlabs/php_codesniffer": "^3.7",
+    "guzzlehttp/psr7": "^2.4"
+  }
 }

--- a/docs/builder-attributes.md
+++ b/docs/builder-attributes.md
@@ -1,0 +1,522 @@
+# Building From Attributes
+
+## Specification
+
+```php
+ClassWithAttributes($className)
+```
+
+This Specification takes a class representing the data you wish to receive.
+
+| Parameter  | Type   | Notes                                                  |
+|------------|--------|--------------------------------------------------------|
+| $className | string | The class-string of the data object you wish to create |
+
+Add attributes to determine how Membrane will process it.
+
+## Example
+
+Use-Case: A user wishes to make a blog post.
+
+Let's start a BlogPost class to hold the user's data.
+
+```php
+class BlogPost
+{
+    public function __construct(
+        public string $title,
+        public string $body,
+        #[Subtype('string')]
+        public array $tags = []
+    ) {
+    }
+}
+```
+
+Okay brilliant, we've got a minimal example, note the Subtype attribute on the $tags array.  
+This is required, Membrane will not accept arrays without defined subtypes.
+
+```php
+$specification = new ClassWithAttributes(BlogPost::class);
+$membrane = new Membrane();
+$examples = [
+    ['title' => 'My Post', 'body' => 'My content'],
+    [],
+];
+
+foreach ($examples as $example) {
+    $result = $membrane->process($example, $specification);
+    var_dump($result->value);
+    if ($result->isValid()) {
+        echo ' is valid';
+    } else {
+        echo ' is invalid' . "\n";
+        foreach($result->messageSets as $messageSet) {
+            foreach ($messageSet->messages as $message) {
+                echo $message->rendered() . "\n";
+            }
+        }
+    }
+    echo "\n";
+}
+```
+
+Outputs
+
+```text
+['title' => 'My Post', 'body' => 'My content'] is valid
+[] is valid
+```
+
+The first example is valid, that's great. The second example has no input, we shouldn't be accepting that; we'll make
+sure the user MUST provide required fields.
+
+### Required Fields
+
+```php
+#[SetFilterOrValidator(new RequiredFields('title', 'body'), Placement::BEFORE)]
+class BlogPost
+{
+    public function __construct(
+        public string $title,
+        public string $body,
+        #[Subtype('string')]
+        public array $tags = [],
+    ) {
+    }
+}
+```
+
+To build a BlogPost, **before** everything else: a title and body are required.
+
+```php
+$specification = new ClassWithAttributes(BlogPost::class);
+$membrane = new Membrane();
+$examples = [
+    ['title' => false, 'body' => null],
+    [],
+];
+
+foreach ($examples as $example) {
+    $result = $membrane->process($example, $specification);
+    var_dump($result->value);
+    if ($result->isValid()) {
+        echo ' is valid';
+    } else {
+        echo ' is invalid' . "\n";
+        foreach($result->messageSets as $messageSet) {
+            foreach ($messageSet->messages as $message) {
+                echo $message->rendered() . "\n";
+            }
+        }
+    }
+    echo "\n";
+}
+```
+
+Outputs
+
+```text
+['title' => false, 'body' => null] is valid
+
+[] is invalid
+title is a required field
+body is a required field
+
+```
+
+The results are valid as long as it contains a title and body, but it does not currently care what the title and body
+are. But our BlogPost class requires strings, certainly not nulls or booleans. So we need another attribute.
+
+### Is It A String?
+
+```php
+#[SetFilterOrValidator(new RequiredFields('title', 'body'), Placement::BEFORE)]
+class BlogPost
+{
+    public function __construct(
+        #[FilterOrValidator(new IsString())]
+        public string $title,
+        #[FilterOrValidator(new IsString())]
+        public string $body,
+        #[FilterOrValidator(new IsString())]
+        #[Subtype('string')]
+        public array $tags,
+    ) {
+    }
+}
+```
+
+To build a BlogPost, **before** everything else: a title and body are required.
+
+The title must be a string.
+
+The body must be a string.
+
+If tags are provided, they must be a string.
+
+```php
+$specification = new ClassWithAttributes(BlogPost::class);
+$membrane = new Membrane();
+$examples = [
+    ['title' => 'My Post', 'body' => 'My content'],
+    ['title' => false, 'body' => null],
+];
+
+foreach ($examples as $example) {
+    $result = $membrane->process($example, $specification);
+    var_dump($result->value);
+    if ($result->isValid()) {
+        echo ' is valid';
+    } else {
+        echo ' is invalid' . "\n";
+        foreach($result->messageSets as $messageSet) {
+            foreach ($messageSet->messages as $message) {
+                echo $message->rendered() . "\n";
+            }
+        }
+    }
+    echo "\n";
+}
+```
+
+Outputs
+
+```text
+['title' => 'My Post', 'body' => 'My content'] is valid
+['title' => false, 'body' => null] is invalid
+IsString validator expects string value, boolean passed instead
+IsString validator expects string value, NULL passed instead
+```
+
+Now the input must be a string,
+we can safely assume our valid result contains data which can create a BlogPost object.
+
+But is that too strict?
+
+If we use a filter instead, we can try to change the data. We could check if we can turn it into a string ourselves,
+before we flag the input as invalid.
+
+### Can We Make It A String?
+
+```php
+#[SetFilterOrValidator(new RequiredFields('title', 'body'), Placement::BEFORE)]
+class BlogPost
+{
+    public function __construct(
+        #[FilterOrValidator(new ToString())]
+        public string $title,
+        #[FilterOrValidator(new ToString())]
+        public string $body,
+        #[FilterOrValidator(new ToString())]
+        #[Subtype('string')]
+        public array $tags,
+    ) {
+    }
+}
+```
+
+To build a BlogPost, **before** everything else: a title and body are required.
+
+The title must be convertable to a string.
+
+The body must be convertable to a string.
+
+If tags are provided, they must be convertable to a string.
+
+```php
+$specification = new ClassWithAttributes(BlogPost::class);
+$membrane = new Membrane();
+$examples = [
+    ['title' => false, 'body' => null],
+    ['title' => ['a', 'b'], 'body' => 'My content'],
+];
+
+foreach ($examples as $example) {
+    $result = $membrane->process($example, $specification);
+    var_dump($result->value);
+    if ($result->isValid()) {
+        echo ' is valid';
+    } else {
+        echo ' is invalid' . "\n";
+        foreach($result->messageSets as $messageSet) {
+            foreach ($messageSet->messages as $message) {
+                echo $message->rendered() . "\n";
+            }
+        }
+    }
+    echo "\n";
+}
+```
+
+Ouputs
+
+```text
+    ['title' => false, 'body' => null] is valid
+    ['title' => ['a', 'b'], 'body' => 'My content'] is invalid
+    ToString filter only accepts objects, null or scalar values, array given
+```
+
+Brilliant! It's a bit more flexible, but we can still rest assured a valid Result contains string values. Let's add some
+more control to our tags.
+
+### Maximum Number Of Tags
+
+```php
+#[SetFilterOrValidator(new RequiredFields('title', 'body'), Placement::BEFORE)]
+class BlogPost
+{
+    public function __construct(
+        #[FilterOrValidator(new ToString())]
+        public string $title,
+        #[FilterOrValidator(new ToString())]
+        public string $body,
+        #[SetFilterOrValidator(new Count(0, 5), Placement::BEFORE)]
+        #[FilterOrValidator(new ToString())]
+        #[Subtype('string')]
+        public array $tags,
+    ) {
+    }
+}
+```
+
+To build a BlogPost, **before** everything else: a title and body are required.
+
+The title must be convertable to a string.
+
+The body must be convertable to a string.
+
+If tags are provided, they must be convertable to a string but
+**before** that it will check the number of tags does not exceed 5.
+
+```php
+$specification = new ClassWithAttributes(BlogPost::class);
+$membrane = new Membrane();
+$examples = [
+    ['title' => '', 'body' => '', 'tags' => ['a', 'b', 'c']],
+    ['title' => '', 'body' => '', 'tags' => ['a', 'b', 'c', 'd', 'e', 'f']],
+];
+
+foreach ($examples as $example) {
+    $result = $membrane->process($example, $specification);
+    var_dump($result->value);
+    if ($result->isValid()) {
+        echo ' is valid';
+    } else {
+        echo ' is invalid' . "\n";
+        foreach($result->messageSets as $messageSet) {
+            foreach ($messageSet->messages as $message) {
+                echo $message->rendered() . "\n";
+            }
+        }
+    }
+    echo "\n";
+}
+```
+
+Outputs
+
+```text
+    ['title' => '', 'body' => '', 'tags' => ['a', 'b', 'c']] is valid
+    ['title' => '', 'body' => '', 'tags' => ['a', 'b', 'c', 'd', 'e', 'f']] is invalid
+    Array is expected have a maximum of 5 values
+```
+
+Okay that should keep those tags under control, but what is going on with these titles?
+We're going to need some structure.
+
+### Regex and Max Length
+
+```php
+#[SetFilterOrValidator(new RequiredFields('title', 'body'), Placement::BEFORE)]
+class BlogPost
+{
+    public function __construct(
+        #[FilterOrValidator(new ToString())]
+        #[FilterOrValidator(new Length(5, 50))]
+        #[FilterOrValidator(new Regex('#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#'))]
+        public string $title,
+        #[FilterOrValidator(new ToString())]
+        public string $body,
+        #[SetFilterOrValidator(new Count(0, 5), Placement::BEFORE)]
+        #[FilterOrValidator(new ToString())]
+        #[Subtype('string')]
+        public array $tags,
+    ) {
+    }
+}
+```
+
+To build a BlogPost, **before** everything else: a title and body are required.
+
+The title must be convertable to a string, between 5-50 characters and match the regular expression provided.
+
+The body must be convertable to a string.
+
+If tags are provided, they must be convertable to a string but
+**before** that it will check the number of tags does not exceed 5.
+
+```php
+$specification = new ClassWithAttributes(BlogPost::class);
+$membrane = new Membrane();
+$examples = [
+    ['title' => 'My Title', 'body' => '', 'tags' => ['a', 'b', 'c']],
+    ['title' => 'mY tItLe tHat iS uNnEcEsSaRiLlY lOnG wItH InCoRrEcT cApItIlIzAtIoN', 'body' => '', 'tags' => ['a', 'b', 'c']],
+];
+
+foreach ($examples as $example) {
+    $result = $membrane->process($example, $specification);
+    var_dump($result->value);
+    if ($result->isValid()) {
+        echo ' is valid';
+    } else {
+        echo ' is invalid' . "\n";
+        foreach($result->messageSets as $messageSet) {
+            foreach ($messageSet->messages as $message) {
+                echo $message->rendered() . "\n";
+            }
+        }
+    }
+    echo "\n";
+}
+```
+
+Outputs
+
+```text
+    ['title' => 'My Title', 'body' => '', 'tags' => ['a', 'b', 'c']] is valid
+    ['title' => 'mY tItLe tHat iS uNnEcEsSaRiLlY lOnG wItH InCoRrEcT cApItIlIzAtIoN', 'body' => '', 'tags' => ['a', 'b', 'c']] is invalid
+    String is expected to be a maximum of 50 characters
+```
+
+Perfect, now our titles have proper capitalization and must be between 1 and 10 words thanks to the Regex Validator.
+They must also be 5-50 characters long thanks to Length Filter.
+
+However, we only got the error for the Length Validator since that applied first.
+It would be better if we could find out all the errors at once.
+
+### List All The Errors
+
+```php
+#[SetFilterOrValidator(new RequiredFields('title', 'body'), Placement::BEFORE)]
+class BlogPost
+{
+    public function __construct(
+        #[FilterOrValidator(new ToString())]
+        #[FilterOrValidator(new AllOf(new Length(5,50), new Regex('#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#')))]
+        public string $title,
+        #[FilterOrValidator(new ToString())]
+        public string $body,
+        #[SetFilterOrValidator(new Count(0, 5), Placement::BEFORE)]
+        #[FilterOrValidator(new ToString())]
+        #[Subtype('string')]
+        public array $tags,
+    ) {
+    }
+}
+```
+
+To build a BlogPost, **before** everything else: a title and body are required.
+
+The title must be convertable to a string and **all of the following:**
+
+* between 5-50 characters
+* match the regular expression provided
+
+The body must be convertable to a string.
+
+If tags are provided, they must be convertable to a string but
+**before** that it will check the number of tags does not exceed 5.
+
+```php
+$specification = new ClassWithAttributes(BlogPost::class);
+$membrane = new Membrane();
+$examples = [
+    ['title' => 'My Title', 'body' => '', 'tags' => ['a', 'b', 'c']],
+    ['title' => 'mY tItLe tHat iS uNnEcEsSaRiLlY lOnG wItH InCoRrEcT cApItIlIzAtIoN', 'body' => '', 'tags' => ['a', 'b', 'c']],
+];
+
+foreach ($examples as $example) {
+    $result = $membrane->process($example, $specification);
+    var_dump($result->value);
+    if ($result->isValid()) {
+        echo ' is valid';
+    } else {
+        echo ' is invalid' . "\n";
+        foreach($result->messageSets as $messageSet) {
+            foreach ($messageSet->messages as $message) {
+                echo $message->rendered() . "\n";
+            }
+        }
+    }
+    echo "\n";
+}
+```
+
+```text
+['title' => 'My Title', 'body' => '', 'tags' => ['a', 'b', 'c']] is valid
+['title' => 'mY tItLe tHat iS uNnEcEsSaRiLlY lOnG wItH InCoRrEcT cApItIlIzAtIoN', 'body' => '', 'tags' => ['a', 'b', 'c']] is invalid
+String is expected to be a maximum of 50 characters
+String does not match the required pattern ^([A-Z][a-z]*\s){1,10}$
+```
+
+Brilliant, now if a user makes an error with their title,
+we can provide them all the detail they need to fix it immediately.
+
+Finally, once we're happy with the input, we'll want to create our BlogPost data object.
+
+### Build Your Blog Post From Named Arguments
+
+```php
+#[SetFilterOrValidator(new RequiredFields('title', 'body'), Placement::BEFORE)]
+#[SetFilterOrValidator(new WithNamedArguments(BlogPost::class), Placement::AFTER)]
+class BlogPost
+{
+    public function __construct(
+        #[FilterOrValidator(new ToString())]
+        #[FilterOrValidator(new AllOf(new Length(5,50), new Regex('#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#')))]
+        public string $title,
+        #[FilterOrValidator(new ToString())]
+        public string $body,
+        #[SetFilterOrValidator(new Count(0, 5), Placement::BEFORE)]
+        #[FilterOrValidator(new ToString())]
+        #[Subtype('string')]
+        public array $tags,
+    ) {
+    }
+}
+```
+
+To build a BlogPost, **before** everything else: a title and body are required.
+
+The title must be convertable to a string and **all of the following:**
+
+* between 5-50 characters
+* match the regular expression provided
+
+The body must be convertable to a string.
+
+If tags are provided, they must be convertable to a string but
+**before** that it will check the number of tags does not exceed 5.
+
+**After** everything else: build a BlogPost from named arguments.
+
+```php
+$specification = new ClassWithAttributes(BlogPost::class);
+$data = [
+    'title' => 'My Title',
+    'body' => 'My content',
+    'tags' => ['tag1', 'tag2', 'tag3', 'tag4'],
+];
+$membrane = new Membrane();
+
+$result = $membrane->process($data, $specification);
+    
+$blogPost = $result->isValid() ? $result->value : null;
+
+echo $blogPost?->title; // My Title
+echo $blogPost?->body; // My content
+echo $blogPost?->tags; // ['tag1', 'tag2', 'tag3', 'tag4']
+```
+
+Now you've successfully validated data to ensure you can safely create your BlogPost class.

--- a/docs/builder-request.md
+++ b/docs/builder-request.md
@@ -1,0 +1,133 @@
+# Building From An OpenAPI Request
+
+## Specification
+
+```php
+\Membrane\OpenAPI\Specification\Request($filePath, $url, $method)
+```
+
+This Specification is an OpenAPI Request from an [OpenAPI document](https://github.com/OAI/OpenAPI-Specification).
+
+| Parameter   | Type   | Notes                                                                   |
+|-------------|--------|-------------------------------------------------------------------------|
+| $filePath   | string | The **absolute** file path of the OpenAPI schema the request belongs to |
+| $url        | string | The url of the path the request belongs to                              |
+| $method     | Method | The method of the request                                               |
+
+Both Json and Yaml schemas are supported.  
+Only application/json content is supported.
+
+**Please Note:** Membrane requires all Schema objects to have an explicitly stated `'type'`.
+
+## Example
+
+Referencing
+the [OpenAPI petstore-expanded.json](https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore-expanded.json):   
+To validate HTTP requests to visit `'http://petstore.swagger.io/api/pets'` using the `'get'` operation then this is the
+schema it should follow:
+
+```json
+{
+  "/pets": {
+    "get": {
+      "description": "Returns all pets from the system that the user has access to. \n",
+      "operationId": "findPets",
+      "parameters": [
+        {
+          "name": "tags",
+          "in": "query",
+          "description": "tags to filter by",
+          "required": false,
+          "style": "form",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "description": "maximum number of results to return",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Our Specification might look like this:
+
+```php
+use Membrane\OpenAPI\Method;use Membrane\OpenAPI\Specification\Request;
+
+$specification = new Request(__DIR__ . './api/OpenAPI.json', 'http://petstore.swagger.io/api/pets', Method::GET);
+```
+
+Notice an absolute file path was used, relative paths will not work in Request Specifications.
+
+With our specification we can build a processor to validate incoming server requests,
+the server requests must implement the Psr/Http/Message/ServerRequestInterface.
+
+For these examples the server requests will be mocked using the "guzzle/http-message" library:
+
+```php
+use GuzzleHttp\Psr7\ServerRequest; 
+
+$dataSets = [
+    'dataSet A' => new ServerRequest('get', 'http://petstore.swagger.io/v1/pets')
+    'dataSet B' => new ServerRequest('get', 'http://petstore.swagger.io/api/pets?limit=5&tags[]=cat&tags[]=tabby'),
+    'dataSet C' => new ServerRequest('get', 'http://petstore.swagger.io/api/pets?limit=five'),
+];
+
+$membrane = new Membrane();
+foreach($dataSets as $key => $dataSet) {
+    $result = $membrane->process($dataSet, $specification);
+    
+    if ($result->isValid()) {
+        echo $key, " is valid. \n", var_export($value, true), "\n";
+    } else {
+        echo $key, " is invalid. \n";
+        foreach($result->messageSets as $messageSet) {
+            foreach ($messageSet->messages as $message) {
+                echo $message->rendered();
+            }
+        }
+    }
+    echo "\n";
+}
+```
+
+Outputs
+
+```text
+DataSet A is valid.
+[
+    'path' => [],
+    'query' => [],
+    'header' => [],
+    'cookie' => [],
+    'body' => '',
+]
+
+DataSet B is valid.
+[
+    'path' => [],
+    'query' => ['limit' => 5, 'tags' => ['cat', 'tabby']],
+    'header' => [],
+    'cookie' => [],
+    'body' => '',
+]
+
+DataSet C is invalid.
+ToInt filter only accepts numeric strings
+```
+
+In this example DataSet C has been invalidated based on the query parameter 'limit'.  
+The OpenAPI specification stated that 'limit' should be an integer, so Membrane will check this for you.

--- a/docs/builder-response.md
+++ b/docs/builder-response.md
@@ -1,0 +1,126 @@
+# Building From An OpenAPI Response
+
+## Specification
+
+```php
+APIResponse($filePath, $url, $method, $httpStatus)
+```
+
+This Specification is an OpenAPI Response from an [OpenAPI document](https://github.com/OAI/OpenAPI-Specification).
+
+| Parameter   | Type   | Notes                                                                    |
+|-------------|--------|--------------------------------------------------------------------------|
+| $filePath   | string | The **absolute** file path of the OpenAPI schema the response belongs to |
+| $url        | string | The url of the path the response belongs to                              |
+| $method     | Method | The method the response belongs to                                       |
+| $httpStatus | string | The http status code of the response                                     |
+
+Both Json and Yaml schemas are supported.  
+Only application/json content is supported.
+
+**Please Note:** Membrane requires Schemas to have an explicitly stated `'type'`.
+
+## Example
+
+Referencing
+the [OpenAPI PetStore.yaml](https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.0/petstore.yaml):  
+If our user is visiting the `/pets` path with the `get` method, if they get a successful response this is the schema it
+should follow.
+
+```yaml
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                  properties:
+                    id:
+                      type: integer
+                      format: int64
+                    name:
+                      type: string
+                    tag:
+                      type: string
+```
+
+For the sake of this example, the references have already been resolved.
+
+Our Specification might look like this.
+
+```php
+$specification = new APIResponse(__DIR__ . './api/OpenAPI.yaml', '/pets', Method::GET, '200');
+```
+
+Notice an absolute file path was used, relative paths will not work in Response Specifications.
+
+We're now ready to validate any data coming in against our response schema like so:
+
+```php
+$dataSets = [
+    'dataSet A' => [
+        ['name' => 'Blink', 'id' => 1],
+        ['name' => 'Harley', 'id' => 2]
+    ],
+    'dataSet B' => [
+        ['name' => 'Blink'],
+        ['id' => 2]
+    ],
+    'dataSet C' => [
+        'Blink',
+        5
+    ],
+];
+
+$membrane = new Membrane();
+foreach($dataSets as $key => $dataSet) {
+    $result = $membrane->process($dataSet, $specification);
+    echo $key;
+    if ($result->isValid()) {
+        echo ' is valid';
+    } else {
+        echo ' is invalid';
+        foreach($result->messageSets as $messageSet) {
+            foreach ($messageSet->messages as $message) {
+                echo $message->rendered();
+            }
+        }
+    }
+    echo "\n";
+}
+```
+
+Outputs
+
+```text
+dataSet A is valid
+dataSet B is invalid
+id is a required field
+name is a required field
+dataSet C is invalid
+IsArray validator expects array value, string passed instead
+IsArray validator expects array value, integer passed instead
+```
+
+In this example DataSet B failed because:
+
+- The first item in the array `['name' => 'Blink']` did not contain an id.
+- The second item in the array `['id' => 2]` did not contain a name.
+
+DataSet C failed because the items were meant to be arrays but:
+
+- The first item was a string
+- The second item was an integer
+
+Notice in both cases that Membrane returned multiple messages.  
+Membrane will provide messages for all reasons for invalidation.

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -5,6 +5,7 @@ to change the input to match the correct format.
 If you do not wish to change the input: See [Validators](validators.md)
 
 All Filters implement the Membrane\Filter interface:
+
 ```php
 interface Filter
 {
@@ -51,6 +52,7 @@ echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
 ```
 
 The above example will output the following
+
 ```text
 foo_bar
 Result was valid
@@ -91,6 +93,7 @@ echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
 ```
 
 The above example will output the following
+
 ```text
 new values
 Result was valid
@@ -115,16 +118,19 @@ new Collect($newField, ...$fields)
 | ...$fields | string |
 
 **Example**
+
 ```php
 $array = ['a' => 1, 'b' => 2, 'c' => 3]
 $collect = new Collect('collected fields', 'a', 'c')
 
 $result = $collect->filter($array);
 
-echo $result->value
+var_export($result->value);
 echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
 ```
+
 The above example will output the following
+
 ```text
 ['b' => 2, 'collected fields' => [1, 3]]
 Result was valid
@@ -166,15 +172,16 @@ $nest = new Nest('nested fields', 'a', 'c')
 
 $result = $nest->filter($array);
 
-echo $result->value
+var_export($result->value);
 echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
 ```
+
 The above example will output the following
+
 ```text
 ['b' => 2, 'nested fields' => ['a' => 1, 'c' => 3]]
 Result was valid
 ```
-
 
 ### Pluck
 
@@ -200,10 +207,12 @@ $pluck = new Pluck('nested fields', 'a', 'c')
 
 $result = $pluck->filter($array);
 
-echo $result->value
+var_export($result->value);
 echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
 ```
+
 The above example will output the following
+
 ```text
 ['a' => 1, 'b' => 2, 'c' => 3, 'nested fields' => ['a' => 1, 'c' => 3]]
 Result was valid
@@ -230,10 +239,12 @@ $rename = new Rename('a', 'd')
 
 $result = $rename->filter($array);
 
-echo $result->value
+var_export($result->value);
 echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
 ```
+
 The above example will output the following
+
 ```text
 ['b' => 2, 'c' => 3, 'd' => 1]
 Result was valid
@@ -259,11 +270,321 @@ $truncate = new Truncate(2)
 
 $result = $truncate->filter($list);
 
-echo $result->value
+var_export($result->value);
 echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
 ```
+
 The above example will output the following
+
 ```text
 ['a', 'b']
+Result was valid
+```
+
+## String
+
+### JsonDecode
+
+Filters a string into a json object, as long as it follows json format.
+
+```php
+new JsonDecode()
+```
+
+**Example**
+
+```php
+$json = '{"id": 1, "name": "Spike", "type": "dog"}'
+$jsonDecode = new JsonDecode();
+
+$result = $jsonDecode->filter($json);
+
+echo json_encode($result->value, JSON_PRETTY_PRINT);
+echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+```
+
+The above example will output the following
+
+```text
+{
+    "id": 1,
+    "name": "Spike",
+    "type": "dog"
+}
+Result was valid
+```
+
+## Type
+
+### ToBool
+
+Filters scalar values that can represent boolean into boolean values.
+
+```php
+new ToBool()
+```
+
+**Example**
+
+```php
+$toBool = new ToBool();
+$values = [1, 'false', 'on', 'off']
+
+foreach($values as $value) {
+$result = $toBool->filter($value);
+echo (string)$value, 'becomes ';
+echo $result->value ? 'true' : 'false';
+echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+}
+```
+
+The above example will output the following
+
+```text
+1 becomes true
+Result was valid
+false becomes false
+Result was valid
+on becomes true
+Result was valid
+off becomes false
+Result was valid
+```
+
+### ToDateTime
+
+Filter strings into DateTime/DateTimeImmutable objects.
+
+```php
+new ToDateTime($format, $immutable)
+```
+
+| Parameter  | Type   | Default | Notes                                              |
+|------------|--------|---------|----------------------------------------------------|
+| $format    | string |         | A DateTime format i.e. 'Y-m-d'                     |
+| $immutable | bool   | true    | Set to true if you want a DateTimeImmutable object |
+
+**Example**
+
+```php
+$toDateTime = new ToDateTime('Y-m-d');
+$value = '1970-01-01';
+
+$result = $toDateTime->filter($value);
+echo $result->value->format('d-M-y'), "\n";
+echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+```
+
+The above example will output the following
+
+```text
+01-jan-1970
+Result was valid
+```
+
+### ToFloat
+
+Filters value to float. Works for null and scalar values (excluding non-numeric strings).
+
+```php
+new ToFloat()
+```
+
+**Example**
+
+```php
+$toFloat = new ToFloat();
+$values = [12, '12', '1.2', true, null]
+
+foreach($values as $value) {
+    $result = $toFloat->filter($value);
+    var_dump($value);
+    echo 'Becomes ', $result->value;
+    echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+}
+```
+
+The above example will output the following
+
+```text
+int(12)
+Becomes 12.0
+Result was valid
+string(2) "12"
+Becomes 12.0
+Result was valid
+string(3) "1.2"
+Becomes 1.2
+Result was valid
+bool(true)
+Becomes 1.0
+Result was valid
+NULL
+Becomes 0.0
+Result was valid
+```
+
+### ToInt
+
+Filters value to integer. Works for null and scalar values (excluding non-numeric strings).
+
+```php
+new ToInt()
+```
+
+**Example**
+
+```php
+$toInt = new ToInt();
+$values = [12, '12', '1.2', true, null]
+
+foreach($values as $value) {
+    $result = $toInt->filter($value);
+    var_dump($value);
+    echo 'Becomes ', $result->value;
+    echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+}
+```
+
+The above example will output the following
+
+```text
+int(12)
+Becomes 12
+Result was valid
+string(2) "12"
+Becomes 12
+Result was valid
+string(3) "1.2"
+Becomes 1
+Result was valid
+bool(true)
+Becomes 1
+Result was valid
+NULL
+Becomes 0
+Result was valid
+```
+
+### ToList
+
+Filters value to a list. Works for list and array values.
+
+```php
+new ToList()
+```
+
+```php
+$toList = new ToList();
+$values = [
+    [],
+    [1, 2, 3],
+    ['a' => 1, 'b' => 2, 'c' => 3]
+]
+
+foreach($values as $value) {
+    $result = $toList->filter($value);
+    var_export($value);
+    echo 'Becomes';
+    var_export($result->value);
+    echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+}
+```
+
+The above example will output the following
+
+```text
+[]
+Becomes
+[]
+Result was valid
+[1, 2, 3]
+Becomes
+[1, 2, 3]
+Result was valid
+['a' => 1, 'b' => 2, 'c' => 3]
+Becomes
+[1, 2, 3]
+Result was valid
+```
+
+### ToNumber
+
+Filters value to a float/integer. Works for integers, floats and numeric strings.
+
+```php
+new ToNumber()
+```
+
+**Example**
+
+```php
+$toNumber = new ToNumber();
+$values = [12, 1.2, '12', '1.2']
+
+foreach($values as $value) {
+    $result = $toNumber->filter($value);
+    var_dump($value);
+    echo 'Becomes the ', gettype($result->value), ' value: ', $result->value;
+    echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+}
+```
+
+The above example will output the following
+
+```text
+int(12)
+Becomes the integer value 12
+Result was valid
+float(1.2)
+Becomes the double value 1.2
+Result was valid
+string(2) "12"
+Becomes the integer value 12
+Result was valid
+string(3) "1.2"
+Becomes the double value 1.2
+Result was valid
+```
+
+### ToString
+
+Filters value to string. Works on null or scalar values, also works on classes implementing the __toString() method.
+
+```php
+new ToString()
+```
+
+**Example**
+
+```php
+$toString = new ToString();
+$values = ['string', 12, 1.2, true, null,]
+
+foreach($values as $value) {
+    $result = $toString->filter($value);
+    var_dump($value);
+    echo 'Becomes the ', gettype($result->value), ' value: "', $result->value, '"';
+    echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+}
+```
+
+The above example will output the following
+
+```text
+string(6) "string"
+Becomes the string value "string"
+Result was valid
+int(12)
+Becomes the string value "12"
+Result was valid
+float(1.2)
+Becomes the string value "1.2"
+Result was valid
+bool(true)
+Becomes the string value "1"
+Result was valid
+NULL
+Becomes the string value ""
 Result was valid
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,67 @@
 # Getting Started
 
+Membrane requirements:
+
+```
+"php": ^8.1.0,
+"cebe/php-openapi": ^1.7.0
+```
+
 ## Installation
+
+To start; require Membrane in [Composer](https://getcomposer.org/)
+
 ```text
 composer require membrane-php/membrane-core
 ```
 
+## The Basics
 
-## What Membrane Is
+### What Goes In
 
-Membrane is a library of tools which, much like its namesake, provides a layer of
-separation between external input and the inner workings of your project.
+Membrane needs a Specification to validate against.   
+These are the supported types of Specification:
 
-## What Membrane Is Not
+* [Class With Attributes](builder-attributes.md#specification)
+* [OpenAPI Request](builder-request.md#specification)
+* [OpenAPI Response](builder-response.md#specification)
 
-Membrane is not...
+With your Specification(s) at hand, Membrane is ready to process your data:
+
+```php
+$membrane = new Membrane();
+
+$membrane->process($data, ...$specifications);
+```
+
+### What Comes Out
+
+All data processed by Membrane will return as a [Result](result.md) object. Your data will be contained in your
+Result's `$value` property.
+
+To check if the data is valid your Result has the following method:
+
+```php
+isValid(): bool
+```
+
+If your data is valid, that's great, your application can now make use of the data with confidence.
+
+What if your data is invalid?  
+Your Result object will create a new [MessageSet](result.md#message-set) for each validation failure, The MessageSet(s)
+will contain information
+aiming to clarify the reason the data is considered invalid.
+
+To get a nested list of messages in an HTML format you can use the following code snippet:
+
+```php
+echo '<ul>';
+foreach($result->messageSets as $messageSet) {
+    echo '<li><ul> <b>' . $messageSet->fieldName->getStringRepresentation() . '</b>';
+    foreach($messageSet->messages as $message) {
+        echo '<li>' . $message->rendered() . '</li>';
+    }
+    echo '</ul></li>';
+}
+echo '</ul>';
+```

--- a/docs/processors.md
+++ b/docs/processors.md
@@ -1,13 +1,31 @@
 # Processors
 
-Processors chain together a sequence of [Filters](filters.md) and [Validators](validators.md) to be performed.
+When Membrane processes your data, behind the scenes it will build a Processor object tailored to validating data
+against your Specification(s).
 
-## Field
+Each Processor is unique, designed with a specific purpose in mind.  
+That said, all Processors have two methods in common:
 
-On its own a Field applies its $chain to all items in any single item of data.
-The type of data is not restricted so can be a single scalar value, an array or an object.
-By using it as part of a FieldSet it will only apply its $chain to a key in the array
-matching the string $processes.
+```php
+processes(): string
+```
+
+`processes()` returns the name of the field it processes
+
+```php
+process(FieldName $parentFieldName, mixed $value): Result
+```
+
+`process()` returns the [Result](result.md) object from validating `$value`.  
+It also asks for the `$parentFieldName` in the case of nested Processors this will make
+your [MessageSet's](result.md#message-set) [FieldName](result.md#field-name)
+more precise.
+
+## General-Use Processors
+
+### Field
+
+A Field validates a single item of data. i.e. A scalar value.
 
 ```php
 new Field($processes, ...$chain)
@@ -18,17 +36,15 @@ new Field($processes, ...$chain)
 | $processes | string              |
 | ...$chain  | Filter or Validator |
 
-## Collection
+When processing lists of scalar values, you will find a Field nested inside a [Collection](processors.md#collection),
+validating the scalar items.  
+When processing arrays with scalar properties, you will find Fields nested inside a [FieldSet](processors.md#field-set),
+validating each scalar
+property.
 
-A collection takes a $chain of Processors and applies their Filters and Validators in succession
-to all elements in a list.
+### Collection
 
-BeforeSets will be applied first, across the entire array.
-
-AfterSets will be applied last, across the entire array.
-
-Other Processors will be applied in between and **require list values.** If other Processors are used,
-ensure that your BeforeSet returns a list value.
+A Collection processes a list. i.e. `['a', 'b', 'c']`
 
 ```php
 new Collection($processes, ...$chain)
@@ -39,18 +55,20 @@ new Collection($processes, ...$chain)
 | $processes | string    |                                                                      |
 | ...$chain  | Processor | It can only take one BeforeSet, one AfterSet and one other Processor |
 
-## Field Set
+A Collection takes a sequence of other Processors to validate a list, as well as the items inside it.
 
-A FieldSet takes a $chain of Processors and applies their Filters and Validators in succession
-to elements in an array either as a group or individually by their key.
+A Collection may take:
 
-BeforeSets will be applied first, across the entire array.
+- one (and only one) [BeforeSet](processors.md#before-set), a specialized Field object that always processes first.
+- one (and only one) [AfterSet](processors.md#after-set), a specialized Field object that always processes last.
+- any number of other processors
 
-AfterSets will be applied last, across the entire array.
+**Please Note**: If other Processors are used they expect to process a list. As such if you create a BeforeSet that
+changes the datatype, those Processors will throw an Exception.
 
-Other Processors will be applied in between and only to the keys in the array that correspond to
-their individual $processes. As such other Processors **require array values.** If other Processors
-are used, ensure that your BeforeSet returns an array value.
+### Field Set
+
+A FieldSet processes an array, i.e. `['a' => 1, 'b' => 2, 'c' => 3]`
 
 ```php
 new FieldSet($processes, ...$chain)
@@ -61,10 +79,20 @@ new FieldSet($processes, ...$chain)
 | $processes | string    |                                                 |
 | ...$chain  | Processor | It can only take one BeforeSet and one AfterSet |
 
-## After Set
+A FieldSet may take:
 
-AfterSets take a $chain of Filters and Validators and apply them across a whole list/array.
-They will always be the final processor to act.
+- one (and only one) [BeforeSet](processors.md#before-set), a specialized Field object that always processes first.
+- one (and only one) [AfterSet](processors.md#after-set), a specialized Field object that always processes last.
+- any number of other processors
+
+**Please Note**: If other Processors are used they expect to process a list. As such if you create a BeforeSet that
+changes the datatype, those Processors will throw an Exception.
+
+### After Set
+
+AfterSets are a specialized [Field](processors.md#field). They work on a List or Array as a whole and **will always be
+the final processor to
+act.**
 
 ```php
 new AfterSet(...$chain)
@@ -74,10 +102,14 @@ new AfterSet(...$chain)
 |------------|---------------------|
 | ...$chain  | Filter or Validator |
 
-## Before Set
+An AfterSet takes a chain of [Filters](filters.md) or [Validators](validators.md) that act on the entire List/Array,
+they do not validate individual items within it.
 
-BeforeSets take a $chain of Filters and Validators and apply them across a whole list/array.
-They will always be the first processor to act.
+### Before Set
+
+AfterSets are a specialized [Field](processors.md#field). They work on a List or Array as a whole and **will always be
+the first processor to
+act.**
 
 ```php
 new BeforeSet(...$chain)
@@ -86,3 +118,69 @@ new BeforeSet(...$chain)
 | Parameter  | Type                |
 |------------|---------------------|
 | ...$chain  | Filter or Validator |
+
+A BeforeSet takes a chain of [Filters](filters.md) or [Validators](validators.md) that act on the entire List/Array,
+they do not validate individual items within it.
+
+## OpenAPI Processors
+
+The following processors are intended for Open-API specific use cases.  
+Alternative uses are not recommended.
+
+### AllOf
+
+Designed specifically to deal with the 'allOf' keyword of OpenAPI:  
+The AllOf processor takes a chain of processors (one for each schema within the 'allOf') and makes sure that all return
+a valid result.
+
+| Parameter  | Type      |
+|------------|-----------|
+| $processes | string    |
+| ...$chain  | Processor |
+
+### AnyOf
+
+| Parameter  | Type      |
+|------------|-----------|
+| $processes | string    |
+| ...$chain  | Processor |
+
+Designed specifically to deal with the 'anyOf' keyword of OpenAPI:  
+The AnyOf processor takes a chain of processors (one for each schema within the 'anyOf') and makes sure that at least
+one processor returns a valid result.
+
+### OneOf
+
+| Parameter  | Type      |
+|------------|-----------|
+| $processes | string    |
+| ...$chain  | Processor |
+
+Designed specifically to deal with the 'oneOf' keyword of OpenAPI:  
+The OneOf processor takes a chain of processors (one for each schema within the 'oneOf') and makes sure that one and
+only one processor returns a valid result.
+
+### Json
+
+| Parameter | Type      |
+|-----------|-----------|
+| $wrapped  | Processor |
+
+Designed specifically to wrap a processor that is expecting a json object. The Json processor attempts to decode a
+string into a json object before passing it into the wrapped processor.
+
+### Request
+
+Designed specifically to convert HTTP Requests into an array format, like so:
+
+```php
+[
+    'path' => '...',
+    'query' => '...',
+    'header' => [...],
+    'cookie' => [...],
+    'body' => '...'
+]
+```
+
+If data is passed into the request processor in this format already, this will pass as well.

--- a/docs/result.md
+++ b/docs/result.md
@@ -1,40 +1,52 @@
-# Result
-A Result object contains your external data after it has passed through Membrane.
+# The Result Object
+
+The Result object represents your data after it has been processed by Membrane.  
+It has three properties you can access:
 
 ## Value
 
-This is the external data after it has passed through Membrane.
+This is the external data after it has passed through Membrane. Unless you made use of [Filters](filters.md) then it
+will remain unchanged.
+
+For the Result object `$result` you can access it like so:
+
+```php
+$result->value
+```
 
 ## Result
 
 This lets you know whether the external data passed through Membrane successfully or unsuccessfully.
 
-It has three states:
+For most use-cases you only need to call the public method `isValid(): bool`.  
+This will return true as long as the data does not fail validation.
+
+If you find yourself needing to access the result property you will notice it has three states:
 
 * `Result::valid` means that the external data has been passed validation.
 * `Result::noResult` means that the external data has neither passed nor failed validation.  
+  isValid() will still return true for noResult.  
   A common reason may be that it has only passed through Filters and no Validators have been used.
 * `Result::invalid` means that the external data has failed validation.
-
-A result is considered valid as long as it is not invalid.
 
 ## Message Set
 
 In the case that the external data fails validation i.e. `Result::invalid` the Result object
 will contain at least one Message Set.
 
-Message Sets provide details on why the external data has failed validation. 
+Message Sets provide details on why the external data has failed validation.
 
 They consist of two properties:
 
-### FieldName
+### Field Name
 
-This specifies what part of the data was being validated when it failed.
+This specifies what part of the data failed validation.
 
 ### Message
 
 This specifies how the data failed validation. Message Sets can contain multiple messages.
 A message can be read using the rendered() method
+
 ```php
 $message = new Message('this message is an %s', ['example']);
 echo $message->rendered(); // this message is an example

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -50,8 +50,6 @@ The above example will output the following
 Result was valid
 ```
 
-## Collection
-
 ### Contained
 
 Checks that a collection contains the given value.
@@ -222,6 +220,40 @@ The above example will output the following
 Result was valid
 ```
 
+## FieldSet
+
+### RequiredFields
+
+Checks if array contains keys corresponding to all required fields.
+
+```php
+new RequiredFields(...$fields)
+```
+
+| Parameter  | Type   |
+|------------|--------|
+| ...$fields | string |
+
+**Example 1**
+
+```php
+<?php
+$requiredFields = new RequiredFields('a', 'c');
+$array = ['a' => 1, 'b' => 2, 'c' => 3]
+
+$result = $requiredFields->validate($array);
+
+echo $result->value;
+echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+```
+
+The above example will output the following
+
+```text
+['a' => 1, 'b' => 2, 'c' => 3]
+Result was valid
+```
+
 ## Numeric
 
 ### Maximum
@@ -316,74 +348,6 @@ The above example will output the following
 
 ```text
 25
-Result was valid
-```
-
-## FieldSet
-
-### RequiredFields
-
-Checks if array contains keys corresponding to all required fields.
-
-```php
-new RequiredFields(...$fields)
-```
-
-| Parameter  | Type   |
-|------------|--------|
-| ...$fields | string |
-
-**Example 1**
-
-```php
-<?php
-$requiredFields = new RequiredFields('a', 'c');
-$array = ['a' => 1, 'b' => 2, 'c' => 3]
-
-$result = $requiredFields->validate($array);
-
-echo $result->value;
-echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
-```
-
-The above example will output the following
-
-```text
-['a' => 1, 'b' => 2, 'c' => 3]
-Result was valid
-```
-
-## Numeric
-
-### Range
-
-Checks if an integer/float is between a specified minimum and maximum.
-
-```php
-new Range($min, $max)
-```
-
-| Parameter | Type               | Default Value | Notes                              |
-|-----------|--------------------|---------------|------------------------------------|
-| $min      | int, float or null | null          | If set to null, minimum is ignored |
-| $max      | int, float or null | null          | If set to null, maximum is ignored |
-
-**Example 1**
-
-```php
-<?php
-$range = new Range(-100, 99.99);
-
-$result = $range->validate(50);
-
-echo $result->value;
-echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
-```
-
-The above example will output the following
-
-```text
-50
 Result was valid
 ```
 
@@ -692,6 +656,40 @@ The above example will output the following
 
 ```text
 NULL
+Result was valid
+```
+
+### IsNumber
+
+Checks if input is numeric.
+
+```php
+new IsNumber()
+```
+
+```php
+<?php
+$isNumber = new IsNumber();
+$values = [1, 2.0, '3']
+
+foreach($values as $value) {
+    $result = $isNumber->validate($value);
+    
+    echo $result->value;
+    echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+}
+
+
+```
+
+The above example will output the following
+
+```text
+1
+Result was valid
+2.0
+Result was valid
+"3"
 Result was valid
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,9 +2,10 @@ site_name: Membrane Documentation
 site_url: https://membrane-php.github.io
 nav:
   - Getting Started: index.md
-  - The Basics: basics.md
-  - The Builder: builder.md
-  - Result: result.md
+  - Processing A Class With Attributes: builder-attributes.md
+  - Processing An OpenAPI Request: builder-request.md
+  - Processing An OpenAPI Response: builder-response.md
+  - The Result Object: result.md
   - Processors: processors.md
   - Filters: filters.md
   - Validators: validators.md

--- a/src/Membrane.php
+++ b/src/Membrane.php
@@ -7,8 +7,11 @@ namespace Membrane;
 use Membrane\Attribute\Builder as AttributeBuilder;
 use Membrane\Builder\Builder as BuilderInterface;
 use Membrane\Builder\Specification;
+use Membrane\OpenAPI\Builder\RequestBuilder;
+use Membrane\OpenAPI\Builder\ResponseBuilder;
 use Membrane\Result\FieldName;
 use Membrane\Result\Result;
+use RuntimeException;
 
 final class Membrane
 {
@@ -18,6 +21,8 @@ final class Membrane
     public function __construct()
     {
         $this->builders[] = new AttributeBuilder();
+        $this->builders[] = new RequestBuilder();
+        $this->builders[] = new ResponseBuilder();
     }
 
     public function process(mixed $data, Specification ...$against): Result
@@ -47,6 +52,6 @@ final class Membrane
         }
 
         //@TODO throw a proper exception here
-        throw new \RuntimeException('Unable to create processor for specification');
+        throw new RuntimeException('Unable to create processor for specification');
     }
 }

--- a/src/OpenAPI/Builder/APIBuilder.php
+++ b/src/OpenAPI/Builder/APIBuilder.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Builder;
+
+use cebe\openapi\spec\Reference;
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\Builder\Builder;
+use Membrane\OpenAPI;
+use Membrane\OpenAPI\Processor\AnyOf;
+use Membrane\Processor;
+use Membrane\Processor\Field;
+use Membrane\Validator\Type\IsNull;
+use Membrane\Validator\Utility;
+
+abstract class APIBuilder implements Builder
+{
+    private Arrays $arrayBuilder;
+    private TrueFalse $trueFalseBuilder;
+    private Numeric $numericBuilder;
+    private Objects $objectBuilder;
+    private Strings $stringBuilder;
+
+    protected function fromSchema(Schema $schema, string $fieldName = '', bool $strict = true): Processor
+    {
+        if ($schema->not !== null) {
+            throw new Exception("Keyword 'not' is currently unsupported");
+        }
+
+        if ($schema->allOf !== null) {
+            return $this->handleAllOf($schema->allOf, $fieldName);
+        }
+
+        if ($schema->anyOf !== null) {
+            return $this->handleAnyOf($schema->anyOf, $fieldName);
+        }
+
+        if ($schema->oneOf !== null) {
+            return $this->handleOneOf($schema->oneOf, $fieldName);
+        }
+
+        switch ($schema->type) {
+            case 'string':
+                $specification = new OpenAPI\Specification\Strings($fieldName, $schema);
+                return ($this->getStringBuilder())->build($specification);
+            case 'number':
+            case 'integer':
+                $specification = new OpenAPI\Specification\Numeric($fieldName, $schema, $strict);
+                return $this->getNumericBuilder()->build($specification);
+            case 'boolean':
+                $specification = new OpenAPI\Specification\TrueFalse($fieldName, $schema, $strict);
+                return $this->getTrueFalseBuilder()->build($specification);
+            case 'array':
+                $specification = new OpenAPI\Specification\Arrays($fieldName, $schema);
+                return $this->getArrayBuilder()->build($specification);
+            case 'object':
+                $specification = new OpenAPI\Specification\Objects($fieldName, $schema);
+                return $this->getObjectBuilder()->build($specification);
+            default:
+                return new Field('', new Utility\Passes());
+        }
+    }
+
+    protected function handleNullable(string $fieldName, Processor $processor): AnyOf
+    {
+        return new AnyOf(
+            $fieldName,
+            new Field($fieldName, new IsNull()),
+            $processor
+        );
+    }
+
+    private function getArrayBuilder(): Arrays
+    {
+        if (!isset($this->arrayBuilder)) {
+            $this->arrayBuilder = new Arrays();
+        }
+
+        return $this->arrayBuilder;
+    }
+
+    private function getTrueFalseBuilder(): TrueFalse
+    {
+        if (!isset($this->trueFalseBuilder)) {
+            $this->trueFalseBuilder = new TrueFalse();
+        }
+
+        return $this->trueFalseBuilder;
+    }
+
+    private function getObjectBuilder(): Objects
+    {
+        if (!isset($this->objectBuilder)) {
+            $this->objectBuilder = new Objects();
+        }
+
+        return $this->objectBuilder;
+    }
+
+    private function getNumericBuilder(): Numeric
+    {
+        if (!isset($this->numericBuilder)) {
+            $this->numericBuilder = new OpenAPI\Builder\Numeric();
+        }
+
+        return $this->numericBuilder;
+    }
+
+    /** @param Reference[]|Schema[] $allOf */
+    private function handleAllOf(array $allOf, string $fieldName): Processor
+    {
+        if (count($allOf) < 2) {
+            assert($allOf[0] instanceof Schema);
+            return $this->fromSchema($allOf[0], $fieldName);
+        }
+
+        $fieldSets = [];
+
+        // @TODO add key to messages in a useful format
+        foreach ($allOf as $key => $objectSchema) {
+            assert($objectSchema instanceof Schema);
+            $fieldSets[] = $this->fromSchema($objectSchema, $fieldName);
+        }
+
+        return new OpenAPI\Processor\AllOf($fieldName, ...$fieldSets);
+    }
+
+    /** @param Reference[]|Schema[] $anyOf */
+    private function handleAnyOf(array $anyOf, string $fieldName): Processor
+    {
+        if (count($anyOf) < 2) {
+            assert($anyOf[0] instanceof Schema);
+            return $this->fromSchema($anyOf[0], $fieldName);
+        }
+
+        $fieldSets = [];
+
+        // @TODO add key to messages in a useful format
+        foreach ($anyOf as $objectSchema) {
+            assert($objectSchema instanceof Schema);
+            $fieldSets[] = $this->fromSchema($objectSchema, $fieldName);
+        }
+
+        return new OpenAPI\Processor\AnyOf($fieldName, ...$fieldSets);
+    }
+
+    /** @param Reference[]|Schema[] $oneOf */
+    private function handleOneOf(array $oneOf, string $fieldName): Processor
+    {
+        if (count($oneOf) < 2) {
+            assert($oneOf[0] instanceof Schema);
+            return $this->fromSchema($oneOf[0], $fieldName);
+        }
+
+        $fieldSets = [];
+
+        // @TODO add key to messages in a useful format
+        foreach ($oneOf as $objectSchema) {
+            assert($objectSchema instanceof Schema);
+            $fieldSets[] = $this->fromSchema($objectSchema, $fieldName);
+        }
+
+        return new OpenAPI\Processor\OneOf($fieldName, ...$fieldSets);
+    }
+
+    private function getStringBuilder(): Strings
+    {
+        if (!isset($this->stringBuilder)) {
+            $this->stringBuilder = new OpenAPI\Builder\Strings();
+        }
+        return $this->stringBuilder;
+    }
+}

--- a/src/OpenAPI/Builder/Arrays.php
+++ b/src/OpenAPI/Builder/Arrays.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Builder;
+
+use cebe\openapi\spec\Schema;
+use Membrane\Builder\Specification;
+use Membrane\Processor;
+use Membrane\Processor\BeforeSet;
+use Membrane\Processor\Collection;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\Collection\Count;
+use Membrane\Validator\Collection\Unique;
+use Membrane\Validator\Type\IsList;
+
+class Arrays extends APIBuilder
+{
+    public function supports(Specification $specification): bool
+    {
+        return $specification instanceof \Membrane\OpenAPI\Specification\Arrays;
+    }
+
+    public function build(Specification $specification): Processor
+    {
+        assert($specification instanceof \Membrane\OpenAPI\Specification\Arrays);
+
+        $beforeChain = [new IsList()];
+
+        if ($specification->enum !== null) {
+            $beforeChain[] = new Contained($specification->enum);
+        }
+
+        if ($specification->minItems > 0 || $specification->maxItems !== null) {
+            $beforeChain[] = new Count($specification->minItems, $specification->maxItems);
+        }
+
+        if ($specification->uniqueItems === true) {
+            $beforeChain[] = new Unique();
+        }
+
+        $beforeSet = new BeforeSet(...$beforeChain);
+
+        if ($specification->items === null) {
+            return new Collection($specification->fieldName, $beforeSet);
+        }
+
+        assert($specification->items instanceof Schema);
+        $collection = new Collection($specification->fieldName, $beforeSet, $this->fromSchema($specification->items));
+
+        if ($specification->nullable) {
+            return $this->handleNullable($specification->fieldName, $collection);
+        }
+
+        return $collection;
+    }
+}

--- a/src/OpenAPI/Builder/Numeric.php
+++ b/src/OpenAPI/Builder/Numeric.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Builder;
+
+use Membrane\Builder\Specification;
+use Membrane\Filter;
+use Membrane\Filter\Type\ToFloat;
+use Membrane\Filter\Type\ToInt;
+use Membrane\Filter\Type\ToNumber;
+use Membrane\OpenAPI;
+use Membrane\Processor;
+use Membrane\Processor\Field;
+use Membrane\Validator;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\Numeric\Maximum;
+use Membrane\Validator\Numeric\Minimum;
+use Membrane\Validator\Numeric\MultipleOf;
+use Membrane\Validator\Type\IsFloat;
+use Membrane\Validator\Type\IsInt;
+use Membrane\Validator\Type\IsNumber;
+
+class Numeric extends APIBuilder
+{
+    public function supports(Specification $specification): bool
+    {
+        return $specification instanceof OpenAPI\Specification\Numeric;
+    }
+
+    public function build(Specification $specification): Processor
+    {
+        assert($specification instanceof OpenAPI\Specification\Numeric);
+
+        if ($specification->type === 'number') {
+            $chain = $this->handleNumber($specification);
+        } else {
+            $chain = $this->handleInteger($specification);
+        }
+
+        if ($specification->enum !== null) {
+            $chain[] = new Contained($specification->enum);
+        }
+
+        $chain = array_merge($chain, $this->handleNumericConstraints($specification));
+
+        if ($specification->nullable) {
+            return $this->handleNullable($specification->fieldName, new Field($specification->fieldName, ...$chain));
+        }
+
+        return new Field($specification->fieldName, ...$chain);
+    }
+
+    /** @return Filter[]|Validator[] */
+    private function handleNumber(OpenAPI\Specification\Numeric $specification): array
+    {
+        if (in_array($specification->format, ['float', 'double'], true)) {
+            return $specification->strict ? [new IsFloat()] : [new ToFloat(), new IsFloat()];
+        } else {
+            return $specification->strict ? [new IsNumber()] : [new ToNumber(), new IsNumber()];
+        }
+    }
+
+    /** @return Filter[]|Validator[] */
+    private function handleInteger(OpenAPI\Specification\Numeric $specification): array
+    {
+        return $specification->strict ? [new IsInt()] : [new ToInt(), new IsInt()];
+    }
+
+    /** @return Validator[] */
+    private function handleNumericConstraints(OpenAPI\Specification\Numeric $specification): array
+    {
+        $chain = [];
+
+        if ($specification->maximum !== null) {
+            $chain[] = new Maximum($specification->maximum, $specification->exclusiveMaximum);
+        }
+
+        if ($specification->minimum !== null) {
+            $chain[] = new Minimum($specification->minimum, $specification->exclusiveMinimum);
+        }
+
+        if ($specification->multipleOf !== null) {
+            $chain[] = new MultipleOf($specification->multipleOf);
+        }
+
+        return $chain;
+    }
+}

--- a/src/OpenAPI/Builder/Objects.php
+++ b/src/OpenAPI/Builder/Objects.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Builder;
+
+use cebe\openapi\spec\Schema;
+use Membrane\Builder\Specification;
+use Membrane\Processor;
+use Membrane\Processor\BeforeSet;
+use Membrane\Processor\FieldSet;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\FieldSet\RequiredFields;
+use Membrane\Validator\Type\IsArray;
+
+class Objects extends APIBuilder
+{
+    public function supports(Specification $specification): bool
+    {
+        return $specification instanceof \Membrane\OpenAPI\Specification\Objects;
+    }
+
+    public function build(Specification $specification): Processor
+    {
+        assert($specification instanceof \Membrane\OpenAPI\Specification\Objects);
+
+        $beforeChain = [new IsArray()];
+
+        if ($specification->enum !== null) {
+            $beforeChain[] = new Contained($specification->enum);
+        }
+
+        if ($specification->required !== null) {
+            $beforeChain[] = new RequiredFields(...$specification->required);
+        }
+
+        // @TODO support minProperties and maxProperties
+
+        $beforeSet = new BeforeSet(...$beforeChain);
+
+        $fields = [];
+        foreach ($specification->properties as $key => $value) {
+            assert($value instanceof Schema);
+            $fields [] = $this->fromSchema($value, $key);
+        }
+
+        $processor = new FieldSet($specification->fieldName, $beforeSet, ...$fields);
+
+        if ($specification->nullable) {
+            return $this->handleNullable($specification->fieldName, $processor);
+        }
+
+        return $processor;
+    }
+}

--- a/src/OpenAPI/Builder/RequestBuilder.php
+++ b/src/OpenAPI/Builder/RequestBuilder.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Builder;
+
+use cebe\openapi\spec\Parameter;
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\Builder\Specification;
+use Membrane\OpenAPI\Filter\HTTPParameters;
+use Membrane\OpenAPI\Filter\PathMatcher as PathMatcherFilter;
+use Membrane\OpenAPI\Processor\Json;
+use Membrane\OpenAPI\Processor\Request as RequestProcessor;
+use Membrane\OpenAPI\Specification\Request;
+use Membrane\Processor;
+use Membrane\Processor\BeforeSet;
+use Membrane\Processor\Field;
+use Membrane\Processor\FieldSet;
+use Membrane\Validator\FieldSet\RequiredFields;
+use Membrane\Validator\Utility\Passes;
+
+class RequestBuilder extends APIBuilder
+{
+    public function supports(Specification $specification): bool
+    {
+        return ($specification instanceof Request);
+    }
+
+    public function build(Specification $specification): Processor
+    {
+        assert($specification instanceof Request);
+
+        $processors = $this->fromParameters($specification);
+        $processors['body'] = new Json($this->fromRequestBody($specification));
+
+        return new RequestProcessor('', $processors);
+    }
+
+    private function fromRequestBody(Request $specification): Processor
+    {
+        if ($specification->requestBodySchema === null) {
+            return new Field('requestBody', new Passes());
+        }
+
+        return $this->fromSchema($specification->requestBodySchema, 'requestBody');
+    }
+
+    /**
+     * @return Processor[]
+     */
+    private function fromParameters(Request $specification): array
+    {
+        $locationFields = [
+            'path' => [
+                'required' => [],
+                'fields' => [],
+                'beforeSet' => [new PathMatcherFilter($specification->matchingPath)],
+            ],
+            'query' => ['required' => [], 'fields' => [], 'beforeSet' => [new HTTPParameters()]],
+            'header' => ['required' => [], 'fields' => [], 'beforeSet' => []],
+            'cookie' => ['required' => [], 'fields' => [], 'beforeSet' => []],
+        ];
+
+        foreach ($specification->pathParameters as $p) {
+            $locationFields[$p->in]['fields'][] = $this->fromSchema($this->findSchema($p), $p->name, false);
+            if ($p->required) {
+                $locationFields[$p->in]['required'][] = $p->name;
+            }
+        }
+
+        $fieldSets = [];
+        foreach ($locationFields as $in => ['required' => $required, 'fields' => $fields, 'beforeSet' => $beforeSet]) {
+            if (count($required) > 0) {
+                $beforeSet[] = new RequiredFields(...$required);
+            }
+
+            if (count($beforeSet) > 0) {
+                $fields[] = new BeforeSet(...$beforeSet);
+            }
+
+            $fieldSets[$in] = new FieldSet($in, ...$fields);
+        }
+
+        return $fieldSets;
+    }
+
+    private function findSchema(Parameter $parameter): Schema
+    {
+        $schemaLocations = [];
+
+        if ($parameter->schema !== null) {
+            $schemaLocations[] = $parameter->schema;
+        }
+
+        if ($parameter->content !== []) {
+            $schemaLocations[] = $parameter->content['application/json']?->schema
+                ??
+                throw new Exception('APISpec requires application/json content');
+        }
+
+        if (count($schemaLocations) !== 1) {
+            throw new Exception(
+                'A parameter MUST contain either a schema property, or a content property, but not both'
+            );
+        }
+
+        assert($schemaLocations[0] instanceof Schema);
+        return $schemaLocations[0];
+    }
+}

--- a/src/OpenAPI/Builder/ResponseBuilder.php
+++ b/src/OpenAPI/Builder/ResponseBuilder.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Builder;
+
+use Membrane\Builder\Specification;
+use Membrane\OpenAPI\Specification\Response;
+use Membrane\Processor;
+use Membrane\Processor\Field;
+use Membrane\Validator\Utility\Passes;
+
+class ResponseBuilder extends APIBuilder
+{
+    public function supports(Specification $specification): bool
+    {
+        return ($specification instanceof Response);
+    }
+
+    public function build(Specification $specification): Processor
+    {
+        assert($specification instanceof Response);
+
+        return $this->fromContent($specification);
+    }
+
+    private function fromContent(Response $response): Processor
+    {
+        if ($response->schema === null) {
+            return new Field('', new Passes());
+        }
+
+        return $this->fromSchema($response->schema);
+    }
+}

--- a/src/OpenAPI/Builder/Strings.php
+++ b/src/OpenAPI/Builder/Strings.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Builder;
+
+use Membrane\Builder\Specification;
+use Membrane\Processor;
+use Membrane\Processor\Field;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\String\DateString;
+use Membrane\Validator\String\Length;
+use Membrane\Validator\String\Regex;
+use Membrane\Validator\Type\IsString;
+
+class Strings extends APIBuilder
+{
+    public function supports(Specification $specification): bool
+    {
+        return $specification instanceof \Membrane\OpenAPI\Specification\Strings;
+    }
+
+    public function build(Specification $specification): Processor
+    {
+        assert($specification instanceof \Membrane\OpenAPI\Specification\Strings);
+
+        $chain = [new IsString()];
+
+        if ($specification->enum !== null) {
+            $chain[] = new Contained($specification->enum);
+        }
+
+        if ($specification->format === 'date') {
+            $chain[] = new DateString('Y-m-d');
+        }
+
+        if ($specification->format === 'date-time') {
+            $chain[] = new DateString('Y-m-d\TH:i:sP');
+        }
+
+        if ($specification->minLength > 0 || $specification->maxLength !== null) {
+            $chain[] = new Length($specification->minLength, $specification->maxLength);
+        }
+
+        if ($specification->pattern !== null) {
+            $chain[] = new Regex($specification->pattern);
+        }
+
+        if ($specification->nullable) {
+            return $this->handleNullable($specification->fieldName, new Field($specification->fieldName, ...$chain));
+        }
+
+        return new Field($specification->fieldName, ...$chain);
+    }
+}

--- a/src/OpenAPI/Builder/TrueFalse.php
+++ b/src/OpenAPI/Builder/TrueFalse.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Builder;
+
+use Membrane\Builder\Specification;
+use Membrane\Filter\Type\ToBool;
+use Membrane\Processor;
+use Membrane\Processor\Field;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\Type\IsBool;
+
+class TrueFalse extends APIBuilder
+{
+    public function supports(Specification $specification): bool
+    {
+        return $specification instanceof \Membrane\OpenAPI\Specification\TrueFalse;
+    }
+
+    public function build(Specification $specification): Processor
+    {
+        assert($specification instanceof \Membrane\OpenAPI\Specification\TrueFalse);
+
+        $chain = $specification->strict ? [new IsBool()] : [new ToBool(), new IsBool()];
+
+        if ($specification->enum !== null) {
+            $chain[] = new Contained($specification->enum);
+        }
+
+        if ($specification->nullable) {
+            return $this->handleNullable($specification->fieldName, new Field($specification->fieldName, ...$chain));
+        }
+
+        return new Field($specification->fieldName, ...$chain);
+    }
+}

--- a/src/OpenAPI/Method.php
+++ b/src/OpenAPI/Method.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI;
+
+enum Method: string
+{
+    case GET = 'get';
+    case POST = 'post';
+    case PUT = 'put';
+    case DELETE = 'delete';
+}

--- a/src/OpenAPI/Processor/Request.php
+++ b/src/OpenAPI/Processor/Request.php
@@ -43,10 +43,11 @@ class Request implements Processor
         $result = Result::valid($value);
         foreach ($this->processors as $in => $processor) {
             $itemResult = $processor->process($parentFieldName, $value[$in]);
+            $value[$in] = $itemResult->value;
             $result = $itemResult->merge($result);
         }
 
-        return $result;
+        return $result->merge(Result::noResult($value));
     }
 
     /** @return array<string, string|array<string, mixed>> */

--- a/src/OpenAPI/Specification/APISpec.php
+++ b/src/OpenAPI/Specification/APISpec.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\exceptions\UnresolvableReferenceException;
+use cebe\openapi\Reader;
+use cebe\openapi\spec\MediaType;
+use cebe\openapi\spec\OpenApi;
+use cebe\openapi\spec\Operation;
+use cebe\openapi\spec\PathItem;
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\Builder\Specification;
+use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\PathMatcher;
+use Throwable;
+
+use function str_starts_with;
+
+abstract class APISpec implements Specification
+{
+    public readonly PathItem $pathItem;
+    public readonly PathMatcher $matchingPath;
+
+    // @TODO support alternative servers found in both Path or PathItem objects
+
+    public function __construct(string $filePath, string $url)
+    {
+        $openAPI = $this->loadOpenAPIFile($filePath);
+        $openAPI->validate() ?: throw new Exception('OpenAPI could not be validated');
+
+        $serverUrl = $this->matchServer($openAPI, $url);
+        foreach ($openAPI->paths->getPaths() as $path => $pathItem) {
+            $pathMatcher = new PathMatcher($serverUrl, $path);
+            if ($pathMatcher->matches($url)) {
+                $this->matchingPath = $pathMatcher;
+                $this->pathItem = $pathItem;
+                break;
+            }
+        }
+
+            $this->matchingPath ?? throw new Exception('url does not match any paths defined by API');
+    }
+
+    protected function getOperation(Method $method): Operation
+    {
+        return $this->pathItem->getOperations()[$method->value]
+            ??
+            throw new Exception('Method does not match any methods defined by path');
+    }
+
+    /** @param MediaType[] $content */
+    protected function getSchema(array $content): ?Schema
+    {
+        if ($content === []) {
+            return null;
+        }
+
+        $schema = $content['application/json']?->schema
+            ??
+            throw new Exception('APISpec requires application/json content');
+
+        assert($schema instanceof Schema);
+        return $schema;
+    }
+
+
+    private function loadOpenAPIFile(string $filePath): OpenApi
+    {
+        if (!file_exists($filePath)) {
+            throw new Exception('File could not be found');
+        }
+
+        $fileExtension = pathinfo(strtolower($filePath), PATHINFO_EXTENSION);
+        try {
+            if ($fileExtension === 'json') {
+                return Reader::readFromJsonFile($filePath);
+            } elseif ($fileExtension === 'yml' || $fileExtension === 'yaml') {
+                return Reader::readFromYamlFile($filePath);
+            }
+        } catch (UnresolvableReferenceException) {
+            throw new Exception('absolute file path required to resolve references in OpenAPI specifications');
+        } catch (Throwable) {
+            throw new Exception(sprintf('%s file is not following OpenAPI specifications', $fileExtension));
+        }
+
+        throw new Exception('Invalid file type');
+    }
+
+    private function matchServer(OpenApi $openAPI, string $url): string
+    {
+        $servers = $openAPI->servers;
+        uasort($servers, fn($a, $b) => strlen($b->url) <=> strlen($a->url));
+
+        foreach ($servers as $server) {
+            $serverUrl = rtrim($server->url, '/');
+            if (str_starts_with($url, $serverUrl . '/')) {
+                return $serverUrl;
+            }
+        }
+
+        return '';
+    }
+}

--- a/src/OpenAPI/Specification/Request.php
+++ b/src/OpenAPI/Specification/Request.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\spec\Operation;
+use cebe\openapi\spec\Parameter;
+use cebe\openapi\spec\PathItem;
+use cebe\openapi\spec\Reference;
+use cebe\openapi\spec\Schema;
+use Membrane\OpenAPI\Method;
+
+class Request extends APISpec
+{
+    /** @var Parameter[] */
+    public readonly array $pathParameters;
+    public readonly ?Schema $requestBodySchema;
+
+    public function __construct(string $filePath, string $url, Method $method)
+    {
+        parent::__construct($filePath, $url);
+
+        $requestOperation = $this->getOperation($method);
+
+        $requestBody = $requestOperation->requestBody ?? null;
+
+        assert(!($requestBody instanceof Reference));
+        $this->requestBodySchema = $requestBody === null ? null : $this->getSchema($requestBody->content);
+
+        $this->pathParameters = $this->getPathParameters($this->pathItem, $requestOperation);
+    }
+
+    /** @return Parameter[] */
+    private function getPathParameters(PathItem $path, Operation $operation): array
+    {
+        $parameters = array_filter(
+            array_merge($path->parameters, $operation->parameters),
+            fn($p) => $p instanceof Parameter
+        );
+
+        $parameters = array_combine(array_map(fn($p) => $p->name, $parameters), $parameters);
+
+        return array_values($parameters);
+    }
+}

--- a/src/OpenAPI/Specification/Request.php
+++ b/src/OpenAPI/Specification/Request.php
@@ -9,7 +9,9 @@ use cebe\openapi\spec\Parameter;
 use cebe\openapi\spec\PathItem;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
+use Exception;
 use Membrane\OpenAPI\Method;
+use Psr\Http\Message\ServerRequestInterface;
 
 class Request extends APISpec
 {
@@ -29,6 +31,13 @@ class Request extends APISpec
         $this->requestBodySchema = $requestBody === null ? null : $this->getSchema($requestBody->content);
 
         $this->pathParameters = $this->getPathParameters($this->pathItem, $requestOperation);
+    }
+
+    public static function fromPsr7(string $apiPath, ServerRequestInterface $request): self
+    {
+        $method = Method::tryFrom(strtolower($request->getMethod())) ?? throw new Exception('not supported');
+
+        return new self($apiPath, $request->getUri()->getPath(), $method);
     }
 
     /** @return Parameter[] */

--- a/src/OpenAPI/Specification/Response.php
+++ b/src/OpenAPI/Specification/Response.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\OpenAPI\Method;
+
+class Response extends APISpec
+{
+    public readonly ?Schema $schema;
+
+    public function __construct(string $filePath, string $url, Method $method, string $httpStatus)
+    {
+        parent::__construct($filePath, $url);
+
+        $response = $this->getResponse($method, $httpStatus);
+
+        $this->schema = $response->content !== [] ? $this->getSchema($response->content) : null;
+    }
+
+    private function getResponse(Method $method, string $httpStatus): \cebe\openapi\spec\Response
+    {
+        $operation = $this->getOperation($method);
+
+        return $operation->responses[$httpStatus]
+            ??
+            $operation->responses['default']
+            ??
+            throw new Exception('No applicable response found');
+    }
+}

--- a/src/Validator/Type/IsNumber.php
+++ b/src/Validator/Type/IsNumber.php
@@ -16,7 +16,7 @@ class IsNumber implements Validator
         if (!(is_int($value) || is_float($value))) {
             return Result::invalid(
                 $value,
-                new MessageSet(null, new Message('Value must be int or float, %s passed', [gettype($value)]))
+                new MessageSet(null, new Message('Value must be a number, %s passed', [gettype($value)]))
             );
         }
 

--- a/tests/Attribute/BuilderTest.php
+++ b/tests/Attribute/BuilderTest.php
@@ -49,32 +49,32 @@ use Membrane\Validator\Type\IsList;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Membrane\Attribute\Builder
- * @uses   \Membrane\Attribute\ClassWithAttributes
- * @uses   \Membrane\Exception\CannotProcessProperty
- * @uses   \Membrane\Attribute\FilterOrValidator
- * @uses   \Membrane\Attribute\SetFilterOrValidator
- * @uses   \Membrane\Attribute\OverrideProcessorType
- * @uses   \Membrane\Attribute\Subtype
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Processor\Collection
- * @uses   \Membrane\Processor\FieldSet
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Processor\BeforeSet
- * @uses   \Membrane\Processor\AfterSet
- * @uses   \Membrane\Validator\FieldSet\RequiredFields
- * @uses   \Membrane\Validator\Type\IsList
- * @uses   \Membrane\Validator\Type\IsInt
- * @uses   \Membrane\Validator\Type\IsString
- * @uses   \Membrane\Filter\Type\ToString
- * @uses   \Membrane\Validator\String\Length
- * @uses   \Membrane\Validator\String\Regex
- * @uses   \Membrane\Validator\Utility\AllOf
- * @uses   \Membrane\Validator\Collection\Count
- * @uses   \Membrane\Filter\CreateObject\WithNamedArguments
+ * @covers   \Membrane\Attribute\Builder
+ * @covers   \Membrane\Exception\CannotProcessProperty
+ * @uses     \Membrane\Attribute\ClassWithAttributes
+ * @uses     \Membrane\Attribute\FilterOrValidator
+ * @uses     \Membrane\Attribute\SetFilterOrValidator
+ * @uses     \Membrane\Attribute\OverrideProcessorType
+ * @uses     \Membrane\Attribute\Subtype
+ * @uses     \Membrane\Result\Result
+ * @uses     \Membrane\Result\MessageSet
+ * @uses     \Membrane\Result\Message
+ * @uses     \Membrane\Result\FieldName
+ * @uses     \Membrane\Processor\Collection
+ * @uses     \Membrane\Processor\FieldSet
+ * @uses     \Membrane\Processor\Field
+ * @uses     \Membrane\Processor\BeforeSet
+ * @uses     \Membrane\Processor\AfterSet
+ * @uses     \Membrane\Validator\FieldSet\RequiredFields
+ * @uses     \Membrane\Validator\Type\IsList
+ * @uses     \Membrane\Validator\Type\IsInt
+ * @uses     \Membrane\Validator\Type\IsString
+ * @uses     \Membrane\Filter\Type\ToString
+ * @uses     \Membrane\Validator\String\Length
+ * @uses     \Membrane\Validator\String\Regex
+ * @uses     \Membrane\Validator\Utility\AllOf
+ * @uses     \Membrane\Validator\Collection\Count
+ * @uses     \Membrane\Filter\CreateObject\WithNamedArguments
  */
 class BuilderTest extends TestCase
 {
@@ -451,7 +451,7 @@ class BuilderTest extends TestCase
                     )
                 ),
             ],
-            'Blog Post: Maximum Number Of Tags A' => [
+            'Blog Post: Maximum Numeric Of Tags A' => [
                 new ClassWithAttributes(BlogPostMaxTags::class),
                 [
                     'title' => '',
@@ -466,7 +466,7 @@ class BuilderTest extends TestCase
                     ]
                 ),
             ],
-            'Blog Post: Maximum Number Of Tags B' => [
+            'Blog Post: Maximum Numeric Of Tags B' => [
                 new ClassWithAttributes(BlogPostMaxTags::class),
                 [
                     'title' => 'TITLE WRITTEN ENTIRELY IN UPPER CASE AND UNNECESSARILY LONG',

--- a/tests/Attribute/BuilderTest.php
+++ b/tests/Attribute/BuilderTest.php
@@ -51,30 +51,30 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers   \Membrane\Attribute\Builder
  * @covers   \Membrane\Exception\CannotProcessProperty
- * @uses     \Membrane\Attribute\ClassWithAttributes
+ * @uses     ClassWithAttributes
  * @uses     \Membrane\Attribute\FilterOrValidator
  * @uses     \Membrane\Attribute\SetFilterOrValidator
  * @uses     \Membrane\Attribute\OverrideProcessorType
  * @uses     \Membrane\Attribute\Subtype
- * @uses     \Membrane\Result\Result
- * @uses     \Membrane\Result\MessageSet
- * @uses     \Membrane\Result\Message
- * @uses     \Membrane\Result\FieldName
- * @uses     \Membrane\Processor\Collection
- * @uses     \Membrane\Processor\FieldSet
- * @uses     \Membrane\Processor\Field
- * @uses     \Membrane\Processor\BeforeSet
- * @uses     \Membrane\Processor\AfterSet
- * @uses     \Membrane\Validator\FieldSet\RequiredFields
- * @uses     \Membrane\Validator\Type\IsList
- * @uses     \Membrane\Validator\Type\IsInt
+ * @uses     Result
+ * @uses     MessageSet
+ * @uses     Message
+ * @uses     FieldName
+ * @uses     Collection
+ * @uses     FieldSet
+ * @uses     Field
+ * @uses     BeforeSet
+ * @uses     AfterSet
+ * @uses     RequiredFields
+ * @uses     IsList
+ * @uses     IsInt
  * @uses     \Membrane\Validator\Type\IsString
  * @uses     \Membrane\Filter\Type\ToString
  * @uses     \Membrane\Validator\String\Length
  * @uses     \Membrane\Validator\String\Regex
  * @uses     \Membrane\Validator\Utility\AllOf
  * @uses     \Membrane\Validator\Collection\Count
- * @uses     \Membrane\Filter\CreateObject\WithNamedArguments
+ * @uses     WithNamedArguments
  */
 class BuilderTest extends TestCase
 {
@@ -451,7 +451,7 @@ class BuilderTest extends TestCase
                     )
                 ),
             ],
-            'Blog Post: Maximum Numeric Of Tags A' => [
+            'Blog Post: Maximum Number Of Tags A' => [
                 new ClassWithAttributes(BlogPostMaxTags::class),
                 [
                     'title' => '',
@@ -466,7 +466,7 @@ class BuilderTest extends TestCase
                     ]
                 ),
             ],
-            'Blog Post: Maximum Numeric Of Tags B' => [
+            'Blog Post: Maximum Number Of Tags B' => [
                 new ClassWithAttributes(BlogPostMaxTags::class),
                 [
                     'title' => 'TITLE WRITTEN ENTIRELY IN UPPER CASE AND UNNECESSARILY LONG',

--- a/tests/Filter/String/JsonDecodeTest.php
+++ b/tests/Filter/String/JsonDecodeTest.php
@@ -21,7 +21,7 @@ class JsonDecodeTest extends TestCase
     public function dataSetsToFilter(): array
     {
         return [
-            'value passed is not a string' => [
+            'value is not a string' => [
                 5,
                 Result::invalid(
                     5,
@@ -31,7 +31,7 @@ class JsonDecodeTest extends TestCase
                     )
                 ),
             ],
-            'value passed causes syntax error' => [
+            'value causes syntax error' => [
                 '"id": 1, "name": "Spike", "type": "dog"}',
                 Result::invalid(
                     null,
@@ -41,9 +41,17 @@ class JsonDecodeTest extends TestCase
                     )
                 ),
             ],
-            'value passed is correct json format' => [
+            'value is correct json format of an object' => [
                 '{"id": 1, "name": "Spike", "type": "dog"}',
                 Result::valid(['id' => '1', 'name' => 'Spike', 'type' => 'dog']),
+            ],
+            'value is correct json format of a string' => [
+                '"string"',
+                Result::valid('string'),
+            ],
+            'value is correct json format of an array' => [
+                '[ 1, 2, 3]',
+                Result::valid([1, 2, 3]),
             ],
         ];
     }

--- a/tests/OpenAPI/Builder/ArraysTest.php
+++ b/tests/OpenAPI/Builder/ArraysTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Builder;
+
+use cebe\openapi\spec\Schema;
+use Membrane\OpenAPI\Builder\Arrays;
+use Membrane\OpenAPI\Processor\AnyOf;
+use Membrane\OpenAPI\Specification;
+use Membrane\Processor;
+use Membrane\Processor\BeforeSet;
+use Membrane\Processor\Collection;
+use Membrane\Processor\Field;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\Collection\Count;
+use Membrane\Validator\Collection\Unique;
+use Membrane\Validator\Type\IsInt;
+use Membrane\Validator\Type\IsList;
+use Membrane\Validator\Type\IsNull;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Builder\Arrays
+ * @covers \Membrane\OpenAPI\Builder\APIBuilder
+ * @uses   \Membrane\OpenAPI\Builder\Numeric
+ * @uses   \Membrane\OpenAPI\Processor\AnyOf
+ * @uses   \Membrane\OpenAPI\Specification\APISchema
+ * @uses   \Membrane\OpenAPI\Specification\Numeric
+ * @uses   \Membrane\Processor\BeforeSet
+ * @uses   \Membrane\Processor\Collection
+ * @uses   \Membrane\Processor\Field
+ * @uses   \Membrane\Validator\Collection\Contained
+ * @uses   \Membrane\Validator\Collection\Count
+ * @uses   \Membrane\Validator\Collection\Unique
+ */
+class ArraysTest extends TestCase
+{
+    public function specificationsToSupport(): array
+    {
+        return [
+            [
+                new class() implements \Membrane\Builder\Specification {
+                },
+                false,
+            ],
+            [self::createStub(Specification\Arrays::class), true],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToSupport
+     */
+    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    {
+        $sut = new Arrays();
+
+        self::assertSame($expected, $sut->supports($specification));
+    }
+
+    public function specificationsToBuild(): array
+    {
+        return [
+            'minimum input' => [
+                new Specification\Arrays('', new Schema(['type' => 'array'])),
+                new Collection('', new BeforeSet(new IsList())),
+            ],
+            'detailed input' => [
+                new Specification\Arrays(
+                    '',
+                    new Schema(
+                        [
+                            'type' => 'array',
+                            'items' => new Schema(['type' => 'integer']),
+                            'maxItems' => 3,
+                            'minItems' => 1,
+                            'uniqueItems' => true,
+                            'enum' => [[1, 2, 3], null],
+                            'format' => 'array of ints',
+                            'nullable' => false,
+                        ]
+                    )
+                ),
+                new Collection(
+                    '',
+                    new BeforeSet(new IsList(), new Contained([[1, 2, 3], null]), new Count(1, 3), new Unique()),
+                    new Field('', new IsInt())
+
+                ),
+            ],
+            'detailed nullable input' => [
+                new Specification\Arrays(
+                    '',
+                    new Schema(
+                        [
+                            'type' => 'array',
+                            'items' => new Schema(['type' => 'integer']),
+                            'maxItems' => 3,
+                            'minItems' => 1,
+                            'uniqueItems' => true,
+                            'enum' => [[1, 2, 3], null],
+                            'format' => 'array of ints',
+                            'nullable' => true,
+                        ]
+                    )
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new Collection(
+                        '',
+                        new BeforeSet(new IsList(), new Contained([[1, 2, 3], null]), new Count(1, 3), new Unique()),
+                        new Field('', new IsInt())
+                    )
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToBuild
+     */
+    public function buildTest(Specification\Arrays $specification, Processor $expected): void
+    {
+        $sut = new Arrays();
+
+        $actual = $sut->build($specification);
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/OpenAPI/Builder/NumericTest.php
+++ b/tests/OpenAPI/Builder/NumericTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Builder;
+
+use cebe\openapi\spec\Schema;
+use Membrane\Filter\Type\ToFloat;
+use Membrane\Filter\Type\ToInt;
+use Membrane\Filter\Type\ToNumber;
+use Membrane\OpenAPI\Builder\Numeric;
+use Membrane\OpenAPI\Processor\AnyOf;
+use Membrane\OpenAPI\Specification;
+use Membrane\Processor;
+use Membrane\Processor\Field;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\Numeric\Maximum;
+use Membrane\Validator\Numeric\Minimum;
+use Membrane\Validator\Numeric\MultipleOf;
+use Membrane\Validator\Type\IsFloat;
+use Membrane\Validator\Type\IsInt;
+use Membrane\Validator\Type\IsNull;
+use Membrane\Validator\Type\IsNumber;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Builder\Numeric
+ * @covers \Membrane\OpenAPI\Builder\APIBuilder
+ * @uses   \Membrane\OpenAPI\Processor\AnyOf
+ * @uses   \Membrane\Processor\Field
+ * @uses   \Membrane\Validator\Collection\Contained
+ * @uses   \Membrane\Validator\Numeric\Maximum
+ * @uses   \Membrane\Validator\Numeric\Minimum
+ * @uses   \Membrane\Validator\Numeric\MultipleOf
+ */
+class NumericTest extends TestCase
+{
+    public function specificationsToSupport(): array
+    {
+        return [
+            [
+                new class() implements \Membrane\Builder\Specification {
+                },
+                false,
+            ],
+            [self::createStub(Specification\Numeric::class), true],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToSupport
+     */
+    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    {
+        $sut = new Numeric();
+
+        self::assertSame($expected, $sut->supports($specification));
+    }
+
+    public function specificationsToBuild(): array
+    {
+        return [
+            'non-strict integer input' => [
+                new Specification\Numeric('', new Schema(['type' => 'integer']), false),
+                new Field('', new ToInt(), new IsInt()),
+            ],
+            'strict integer input' => [
+                new Specification\Numeric('', new Schema(['type' => 'integer']), true),
+                new Field('', new IsInt()),
+            ],
+            'non-strict number input' => [
+                new Specification\Numeric('', new Schema(['type' => 'number']), false),
+                new Field('', new ToNumber(), new IsNumber()),
+            ],
+            'strict number input' => [
+                new Specification\Numeric('', new Schema(['type' => 'number']), true),
+                new Field('', new IsNumber()),
+            ],
+            'non-strict float input' => [
+                new Specification\Numeric('', new Schema(['type' => 'number', 'format' => 'float']), false),
+                new Field('', new ToFloat(), new IsFloat()),
+            ],
+            'strict float input' => [
+                new Specification\Numeric('', new Schema(['type' => 'number', 'format' => 'float']), true),
+                new Field('', new IsFloat()),
+            ],
+            'detailed input' => [
+                new Specification\Numeric(
+                    '',
+                    new Schema(
+                        [
+                            'type' => 'integer',
+                            'exclusiveMinimum' => true,
+                            'exclusiveMaximum' => true,
+                            'maximum' => 4,
+                            'minimum' => 0,
+                            'multipleOf' => 3,
+                            'enum' => [1, 2, 3, null],
+                            'format' => 'nullable int',
+                            'nullable' => true,
+                        ]
+                    ),
+                    false
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new Field(
+                        '',
+                        new ToInt(),
+                        new IsInt(),
+                        new Contained([1, 2, 3, null]),
+                        new Maximum(4, true),
+                        new Minimum(0, true),
+                        new MultipleOf(3)
+                    )
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToBuild
+     */
+    public function buildTest(Specification\Numeric $specification, Processor $expected): void
+    {
+        $sut = new Numeric();
+
+        $actual = $sut->build($specification);
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/OpenAPI/Builder/ObjectsTest.php
+++ b/tests/OpenAPI/Builder/ObjectsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Builder;
+
+use cebe\openapi\spec\Schema;
+use Membrane\OpenAPI\Builder\Objects;
+use Membrane\OpenAPI\Processor\AnyOf;
+use Membrane\OpenAPI\Specification;
+use Membrane\Processor;
+use Membrane\Processor\BeforeSet;
+use Membrane\Processor\Field;
+use Membrane\Processor\FieldSet;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\FieldSet\RequiredFields;
+use Membrane\Validator\Type\IsArray;
+use Membrane\Validator\Type\IsInt;
+use Membrane\Validator\Type\IsNull;
+use Membrane\Validator\Type\IsString;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Builder\Objects
+ * @covers \Membrane\OpenAPI\Builder\APIBuilder
+ * @uses   \Membrane\OpenAPI\Builder\Numeric
+ * @uses   \Membrane\OpenAPI\Builder\Strings
+ * @uses   \Membrane\OpenAPI\Processor\AnyOf
+ * @uses   \Membrane\OpenAPI\Specification\APISchema
+ * @uses   \Membrane\OpenAPI\Specification\Numeric
+ * @uses   \Membrane\OpenAPI\Specification\Strings
+ * @uses   \Membrane\Processor\BeforeSet
+ * @uses   \Membrane\Processor\Field
+ * @uses   \Membrane\Processor\FieldSet
+ * @uses   \Membrane\Validator\Collection\Contained
+ * @uses   \Membrane\Validator\FieldSet\RequiredFields
+ */
+class ObjectsTest extends TestCase
+{
+    public function specificationsToSupport(): array
+    {
+        return [
+            [
+                new class() implements \Membrane\Builder\Specification {
+                },
+                false,
+            ],
+            [self::createStub(Specification\Objects::class), true],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToSupport
+     */
+    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    {
+        $sut = new Objects();
+
+        self::assertSame($expected, $sut->supports($specification));
+    }
+
+    public function specificationsToBuild(): array
+    {
+        return [
+            'minimum input' => [
+                new Specification\Objects('', new Schema(['type' => 'object'])),
+                new FieldSet('', new BeforeSet(new IsArray())),
+            ],
+            'detailed input' => [
+                new Specification\Objects(
+                    '',
+                    new Schema(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'id' => new Schema(['type' => 'integer']),
+                                'name' => new Schema(['type' => 'string']),
+                            ],
+                            'required' => ['id', 'name'],
+                            'format' => 'pet',
+                            'enum' => [['id' => 5, 'name' => 'Blink'], null],
+                            'nullable' => true,
+                        ]
+                    )
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new FieldSet(
+                        '',
+                        new BeforeSet(
+                            new IsArray(),
+                            new Contained([['id' => 5, 'name' => 'Blink'], null]),
+                            new RequiredFields('id', 'name')
+                        ),
+                        new Field('id', new IsInt()),
+                        new Field('name', new IsString())
+                    )
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToBuild
+     */
+    public function buildTest(Specification\Objects $specification, Processor $expected): void
+    {
+        $sut = new Objects();
+
+        $actual = $sut->build($specification);
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/OpenAPI/Builder/RequestBuilderTest.php
+++ b/tests/OpenAPI/Builder/RequestBuilderTest.php
@@ -1,0 +1,543 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Builder;
+
+use Exception;
+use GuzzleHttp\Psr7\ServerRequest;
+use Membrane\Builder\Specification;
+use Membrane\Filter\Type\ToInt;
+use Membrane\OpenAPI\Builder\RequestBuilder;
+use Membrane\OpenAPI\Filter\HTTPParameters;
+use Membrane\OpenAPI\Filter\PathMatcher;
+use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\PathMatcher as PathMatcherClass;
+use Membrane\OpenAPI\Processor\Json;
+use Membrane\OpenAPI\Processor\Request as RequestProcessor;
+use Membrane\OpenAPI\Specification\Request;
+use Membrane\OpenAPI\Specification\Response;
+use Membrane\Processor;
+use Membrane\Processor\BeforeSet;
+use Membrane\Processor\Collection;
+use Membrane\Processor\Field;
+use Membrane\Processor\FieldSet;
+use Membrane\Result\FieldName;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Validator\FieldSet\RequiredFields;
+use Membrane\Validator\Type\IsFloat;
+use Membrane\Validator\Type\IsInt;
+use Membrane\Validator\Type\IsList;
+use Membrane\Validator\Type\IsString;
+use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @covers    \Membrane\OpenAPI\Builder\RequestBuilder
+ * @covers    \Membrane\OpenAPI\Builder\APIBuilder
+ * @uses      \Membrane\OpenAPI\Builder\Arrays
+ * @uses      \Membrane\OpenAPI\Builder\Numeric
+ * @uses      \Membrane\OpenAPI\Builder\Strings
+ * @uses      \Membrane\OpenAPI\Filter\HTTPParameters
+ * @uses      \Membrane\OpenAPI\Filter\PathMatcher
+ * @uses      \Membrane\OpenAPI\PathMatcher
+ * @uses      \Membrane\OpenAPI\Processor\Json
+ * @uses      \Membrane\OpenAPI\Processor\Request
+ * @uses      \Membrane\OpenAPI\Specification\APISchema
+ * @uses      \Membrane\OpenAPI\Specification\APISpec
+ * @uses      \Membrane\OpenAPI\Specification\Arrays
+ * @uses      \Membrane\OpenAPI\Specification\Numeric
+ * @uses      \Membrane\OpenAPI\Specification\Strings
+ * @uses      \Membrane\OpenAPI\Specification\Request
+ * @uses      \Membrane\Filter\Type\ToInt
+ * @uses      \Membrane\Processor\BeforeSet
+ * @uses      \Membrane\Processor\Collection
+ * @uses      \Membrane\Processor\Field
+ * @uses      \Membrane\Processor\FieldSet
+ * @uses      \Membrane\Result\FieldName
+ * @uses      \Membrane\Result\Message
+ * @uses      \Membrane\Result\MessageSet
+ * @uses      \Membrane\Result\Result
+ * @uses      \Membrane\Validator\FieldSet\RequiredFields
+ * @uses      \Membrane\Validator\Numeric\Maximum
+ * @uses      \Membrane\Validator\Type\IsInt
+ * @uses      \Membrane\Validator\Type\IsList
+ * @uses      \Membrane\Validator\Type\IsString
+ * @uses      \Membrane\Validator\Utility\Passes
+ */
+class RequestBuilderTest extends TestCase
+{
+    public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
+
+    /** @test */
+    public function throwsExceptionIfParameterHasContentThatIsNotJson(): void
+    {
+        $specification = new Request(
+            self::DIR . 'noReferences.json',
+            '/requestpathexceptions',
+            Method::POST
+        );
+        $sut = new RequestBuilder();
+
+        self::expectExceptionObject(
+            new Exception('APISpec requires application/json content')
+        );
+
+        $sut->build($specification);
+    }
+
+    /** @test */
+    public function throwsExceptionIfParameterHasNoSchemaNorContent(): void
+    {
+        $specification = new Request(self::DIR . 'noReferences.json', '/requestpathexceptions', Method::GET);
+        $sut = new RequestBuilder();
+
+        self::expectExceptionObject(
+            new Exception('A parameter MUST contain either a schema property, or a content property, but not both')
+        );
+
+        $sut->build($specification);
+    }
+
+    public function dataSetsforSupports(): array
+    {
+        return [
+            [
+                new class() implements Specification {
+                },
+                false,
+            ],
+            [
+                self::createStub(Request::class),
+                true,
+            ],
+            [
+                self::createStub(Response::class),
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsforSupports
+     */
+    public function supportsTest(Specification $spec, bool $expected): void
+    {
+        $sut = new RequestBuilder();
+
+        $supported = $sut->supports($spec);
+
+        self::assertSame($expected, $supported);
+    }
+
+    public function dataSetsForBuild(): array
+    {
+        return [
+            'no path params, no operation params, no requestBody' => [
+                new Request(
+                    self::DIR . 'noReferences.json',
+                    'http://www.test.com/path/path',
+                    Method::GET
+                ),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com/path', '/path'))
+                            )
+                        ),
+                        'query' => new FieldSet('query', new BeforeSet(new HTTPParameters())),
+                        'header' => new FieldSet('header'),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new Passes())),
+                    ]
+
+                ),
+            ],
+            'path param in path, no operation params, no requestBody' => [
+                new Request(
+                    self::DIR . 'noReferences.json',
+                    'http://www.test.com/requestpathone/{id}',
+                    Method::GET
+                ),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestpathone/{id}')),
+                                new RequiredFields('id')
+                            ),
+                            new Field('id', new ToInt(), new IsInt())
+                        ),
+                        'query' => new FieldSet('query', new BeforeSet(new HTTPParameters())),
+                        'header' => new FieldSet('header'),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new Passes())),
+                    ]
+
+                ),
+            ],
+            'path param in path, operation param in query not required, no requestBody' => [
+                new Request(self::DIR . 'noReferences.json', '/requestpathone/{id}', Method::POST),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestpathone/{id}')),
+                                new RequiredFields('id')
+                            ),
+                            new Field('id', new ToInt(), new IsInt())
+                        ),
+                        'query' => new FieldSet(
+                            'query',
+                            new BeforeSet(new HTTPParameters()),
+                            new Collection('names', new BeforeSet(new IsList()))
+                        ),
+                        'header' => new FieldSet('header'),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new Passes())),
+                    ]
+                ),
+            ],
+            'path param in path, operation param in query required, no requestBody' => [
+                new Request(
+                    self::DIR . 'noReferences.json',
+                    '/requestpathone/{id}',
+                    Method::PUT
+                ),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestpathone/{id}')),
+                                new RequiredFields('id')
+                            ),
+                            new Field('id', new ToInt(), new IsInt())
+                        ),
+                        'query' => new FieldSet(
+                            'query',
+                            new BeforeSet(new HTTPParameters(), new RequiredFields('name')),
+                            new Field('name', new IsString())
+                        ),
+                        'header' => new FieldSet('header'),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new Passes())),
+                    ]
+
+                ),
+            ],
+            'path param in path, operation param in query with json content, required, no requestBody' => [
+                new Request(
+                    self::DIR . 'noReferences.json',
+                    '/requestpathone/{id}',
+                    Method::DELETE
+                ),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestpathone/{id}')),
+                                new RequiredFields('id')
+                            ),
+                            new Field('id', new ToInt(), new IsInt())
+                        ),
+                        'query' => new FieldSet(
+                            'query',
+                            new BeforeSet(new HTTPParameters(), new RequiredFields('name')),
+                            new Field('name', new IsString())
+                        ),
+                        'header' => new FieldSet('header'),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new Passes())),
+                    ]
+                ),
+            ],
+            'path param in header, no requestBody' => [
+                new Request(
+                    self::DIR . 'noReferences.json',
+                    '/requestpathtwo',
+                    Method::GET
+                ),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestpathtwo'))
+                            )
+                        ),
+                        'query' => new FieldSet('query', new BeforeSet(new HTTPParameters())),
+                        'header' => new FieldSet('header', new Field('id', new ToInt(), new IsInt())),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new Passes())),
+                    ]
+
+                ),
+            ],
+            'path param in header, operation param in cookie, no requestBody' => [
+                new Request(self::DIR . 'noReferences.json', '/requestpathtwo', Method::POST),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestpathtwo'))
+                            )
+                        ),
+                        'query' => new FieldSet('query', new BeforeSet(new HTTPParameters())),
+                        'header' => new FieldSet('header', new Field('id', new ToInt(), new IsInt())),
+                        'cookie' => new FieldSet('cookie', new Field('name', new IsString())),
+                        'body' => new Json(new Field('requestBody', new Passes())),
+                    ]
+
+                ),
+            ],
+            'identical param in header and query, no requestBody' => [
+                new Request(
+                    self::DIR . 'noReferences.json',
+                    '/requestpathtwo',
+                    Method::PUT
+                ),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestpathtwo'))
+                            )
+                        ),
+                        'query' => new FieldSet(
+                            'query',
+                            new BeforeSet(new HTTPParameters()),
+                            new Field('id', new ToInt(), new IsInt())
+                        ),
+                        'header' => new FieldSet('header'),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new Passes())),
+                    ]
+
+                ),
+            ],
+            'same param in path and operation with different types, no requestBody' => [
+                new Request(
+                    self::DIR . 'noReferences.json',
+                    '/requestpathtwo',
+                    Method::DELETE
+                ),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestpathtwo'))
+                            )
+                        ),
+                        'query' => new FieldSet('query', new BeforeSet(new HTTPParameters())),
+                        'header' => new FieldSet('header', new Field('id', new IsString())),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new Passes())),
+                    ]
+
+                ),
+            ],
+            'requestBody param' => [
+                new Request(
+                    self::DIR . 'noReferences.json',
+                    '/requestbodypath',
+                    Method::GET
+                ),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestbodypath'))
+                            )
+                        ),
+                        'query' => new FieldSet('query', new BeforeSet(new HTTPParameters())),
+                        'header' => new FieldSet('header'),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new IsInt())),
+                    ]
+
+                ),
+            ],
+            'operation param in query, requestBody param' => [
+                new Request(
+                    self::DIR . 'noReferences.json',
+                    '/requestbodypath',
+                    Method::POST
+                ),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestbodypath'))
+                            )
+                        ),
+                        'query' => new FieldSet(
+                            'query',
+                            new BeforeSet(new HTTPParameters()),
+                            new Field('id', new IsString())
+                        ),
+                        'header' => new FieldSet('header'),
+                        'cookie' => new FieldSet('cookie'),
+                        'body' => new Json(new Field('requestBody', new IsInt())),
+                    ]
+
+                ),
+            ],
+            'path param in path, operation param in query, header, cookie, requestBody param' => [
+                new Request(self::DIR . 'noReferences.json', '/requestbodypath/{id}', Method::GET),
+                new RequestProcessor(
+                    '',
+                    [
+                        'path' => new FieldSet(
+                            'path',
+                            new BeforeSet(
+                                new PathMatcher(new PathMatcherClass('http://www.test.com', '/requestbodypath/{id}')),
+                                new RequiredFields('id')
+                            ),
+                            new Field('id', new ToInt(), new IsInt())
+                        ),
+                        'query' => new FieldSet(
+                            'query',
+                            new BeforeSet(new HTTPParameters()),
+                            new Field('name', new IsString())
+                        ),
+                        'header' => new FieldSet('header', new Field('species', new IsString())),
+                        'cookie' => new FieldSet('cookie', new Field('subspecies', new IsString())),
+                        'body' => new Json(new Field('requestBody', new IsFloat())),
+                    ]
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsForBuild
+     */
+    public function buildTest(Specification $spec, Processor $expected): void
+    {
+        $sut = new RequestBuilder();
+
+        $actual = $sut->build($spec);
+
+        self::assertEquals($expected, $actual);
+    }
+
+
+    public function dataSetsForDocExamples(): array
+    {
+        $api = self::DIR . '/docs/petstore.yaml';
+        $expanded = self::DIR . '/docs/petstore-expanded.json';
+
+        return [
+            'petstore /pets get, minimal (valid)' => [
+                new Request($api, 'http://petstore.swagger.io/v1/pets', Method::GET),
+                new ServerRequest('get', 'http://petstore.swagger.io/v1/pets'),
+                Result::valid(
+                    [
+                        'path' => [],
+                        'query' => [],
+                        'header' => [],
+                        'cookie' => [],
+                        'body' => '',
+                    ],
+                ),
+            ],
+            'petstore /pets/{petid} get, minimal (valid)' => [
+                new Request($api, 'http://petstore.swagger.io/v1/pets/Blink', Method::GET),
+                new ServerRequest('get', 'http://petstore.swagger.io/v1/pets/Harley'),
+                Result::valid(
+                    [
+                        'path' => ['petId' => 'Harley'],
+                        'query' => [],
+                        'header' => [],
+                        'cookie' => [],
+                        'body' => '',
+                    ],
+                ),
+            ],
+            'petstore expanded /pets get (invalid)' => [
+                new Request(
+                    $expanded,
+                    'http://petstore.swagger.io/api/pets',
+                    Method::GET
+                ),
+                new ServerRequest('get', 'http://petstore.swagger.io/api/pets?limit=five'),
+                Result::invalid(
+                    [
+                        'path' => [],
+                        'query' => ['limit' => 'five'],
+                        'header' => [],
+                        'cookie' => [],
+                        'body' => '',
+                    ],
+                    new MessageSet(
+                        new FieldName('limit', '', 'query'),
+                        new Message('ToInt filter only accepts numeric strings', [])
+                    )
+                ),
+            ],
+            'petstore expanded /pets get, minimal (valid)' => [
+                new Request(
+                    $expanded,
+                    'http://petstore.swagger.io/api/pets',
+                    Method::GET
+                ),
+                new ServerRequest('get', 'http://petstore.swagger.io/api/pets?limit=5&tags[]=cat&tags[]=tabby'),
+                Result::valid(
+                    [
+                        'path' => [],
+                        'query' => ['limit' => 5, 'tags' => ['cat', 'tabby']],
+                        'header' => [],
+                        'cookie' => [],
+                        'body' => '',
+                    ]
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsForDocExamples
+     */
+    public function docsTest(
+        Request $specification,
+        array|ServerRequestInterface $serverRequest,
+        Result $expected
+    ): void {
+        $sut = new RequestBuilder();
+
+        $processor = $sut->build($specification);
+
+        $actual = $processor->process(new FieldName(''), $serverRequest);
+
+        self::assertEquals($expected, $actual);
+        self::assertSame($expected->value, $actual->value);
+    }
+}

--- a/tests/OpenAPI/Builder/ResponseBuilderTest.php
+++ b/tests/OpenAPI/Builder/ResponseBuilderTest.php
@@ -1,0 +1,943 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Builder;
+
+use Exception;
+use Membrane\Builder\Specification;
+use Membrane\OpenAPI\Builder\ResponseBuilder;
+use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\Processor\AllOf;
+use Membrane\OpenAPI\Processor\AnyOf;
+use Membrane\OpenAPI\Processor\OneOf;
+use Membrane\OpenAPI\Specification\Request;
+use Membrane\OpenAPI\Specification\Response;
+use Membrane\Processor;
+use Membrane\Processor\BeforeSet;
+use Membrane\Processor\Collection;
+use Membrane\Processor\Field;
+use Membrane\Processor\FieldSet;
+use Membrane\Result\FieldName;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\Collection\Count;
+use Membrane\Validator\Collection\Unique;
+use Membrane\Validator\FieldSet\RequiredFields;
+use Membrane\Validator\Numeric\Maximum;
+use Membrane\Validator\Numeric\Minimum;
+use Membrane\Validator\Numeric\MultipleOf;
+use Membrane\Validator\String\DateString;
+use Membrane\Validator\String\Length;
+use Membrane\Validator\String\Regex;
+use Membrane\Validator\Type\IsArray;
+use Membrane\Validator\Type\IsBool;
+use Membrane\Validator\Type\IsFloat;
+use Membrane\Validator\Type\IsInt;
+use Membrane\Validator\Type\IsList;
+use Membrane\Validator\Type\IsNull;
+use Membrane\Validator\Type\IsNumber;
+use Membrane\Validator\Type\IsString;
+use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers   \Membrane\OpenAPI\Builder\ResponseBuilder
+ * @covers   \Membrane\OpenAPI\Builder\APIBuilder
+ * @uses     \Membrane\OpenAPI\Builder\Arrays
+ * @uses     \Membrane\OpenAPI\Builder\TrueFalse
+ * @uses     \Membrane\OpenAPI\Builder\Numeric
+ * @uses     \Membrane\OpenAPI\Builder\Objects
+ * @uses     \Membrane\OpenAPI\Builder\Strings
+ * @uses     \Membrane\OpenAPI\PathMatcher
+ * @uses     \Membrane\OpenAPI\Processor\AllOf
+ * @uses     \Membrane\OpenAPI\Processor\AnyOf
+ * @uses     \Membrane\OpenAPI\Processor\OneOf
+ * @uses     \Membrane\OpenAPI\Specification\APISchema
+ * @uses     \Membrane\OpenAPI\Specification\APISpec
+ * @uses     \Membrane\OpenAPI\Specification\Arrays
+ * @uses     \Membrane\OpenAPI\Specification\TrueFalse
+ * @uses     \Membrane\OpenAPI\Specification\Numeric
+ * @uses     \Membrane\OpenAPI\Specification\Objects
+ * @uses     \Membrane\OpenAPI\Specification\Strings
+ * @uses     \Membrane\OpenAPI\Specification\Response
+ * @uses     \Membrane\Processor\BeforeSet
+ * @uses     \Membrane\Processor\Collection
+ * @uses     \Membrane\Processor\Field
+ * @uses     \Membrane\Processor\FieldSet
+ * @uses     \Membrane\Result\FieldName
+ * @uses     \Membrane\Result\Message
+ * @uses     \Membrane\Result\MessageSet
+ * @uses     \Membrane\Result\Result
+ * @uses     \Membrane\Validator\Collection\Contained
+ * @uses     \Membrane\Validator\Collection\Count
+ * @uses     \Membrane\Validator\Collection\Unique
+ * @uses     \Membrane\Validator\FieldSet\RequiredFields
+ * @uses     \Membrane\Validator\Numeric\Maximum
+ * @uses     \Membrane\Validator\Numeric\Minimum
+ * @uses     \Membrane\Validator\Numeric\MultipleOf
+ * @uses     \Membrane\Validator\String\DateString
+ * @uses     \Membrane\Validator\String\Length
+ * @uses     \Membrane\Validator\String\Regex
+ * @uses     \Membrane\Validator\Type\IsArray
+ * @uses     \Membrane\Validator\Type\IsInt
+ * @uses     \Membrane\Validator\Type\IsList
+ * @uses     \Membrane\Validator\Type\IsString
+ */
+class ResponseBuilderTest extends TestCase
+{
+    public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
+
+    /** @test */
+    public function throwsExceptionIfNotIsFound(): void
+    {
+        $sut = new ResponseBuilder();
+        $response = new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '360');
+
+        self::expectExceptionObject(new Exception("Keyword 'not' is currently unsupported"));
+
+        $sut->build($response);
+    }
+
+    public function dataSetsforSupports(): array
+    {
+        return [
+            [
+                new class() implements Specification {
+                },
+                false,
+            ],
+            [
+                self::createStub(Request::class),
+                false,
+            ],
+            [
+                self::createStub(Response::class),
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsforSupports
+     */
+    public function supportsTest(Specification $spec, bool $expected): void
+    {
+        $sut = new ResponseBuilder();
+
+        $supported = $sut->supports($spec);
+
+        self::assertSame($expected, $supported);
+    }
+
+    public function dataSetsforBuilds(): array
+    {
+        return [
+            'no properties' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/path',
+                    Method::GET,
+                    '200'
+                ),
+                new Field('', new Passes()),
+            ],
+            'int' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '200'
+                ),
+                new Field('', new IsInt()),
+            ],
+            'nullable int' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '201'
+                ),
+                new AnyOf('', new Field('', new IsNull()), new Field('', new IsInt())),
+            ],
+            'int, inclusive min' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '202'),
+                new Field('', new IsInt(), new Minimum(0)),
+            ],
+            'int, exclusive min' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '203',
+                ),
+                new Field('', new IsInt(), new Minimum(0, true)),
+            ],
+            'int, inclusive max' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '204',
+                ),
+                new Field('', new IsInt(), new Maximum(100)),
+            ],
+            'int, exclusive max' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '205',
+                ),
+                new Field('', new IsInt(), new Maximum(100, true)),
+            ],
+            'int, multipleOf' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '206',
+                ),
+                new Field('', new IsInt(), new MultipleOf(3)),
+            ],
+            'int, enum' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '207',
+                ),
+                new Field('', new IsInt(), new Contained([1, 2, 3])),
+            ],
+            'nullable int, enum, exclusive min, inclusive max, multipleOf' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '209',
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new Field(
+                        '',
+                        new IsInt(),
+                        new Contained([1, 2, 3]),
+                        new Maximum(100),
+                        new Minimum(0, true),
+                        new MultipleOf(3)
+
+                    )
+                ),
+            ],
+            'number' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '210',
+                ),
+                new Field('', new IsNumber()),
+            ],
+            'nullable number' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '211',
+                ),
+                new AnyOf('', new Field('', new IsNull()), new Field('', new IsNumber())),
+            ],
+            'number, enum' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '212',
+                ),
+                new Field('', new IsNumber(), new Contained([1, 2.3, 4])),
+            ],
+            'number, float format' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '213'
+                ),
+                new Field('', new IsFloat()),
+            ],
+            'nullable number, float format' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '214'),
+                new AnyOf('', new Field('', new IsNull()), new Field('', new IsFloat())),
+            ],
+            'number, double format' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '215'
+                ),
+                new Field('', new IsFloat()),
+            ],
+            'nullable number, enum, inclusive min, exclusive max, multipleOf' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '219'
+                ),
+                new AnyOf(
+                    '', new Field('', new IsNull()), new Field(
+                        '',
+                        new IsNumber(),
+                        new Contained([1, 2.3, 4]),
+                        new Maximum(99.99, true),
+                        new Minimum(6.66),
+                        new MultipleOf(3.33)
+
+                    )
+                ),
+            ],
+            'string' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '220'),
+                new Field('', new IsString()),
+            ],
+            'nullable string' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '221'),
+                new AnyOf('', new Field('', new IsNull()), new Field('', new IsString())),
+            ],
+            'string, enum' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '222'
+                ),
+                new Field('', new IsString(), new Contained(['a', 'b', 'c'])),
+            ],
+            'string, date format' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '223'
+                ),
+                new Field('', new IsString(), new DateString('Y-m-d')),
+            ],
+            'string, date-time format' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '224'
+                ),
+                new Field('', new IsString(), new DateString(DATE_ATOM)),
+            ],
+            'string, minLength' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '225'),
+                new Field('', new IsString(), new Length(5)),
+            ],
+            'string, maxLength' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '226'),
+                new Field('', new IsString(), new Length(0, 10)),
+            ],
+            'string, pattern' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '227'),
+                new Field('', new IsString(), new Regex('#[A-Za-z]+#')),
+            ],
+            'nullable string, enum, minLength, maxLength, pattern' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '229'),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new Field(
+                        '',
+                        new IsString(),
+                        new Contained(['a', 'b', 'c']),
+                        new Length(5, 10),
+                        new Regex('#[A-Za-z]+#')
+                    )
+                ),
+            ],
+            'bool' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '230'
+                ),
+                new Field('', new IsBool()),
+            ],
+            'nullable bool' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '231'
+                ),
+                new AnyOf('', new Field('', new IsNull()), new Field('', new IsBool())),
+            ],
+            'bool, enum' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '232'),
+                new Field('', new IsBool(), new Contained([true])),
+            ],
+            'nullable bool, enum' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '239'
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new Field('', new IsBool(), new Contained([true, null]))
+                ),
+            ],
+            'array of ints' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '240'
+                ),
+                new Collection('', new BeforeSet(new IsList()), new Field('', new IsInt())),
+            ],
+            'array of strings, enum' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '241'
+                ),
+                new Collection(
+                    '',
+                    new BeforeSet(new IsList(), new Contained([['a', 'b', 'c'], ['d', 'e', 'f']])),
+                    new Field('', new IsString())
+                ),
+            ],
+            'nullable array of strings' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '242'
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new Collection('', new BeforeSet(new IsList()), new Field('', new IsString()))
+                ),
+            ],
+            'array of booleans, minItems' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '243'
+                ),
+                new Collection('', new BeforeSet(new IsList(), new Count(5)), new Field('', new IsBool())),
+            ],
+            'array of floats, maxItems' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '244'
+                ),
+                new Collection('', new BeforeSet(new IsList(), new Count(0, 5)), new Field('', new IsFloat())),
+            ],
+            'array of numbers, uniqueItems' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '245'
+                ),
+                new Collection('', new BeforeSet(new IsList(), new Unique()), new Field('', new IsNumber())),
+            ],
+            'nullable array of nullable numbers, enum, minItems, maxItems, uniqueItems' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '269'
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new Collection(
+                        '',
+                        new BeforeSet(
+                            new IsList(),
+                            new Contained([[1, 2.0, null], [4.0, null, 6]]),
+                            new Count(2, 5),
+                            new Unique()
+
+                        ),
+                        new AnyOf('', new Field('', new IsNull()), new Field('', new IsNumber()))
+                    )
+                ),
+            ],
+            'object with (string) name' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '270'),
+                new FieldSet(
+                    '',
+                    new BeforeSet(new IsArray()),
+                    new Field('name', new IsString())
+                ),
+            ],
+            'object with (int) id, enum' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '271'),
+                new FieldSet(
+                    '',
+                    new BeforeSet(new IsArray(), new Contained([['id' => 5], ['id' => 10]])),
+                    new Field('id', new IsInt())
+                ),
+            ],
+            'nullable object with (float) price' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '272'
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new FieldSet('', new BeforeSet(new IsArray()), new Field('price', new IsFloat()))
+
+                ),
+            ],
+            'object with (string) name, (int) id, (bool) status' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '273'
+                ),
+                new FieldSet(
+                    '',
+                    new BeforeSet(new IsArray()),
+                    new Field('name', new IsString()),
+                    new Field('id', new IsInt()),
+                    new Field('status', new IsBool())
+                ),
+            ],
+            'object with (string) name, (int) id, (bool) status, required' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '274'),
+                new FieldSet(
+                    '',
+                    new BeforeSet(new IsArray(), new RequiredFields('name', 'id')),
+                    new Field('name', new IsString()),
+                    new Field('id', new IsInt()),
+                    new Field('status', new IsBool())
+                ),
+            ],
+            'nullable object with (string) name, (int) id, (bool) status, enum, required' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '299'),
+                new FieldSet(
+                    '',
+                    new BeforeSet(
+                        new IsArray(),
+                        new Contained(
+                            [
+                                ['name' => 'Ben', 'id' => 5, 'status' => true],
+                                ['name' => 'Blink', 'id' => 10, 'status' => true],
+                            ]
+                        ),
+                        new RequiredFields('name', 'id')
+                    ),
+                    new Field('name', new IsString()),
+                    new Field('id', new IsInt()),
+                    new Field('status', new IsBool())
+                ),
+            ],
+            'allOf, one object (should act like normal object)' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '300'),
+                new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray())),
+            ],
+            'allOf, two objects, one identical parameter' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '301'
+                ),
+                new AllOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
+                ),
+            ],
+            'allOf, two objects, one unique parameters' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '302'
+                ),
+                new AllOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray()))
+                ),
+            ],
+            'allOf, two objects, conflicting parameter' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '303'
+                ),
+                new AllOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('', new Field('id', new IsString()), new BeforeSet(new IsArray()))
+                ),
+            ],
+            'allOf, two objects, unique parameters, one requiredField' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '304'),
+                new AllOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet(
+                        '',
+                        new BeforeSet(new IsArray(), new RequiredFields('name')),
+                        new Field('name', new IsString())
+                    )
+                ),
+            ],
+            'allOf, two objects, unique parameters, two requiredField' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '305'),
+                new AllOf(
+                    '',
+                    new FieldSet(
+                        '',
+                        new Field('id', new IsInt()),
+                        new BeforeSet(new IsArray(), new RequiredFields('id'))
+                    ),
+                    new FieldSet(
+                        '',
+                        new Field('name', new IsString()),
+                        new BeforeSet(new IsArray(), new RequiredFields('name'))
+                    )
+                ),
+            ],
+            'allOf, two objects, unique parameters, two requiredFields requiring the other schemas property' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '306'),
+                new AllOf(
+                    '',
+                    new FieldSet(
+                        '',
+                        new Field('id', new IsInt()),
+                        new BeforeSet(new IsArray(), new RequiredFields('name'))
+                    ),
+                    new FieldSet(
+                        '',
+                        new Field('name', new IsString()),
+                        new BeforeSet(new IsArray(), new RequiredFields('id'))
+                    )
+                ),
+            ],
+            'anyOf, one object (should act like normal object)' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '320'
+                ),
+                new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray())),
+            ],
+            'anyOf, two objects, one identical parameter' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '321'),
+                new AnyOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
+                ),
+            ],
+            'anyOf, two objects, one unique parameters' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '322'
+                ),
+                new AnyOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray()))
+                ),
+            ],
+            'anyOf, two objects, conflicting parameter' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '323'
+                ),
+                new AnyOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('', new Field('id', new IsString()), new BeforeSet(new IsArray()))
+                ),
+            ],
+            'anyOf, two objects, unique parameters, one requiredField' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '324'),
+                new AnyOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet(
+                        '',
+                        new Field('name', new IsString()),
+                        new BeforeSet(new IsArray(), new RequiredFields('name'))
+                    )
+                ),
+            ],
+            'anyOf, two objects, unique parameters, two requiredField' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '325'
+                ),
+                new AnyOf(
+                    '',
+                    new FieldSet(
+                        '',
+                        new Field('id', new IsInt()),
+                        new BeforeSet(new IsArray(), new RequiredFields('id'))
+                    ),
+                    new FieldSet(
+                        '',
+                        new Field('name', new IsString()),
+                        new BeforeSet(new IsArray(), new RequiredFields('name'))
+                    )
+                ),
+            ],
+            'anyOf, two objects, unique parameters, two requiredFields requiring the other schemas property' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '326'
+                ),
+                new AnyOf(
+                    '',
+                    new FieldSet(
+                        '',
+                        new Field('id', new IsInt()),
+                        new BeforeSet(new IsArray(), new RequiredFields('name'))
+                    ),
+                    new FieldSet(
+                        '',
+                        new Field('name', new IsString()),
+                        new BeforeSet(new IsArray(), new RequiredFields('id'))
+                    )
+                ),
+            ],
+            'oneOf, one object (should act like normal object)' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '340'),
+                new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray())),
+            ],
+            'oneOf, two objects, one identical parameter' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '341'),
+                new OneOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
+                ),
+            ],
+            'oneOf, two objects, one unique parameters' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '342'),
+                new OneOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray()))
+                ),
+            ],
+            'oneOf, two objects, conflicting parameter' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '343'
+                ),
+                new OneOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('', new Field('id', new IsString()), new BeforeSet(new IsArray()))
+                ),
+            ],
+            'oneOf, two objects, unique parameters, one requiredField' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '344'),
+                new OneOf(
+                    '',
+                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet(
+                        '',
+                        new Field('name', new IsString()),
+                        new BeforeSet(new IsArray(), new RequiredFields('name'))
+                    )
+                ),
+            ],
+            'oneOf, two objects, unique parameters, two requiredField' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '345'
+                ),
+                new OneOf(
+                    '',
+                    new FieldSet(
+                        '',
+                        new Field('id', new IsInt()),
+                        new BeforeSet(new IsArray(), new RequiredFields('id'))
+                    ),
+                    new FieldSet(
+                        '',
+                        new Field('name', new IsString()),
+                        new BeforeSet(new IsArray(), new RequiredFields('name'))
+                    )
+                ),
+            ],
+            'oneOf, two objects, unique parameters, two requiredFields requiring the other schemas property' => [
+                new Response(
+                    self::DIR . 'noReferences.json',
+                    '/responsepath',
+                    Method::GET,
+                    '346'
+                ),
+                new OneOf(
+                    '',
+                    new FieldSet(
+                        '',
+                        new Field('id', new IsInt()),
+                        new BeforeSet(new IsArray(), new RequiredFields('name'))
+                    ),
+                    new FieldSet(
+                        '',
+                        new Field('name', new IsString()),
+                        new BeforeSet(new IsArray(), new RequiredFields('id'))
+                    )
+                ),
+            ],
+            'schema with no specified type' => [
+                new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '404'),
+                new Field('', new Passes()),
+            ],
+            'petstore.yaml: /pets path -> get operation -> 200 response' => [
+                new Response(
+                    self::DIR . 'docs/petstore.yaml',
+                    '/pets',
+                    Method::GET,
+                    '200'
+                ),
+                new Collection(
+                    '',
+                    new BeforeSet(new IsList(), new Count(0, 100)),
+                    new FieldSet(
+                        '',
+                        new BeforeSet(new IsArray(), new RequiredFields('id', 'name')),
+                        new Field('id', new IsInt()),
+                        new Field('name', new IsString()),
+                        new Field('tag', new IsString())
+                    ),
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsforBuilds
+     */
+    public function buildsTest(Specification $spec, Processor $expected): void
+    {
+        $sut = new ResponseBuilder();
+
+        $processor = $sut->build($spec);
+
+        self::assertEquals($expected, $processor);
+    }
+
+    public function dataSetsForDocExamples(): array
+    {
+        $petStore1 = new Response(
+            self::DIR . 'docs/petstore.yaml',
+            '/pets',
+            Method::GET,
+            '200'
+        );
+
+        return [
+            'dataSet A' => [
+                $petStore1,
+                [
+                    ['name' => 'Blink', 'id' => 1],
+                    ['name' => 'Harley', 'id' => 2],
+                ],
+                Result::valid(
+                    [
+                        ['name' => 'Blink', 'id' => 1],
+                        ['name' => 'Harley', 'id' => 2],
+                    ]
+                ),
+            ],
+            'dataSet B' => [
+                $petStore1,
+                [
+                    ['name' => 'Blink'],
+                    ['id' => 2],
+                ],
+                Result::invalid(
+                    [
+                        ['name' => 'Blink'],
+                        ['id' => 2],
+                    ],
+                    new MessageSet(new FieldName('', '', '', '0', ''), new Message('%s is a required field', ['id'])),
+                    new MessageSet(new FieldName('', '', '', '1', ''), new Message('%s is a required field', ['name'])),
+                ),
+            ],
+            'dataSet C' => [
+                $petStore1,
+                [
+                    'Blink',
+                    5,
+                ],
+                Result::invalid(
+                    [
+                        'Blink',
+                        5,
+                    ],
+                    new MessageSet(
+                        new FieldName('', '', '', '0', ''),
+                        new Message('IsArray validator expects array value, %s passed instead', ['string'])
+                    ),
+                    new MessageSet(
+                        new FieldName('', '', '', '1', ''),
+                        new Message('IsArray validator expects array value, %s passed instead', ['integer'])
+                    ),
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsForDocExamples
+     */
+    public function docsTest(Specification $spec, array $data, Result $expected): void
+    {
+        $sut = new ResponseBuilder();
+
+        $processor = $sut->build($spec);
+
+        self::assertEquals($expected, $processor->process(new FieldName(''), $data));
+    }
+}

--- a/tests/OpenAPI/Builder/StringsTest.php
+++ b/tests/OpenAPI/Builder/StringsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Builder;
+
+use cebe\openapi\spec\Schema;
+use Membrane\OpenAPI\Builder\Strings;
+use Membrane\OpenAPI\Processor\AnyOf;
+use Membrane\OpenAPI\Specification;
+use Membrane\Processor;
+use Membrane\Processor\Field;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\String\DateString;
+use Membrane\Validator\String\Length;
+use Membrane\Validator\String\Regex;
+use Membrane\Validator\Type\IsNull;
+use Membrane\Validator\Type\IsString;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Builder\Strings
+ * @covers \Membrane\OpenAPI\Builder\APIBuilder
+ * @uses   \Membrane\OpenAPI\Processor\AnyOf
+ * @uses   \Membrane\OpenAPI\Specification\Strings
+ * @uses   \Membrane\Processor\Field
+ * @uses   \Membrane\Validator\Collection\Contained
+ * @uses   \Membrane\Validator\String\DateString
+ * @uses   \Membrane\Validator\String\Length
+ * @uses   \Membrane\Validator\String\Regex
+ */
+class StringsTest extends TestCase
+{
+    public function specificationsToSupport(): array
+    {
+        return [
+            [
+                new class() implements \Membrane\Builder\Specification {
+                },
+                false,
+            ],
+            [self::createStub(Specification\Strings::class), true],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToSupport
+     */
+    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    {
+        $sut = new Strings();
+
+        self::assertSame($expected, $sut->supports($specification));
+    }
+
+    public function specificationsToBuild(): array
+    {
+        return [
+            'minimum input' => [
+                new Specification\Strings('', new Schema(['type' => 'string'])),
+                new Field('', new IsString()),
+            ],
+            'date input' => [
+                new Specification\Strings('', new Schema(['type' => 'string', 'format' => 'date',])),
+                new Field('', new IsString(), new DateString('Y-m-d')),
+            ],
+            'date-time input' => [
+                new Specification\Strings('', new Schema(['type' => 'string', 'format' => 'date-time',])),
+                new Field('', new IsString(), new DateString('Y-m-d\TH:i:sP')),
+            ],
+            'detailed input' => [
+                new Specification\Strings(
+                    '',
+                    new Schema(
+                        [
+                            'type' => 'string',
+                            'maxLength' => 100,
+                            'minLength' => 0,
+                            'pattern' => '#.+#',
+                            'format' => 'date',
+                            'enum' => ['1970/01/01', null],
+                            'nullable' => true,
+                        ]
+                    )
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new Field(
+                        '',
+                        new IsString(),
+                        new Contained(['1970/01/01', null]),
+                        new DateString('Y-m-d'),
+                        new Length(0, 100),
+                        new Regex('#.+#')
+                    )
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToBuild
+     */
+    public function buildTest(Specification\Strings $specification, Processor $expected): void
+    {
+        $sut = new Strings();
+
+        $actual = $sut->build($specification);
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/OpenAPI/Builder/TrueFalseTest.php
+++ b/tests/OpenAPI/Builder/TrueFalseTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Builder;
+
+
+use cebe\openapi\spec\Schema;
+use Membrane\Filter\Type\ToBool;
+use Membrane\OpenAPI\Builder\TrueFalse;
+use Membrane\OpenAPI\Processor\AnyOf;
+use Membrane\OpenAPI\Specification;
+use Membrane\Processor;
+use Membrane\Processor\Field;
+use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\Type\IsBool;
+use Membrane\Validator\Type\IsNull;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Builder\TrueFalse
+ * @covers \Membrane\OpenAPI\Builder\APIBuilder
+ * @uses   \Membrane\OpenAPI\Processor\AnyOf
+ * @uses   \Membrane\OpenAPI\Specification\TrueFalse
+ * @uses   \Membrane\Processor\Field
+ * @uses   \Membrane\Validator\Collection\Contained
+ */
+class TrueFalseTest extends TestCase
+{
+
+    public function specificationsToSupport(): array
+    {
+        return [
+            [
+                new class() implements \Membrane\Builder\Specification {
+                },
+                false,
+            ],
+            [self::createStub(Specification\TrueFalse::class), true],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToSupport
+     */
+    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    {
+        $sut = new TrueFalse();
+
+        self::assertSame($expected, $sut->supports($specification));
+    }
+
+    public function specificationsToBuild(): array
+    {
+        return [
+            'non-strict input' => [
+                new Specification\TrueFalse('', new Schema(['type' => 'boolean']), false),
+                new Field('', new ToBool(), new IsBool()),
+            ],
+            'strict input' => [
+                new Specification\TrueFalse('', new Schema(['type' => 'boolean']), true),
+                new Field('', new IsBool()),
+            ],
+            'detailed input' => [
+                new Specification\TrueFalse(
+                    '',
+                    new Schema(
+                        [
+                            'type' => 'boolean',
+                            'enum' => [true, null],
+                            'format' => 'rather pointless boolean',
+                            'nullable' => true,
+                        ]
+                    ),
+                    false
+                ),
+                new AnyOf(
+                    '',
+                    new Field('', new IsNull()),
+                    new Field('', new ToBool(), new IsBool(), new Contained([true, null]))
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider specificationsToBuild
+     */
+    public function buildTest(Specification\TrueFalse $specification, Processor $expected): void
+    {
+        $sut = new TrueFalse();
+
+        $actual = $sut->build($specification);
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/OpenAPI/Processor/RequestTest.php
+++ b/tests/OpenAPI/Processor/RequestTest.php
@@ -61,13 +61,29 @@ class RequestTest extends TestCase
 
     public function dataSetsToProcess(): array
     {
-        $validProcessor = self::createMock(Processor::class);
-        $validProcessor->method('process')
-            ->willReturn(Result::valid(''));
+        $validProcessor = new class() implements Processor {
+            public function processes(): string
+            {
+                return '';
+            }
 
-        $invalidProcessor = self::createMock(Processor::class);
-        $invalidProcessor->method('process')
-            ->willReturn(Result::invalid('', new MessageSet(null, new Message('invalid result', []))));
+            public function process(FieldName $parentFieldName, mixed $value): Result
+            {
+                return Result::valid($value);
+            }
+        };
+
+        $invalidProcessor = new class() implements Processor {
+            public function processes(): string
+            {
+                return '';
+            }
+
+            public function process(FieldName $parentFieldName, mixed $value): Result
+            {
+                return Result::invalid($value, new MessageSet(null, new Message('invalid result', [])));
+            }
+        };
 
         $uri = self::createMock(UriInterface::class);
         $uri->method('getPath')
@@ -196,7 +212,6 @@ class RequestTest extends TestCase
                     'body' => 'request body',
                 ]),
             ],
-
         ];
     }
 

--- a/tests/OpenAPI/Specification/APISpecTest.php
+++ b/tests/OpenAPI/Specification/APISpecTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Specification;
+
+use cebe\openapi\spec\Operation;
+use cebe\openapi\spec\PathItem;
+use cebe\openapi\spec\Response;
+use Exception;
+use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\Specification\APISpec;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Specification\APISpec
+ * @uses   \Membrane\OpenAPI\PathMatcher
+ */
+class APISpecTest extends TestCase
+{
+    public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
+
+    /** @test */
+    public function throwExceptionForRelativeFilePaths(): void
+    {
+        self::expectExceptionObject(
+            new Exception('absolute file path required to resolve references in OpenAPI specifications')
+        );
+
+        new class('./tests/fixtures/OpenAPI/docs/petstore.yaml', '/path') extends APISpec {
+        };
+    }
+
+    /** @test */
+    public function throwExceptionForNonExistentFilePaths(): void
+    {
+        self::expectExceptionObject(new Exception('File could not be found'));
+
+        new class('nonExistentFilePath', '/testpath') extends APISpec {
+        };
+    }
+
+    /** @test */
+    public function throwExceptionForInvalidFileTypes(): void
+    {
+        self::expectExceptionObject(new Exception('Invalid file type'));
+
+        new class(self::DIR . 'invalidFileType.txt', '/testpath') extends APISpec {
+        };
+    }
+
+    public function dataSetsForInvalidFormats(): array
+    {
+        return [
+            'json file that is not OpenAPI format' => [
+                'notOpenAPI.json',
+                'json file is not following OpenAPI specifications',
+            ],
+            'yml/yaml file that is not OpenAPI format' => [
+                'notOpenAPI.yml',
+                'yml file is not following OpenAPI specifications',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsForInvalidFormats
+     */
+    public function throwsExceptionForInvalidFormats(string $filePath, string $exceptionMessage): void
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage($exceptionMessage);
+
+        new class(self::DIR . $filePath, '/path') extends APISpec {
+        };
+    }
+
+    /** @test */
+    public function throwsExceptionForInvalidOpenAPI(): void
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('OpenAPI could not be validated');
+
+        new class(self::DIR . 'invalidOpenAPI.json', '/path') extends APISpec {
+        };
+    }
+
+    /** @test */
+    public function throwsExceptionIfNoPathMatches(): void
+    {
+        self::expectExceptionObject(new Exception('url does not match any paths defined by API'));
+
+        new class(self::DIR . 'noReferences.json', 'incorrect/path') extends APISpec {
+        };
+    }
+
+    public function dataSetsThatPass(): array
+    {
+        return [
+            'GET does not have any content' => [
+                'noReferences.json',
+                'http://test.com/path',
+                Method::GET,
+            ],
+            'POST has empty content' => [
+                'noReferences.json',
+                'http://test.com/path',
+                Method::POST,
+            ],
+            'DELETE has application/json content' => [
+                'noReferences.json',
+                'http://test.com/path',
+                Method::DELETE,
+            ],
+            'path that contains reference that must be resolved .json' => [
+                'references.json',
+                'http://test.com/path',
+                Method::GET,
+            ],
+            'path that contains reference that must be resolved .yaml' => [
+                'references.json',
+                'http://test.com/path',
+                Method::GET,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsThatPass
+     */
+    public function successfulConstructionForValidInputs(string $filePath, string $url, Method $method): void
+    {
+        $class = new class(self::DIR . $filePath, $url, $method) extends APISpec {
+            public Operation $requestOperation;
+
+            public function __construct(string $filePath, string $url, Method $method)
+            {
+                parent::__construct($filePath, $url);
+                $this->requestOperation = $this->getOperation($method);
+            }
+        };
+
+        self::assertInstanceOf(PathItem::class, $class->pathItem);
+        self::assertInstanceOf(Operation::class, $class->requestOperation);
+        self::assertInstanceOf(Response::class, $class->pathItem->get->responses->getResponse('200'));
+    }
+}

--- a/tests/OpenAPI/Specification/RequestTest.php
+++ b/tests/OpenAPI/Specification/RequestTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Specification;
+
+use cebe\openapi\spec\Parameter;
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\Specification\Request;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Specification\Request
+ * @covers \Membrane\OpenAPI\Specification\APISpec
+ * @uses   \Membrane\OpenAPI\PathMatcher
+ */
+class RequestTest extends TestCase
+{
+    public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
+
+    public function dataSetsWithIncorrectMethods(): array
+    {
+        return [
+            'no methods in path' => [
+                'simple.json',
+                '/path',
+                Method::GET,
+            ],
+            'delete not in parampath' => [
+                'noReferences.json',
+                'http://test.com/parampath/01',
+                Method::DELETE,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsWithIncorrectMethods
+     */
+    public function getOperationThrowsExceptionForIncorrectMethod(string $filePath, string $url, Method $method): void
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('Method does not match any methods defined by path');
+
+        new Request(self::DIR . $filePath, $url, $method);
+    }
+
+    /**
+     * @test
+     */
+    public function throwsExceptionIfRequestBodyFoundButContentNotJson(): void
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('APISpec requires application/json content');
+
+        new Request(self::DIR . 'noReferences.json', 'http://test.com/path', Method::PUT);
+    }
+
+
+    public function dataSetsWithValidSchemas(): array
+    {
+        return [
+            [
+                'http://test.com/path',
+                Method::DELETE,
+                'noReferences.json',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsWithValidSchemas
+     */
+    public function schemaIsSchemaObjectIfRequestBodyWithContentJson(string $url, Method $method, $filePath): void
+    {
+        $class = new Request(self::DIR . $filePath, $url, $method);
+
+        self::assertInstanceOf(Schema::class, $class->requestBodySchema);
+    }
+
+
+    public function dataSetsWithNullSchemas(): array
+    {
+        return [
+            'requestBody not found' => [
+                'http://test.com/path',
+                Method::GET,
+                'noReferences.json',
+            ],
+            'requestBody found with empty content array' => [
+                'http://test.com/path',
+                Method::POST,
+                'noReferences.json',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsWithNullSchemas
+     */
+    public function schemaIsNullIfNoRequestBodyNorContent(string $url, Method $method, $filePath): void
+    {
+        $class = new Request(self::DIR . $filePath, $url, $method);
+
+        self::assertNull($class->requestBodySchema);
+    }
+
+    /**
+     * @test
+     */
+    public function mergesPathAndOperationParameters(): void
+    {
+        $class = new Request(self::DIR . 'noReferences.json', 'http://test.com/parampath/01', Method::GET);
+
+        self::assertContainsOnlyInstancesOf(Parameter::class, $class->pathParameters);
+
+        $names = array_map(fn(Parameter $p) => $p->name, $class->pathParameters);
+        self::assertContains('id', $names);
+        self::assertContains('name', $names);
+    }
+
+    public function dataSetsWithReferences(): array
+    {
+        return [
+            'json file with references that must be resolved' => [
+                'http://test.com/path',
+                Method::GET,
+                'references.json',
+            ],
+            'yaml file with references that must be resolved' => [
+                'http://test.com/path',
+                Method::GET,
+                'references.yaml',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsWithReferences
+     */
+    public function ParameterSchemaReferencesResolved(string $url, Method $method, string $filePath): void
+    {
+        $class = new Request(self::DIR . $filePath, $url, $method);
+
+        self::assertContainsOnlyInstancesOf(Parameter::class, $class->pathParameters);
+
+        self::assertInstanceOf(Schema::class, $class->pathParameters[0]->schema);
+    }
+}

--- a/tests/OpenAPI/Specification/RequestTest.php
+++ b/tests/OpenAPI/Specification/RequestTest.php
@@ -7,6 +7,7 @@ namespace OpenAPI\Specification;
 use cebe\openapi\spec\Parameter;
 use cebe\openapi\spec\Schema;
 use Exception;
+use GuzzleHttp\Psr7\ServerRequest;
 use Membrane\OpenAPI\Method;
 use Membrane\OpenAPI\Specification\Request;
 use PHPUnit\Framework\TestCase;
@@ -151,5 +152,26 @@ class RequestTest extends TestCase
         self::assertContainsOnlyInstancesOf(Parameter::class, $class->pathParameters);
 
         self::assertInstanceOf(Schema::class, $class->pathParameters[0]->schema);
+    }
+
+    /** @test */
+    public function fromPsr7ThrowsExceptionIfUnsupportedMethod(): void
+    {
+        self::expectExceptionObject(new Exception('not supported'));
+
+        $serverRequest = new ServerRequest('UPDATE', 'http://test.com/path');
+
+        Request::fromPsr7(self::DIR . 'noReferences.json', $serverRequest);
+    }
+
+    /** @test */
+    public function fromPsr7SuccessfulConstructionTest(): void
+    {
+        $expected = new Request(self::DIR . 'noReferences.json', 'http://test.com/path', Method::GET);
+        $serverRequest = new ServerRequest('GET', 'http://test.com/path');
+
+        $actual = Request::fromPsr7(self::DIR . 'noReferences.json', $serverRequest);
+
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/OpenAPI/Specification/ResponseTest.php
+++ b/tests/OpenAPI/Specification/ResponseTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\Specification\Response;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Specification\Response
+ * @covers \Membrane\OpenAPI\Specification\APISpec
+ * @uses   \Membrane\OpenAPI\PathMatcher
+ */
+class ResponseTest extends TestCase
+{
+    public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
+
+    /**
+     * @test
+     */
+    public function throwsExceptionIfApplicableResponseNotFound(): void
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('No applicable response found');
+
+        new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::GET, '404');
+    }
+
+    /**
+     * @test
+     */
+    public function throwsExceptionIfResponseContentNotJson(): void
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('APISpec requires application/json content');
+
+        new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::PUT, '200');
+    }
+
+    /**
+     * @test
+     */
+    public function returnsDefaultResponseIfExactMatchNotFound(): void
+    {
+        $class = new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::DELETE, '404');
+
+        self::assertInstanceOf(Schema::class, $class->schema);
+    }
+
+    /**
+     * @test
+     */
+    public function schemaIsSchemaObjectIfContentJson(): void
+    {
+        $class = new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::DELETE, 'default');
+
+        self::assertInstanceOf(Schema::class, $class->schema);
+    }
+
+    public function dataSetsWithNullSchemas(): array
+    {
+        return [
+            'response with no content' => [
+                'http://test.com/path',
+                Method::GET,
+                '200',
+                'noReferences.json',
+            ],
+            'response with empty content' => [
+                'http://test.com/path',
+                Method::POST,
+                '200',
+                'noReferences.json',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsWithNullSchemas
+     */
+    public function schemaIsNullIfResponseHasNoContentOrEmpty(
+        string $url,
+        Method $method,
+        string $httpStatus,
+        string $filePath
+    ): void {
+        $class = new Response(self::DIR . $filePath, $url, $method, $httpStatus);
+
+        self::assertNull($class->schema);
+    }
+
+    public function dataSetsWithReferences(): array
+    {
+        return [
+            [
+                'http://test.com/path',
+                Method::GET,
+                '200',
+                'references.json',
+            ],
+            [
+                'http://test.com/path',
+                Method::GET,
+                '200',
+                'references.yaml',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsWithReferences
+     */
+    public function ResponseSchemaReferencesResolved(
+        string $url,
+        Method $method,
+        string $httpStatus,
+        string $filePath
+    ): void {
+        $class = new Response(self::DIR . $filePath, $url, $method, $httpStatus);
+
+        self::assertInstanceOf(Schema::class, $class->schema);
+    }
+}

--- a/tests/Validator/Type/IsNumberTest.php
+++ b/tests/Validator/Type/IsNumberTest.php
@@ -37,47 +37,47 @@ class IsNumberTest extends TestCase
                 '4',
                 Result::invalid(
                     '4',
-                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['string']))
+                    new MessageSet(null, new Message('Value must be a number, %s passed', ['string']))
                 ),
             ],
             'invalidates float string' => [
                 '5.6',
                 Result::invalid(
                     '5.6',
-                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['string']))
+                    new MessageSet(null, new Message('Value must be a number, %s passed', ['string']))
                 ),
             ],
             'invalidates non-numeric string' => [
                 'six',
                 Result::invalid(
                     'six',
-                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['string']))
+                    new MessageSet(null, new Message('Value must be a number, %s passed', ['string']))
                 ),
             ],
             'invalidates bool' => [
                 true,
                 Result::invalid(
                     true,
-                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['boolean']))
+                    new MessageSet(null, new Message('Value must be a number, %s passed', ['boolean']))
                 ),
             ],
             'invalidates null' => [
                 null,
                 Result::invalid(
                     null,
-                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['NULL']))
+                    new MessageSet(null, new Message('Value must be a number, %s passed', ['NULL']))
                 ),
             ],
             'invalidates array' => [
                 [1, 2, 3],
                 Result::invalid([1, 2, 3],
-                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['array']))),
+                    new MessageSet(null, new Message('Value must be a number, %s passed', ['array']))),
             ],
             'invalidates object' => [
                 $class,
                 Result::invalid(
                     $class,
-                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['object']))
+                    new MessageSet(null, new Message('Value must be a number, %s passed', ['object']))
                 ),
             ],
         ];

--- a/tests/fixtures/OpenAPI/docs/petstore-expanded.json
+++ b/tests/fixtures/OpenAPI/docs/petstore-expanded.json
@@ -1,0 +1,242 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/api"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store. Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewPet"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
+      "NewPet": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/OpenAPI/docs/petstore.yaml
+++ b/tests/fixtures/OpenAPI/docs/petstore.yaml
@@ -1,0 +1,113 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/fixtures/OpenAPI/invalidOpenAPI.json
+++ b/tests/fixtures/OpenAPI/invalidOpenAPI.json
@@ -1,0 +1,7 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API That's Missing Paths Field",
+    "version": "1.0.0"
+  }
+}

--- a/tests/fixtures/OpenAPI/noReferences.json
+++ b/tests/fixtures/OpenAPI/noReferences.json
@@ -1,0 +1,1646 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://www.test.com"
+    },
+    {
+      "url": "http://www.test.com/path",
+      "description": "this server contains the path name '/path' inside"
+    }
+  ],
+  "paths": {
+    "/emptypath": {
+      "description": "/emptypath has no operations"
+    },
+    "/path": {
+      "description": "/path has all operations, only DELETE has a default response",
+      "get": {
+        "description": "Get operation on /path, no requestBody",
+        "responses": {
+          "200": {
+            "description": "successful response, no content"
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "description": "Post operation on /path, requestBody->content is empty",
+          "required": true,
+          "content": {}
+        },
+        "responses": {
+          "200": {
+            "description": "successful response with content that is empty",
+            "content": {}
+          }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "description": "Put operation on /path, requestBody content is not application/json",
+          "required": true,
+          "content": {
+            "application/pdf": {
+              "schema": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful response with content that is not application/json",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "requestBody": {
+          "description": "Delete operation on /path, requestBody content is application/json",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful response with content that is application/json",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "default response with content that is application/json",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parampath/{id}": {
+      "description": "/parampath has a parameter in the path, applying to all operations",
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      ],
+      "get": {
+        "description": "Get operation in /parampath/{id}, should have two parameters, 'id' and 'name'",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful response"
+          }
+        }
+      }
+    },
+    "/requestpathexceptions": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/requestpathone/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "names",
+            "in": "query",
+            "schema": {
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/requestpathtwo": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "header",
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "name",
+            "in": "cookie",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/requestbodypath": {
+      "get": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/requestbodypath/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "species",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subspecies",
+            "in": "cookie",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "number",
+                "format": "float"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/responsepath": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "int",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "nullable int",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "int, inclusive min",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "203": {
+            "description": "int, exclusive min",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "exclusiveMinimum": true
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "int, inclusive max",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "maximum": 100
+                }
+              }
+            }
+          },
+          "205": {
+            "description": "int, exclusive max",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "maximum": 100,
+                  "exclusiveMaximum": true
+                }
+              }
+            }
+          },
+          "206": {
+            "description": "int, multipleOf",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "multipleOf": 3
+                }
+              }
+            }
+          },
+          "207": {
+            "description": "int, enum",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "enum": [
+                    1,
+                    2,
+                    3
+                  ]
+                }
+              }
+            }
+          },
+          "209": {
+            "description": "nullable int, exclusive min, inclusive max, multipleOf, enum",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "exclusiveMinimum": true,
+                  "maximum": 100,
+                  "multipleOf": 3,
+                  "enum": [
+                    1,
+                    2,
+                    3
+                  ],
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "210": {
+            "description": "number",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "211": {
+            "description": "nullable number",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "212": {
+            "description": "number, enum",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number",
+                  "enum": [
+                    1,
+                    2.3,
+                    4
+                  ]
+                }
+              }
+            }
+          },
+          "213": {
+            "description": "number, float format",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number",
+                  "format": "float"
+                }
+              }
+            }
+          },
+          "214": {
+            "description": "nullable number, float format",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number",
+                  "format": "float",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "215": {
+            "description": "number, double format",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number",
+                  "format": "double"
+                }
+              }
+            }
+          },
+          "219": {
+            "description": "nullable number, enum, inclusive min, exclusive max, multipleOf",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number",
+                  "minimum": 6.66,
+                  "maximum": 99.99,
+                  "exclusiveMaximum": true,
+                  "multipleOf": 3.33,
+                  "enum": [
+                    1,
+                    2.3,
+                    4
+                  ],
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "220": {
+            "description": "string",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "221": {
+            "description": "nullable string",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "222": {
+            "description": "string, enum",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "a",
+                    "b",
+                    "c"
+                  ]
+                }
+              }
+            }
+          },
+          "223": {
+            "description": "string, date format",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "date"
+                }
+              }
+            }
+          },
+          "224": {
+            "description": "string, date-time format",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "225": {
+            "description": "string, minLength",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "minLength": 5
+                }
+              }
+            }
+          },
+          "226": {
+            "description": "string, maxLength",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "maxLength": 10
+                }
+              }
+            }
+          },
+          "227": {
+            "description": "string, pattern",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "pattern": "#[A-Za-z]+#"
+                }
+              }
+            }
+          },
+          "229": {
+            "description": "nullable string, enum, minLength, maxLength, pattern",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "minLength": 5,
+                  "maxLength": 10,
+                  "pattern": "#[A-Za-z]+#",
+                  "enum": [
+                    "a",
+                    "b",
+                    "c"
+                  ],
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "230": {
+            "description": "bool",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "231": {
+            "description": "nullable bool",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "232": {
+            "description": "bool, enum",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "enum": [
+                    true
+                  ]
+                }
+              }
+            }
+          },
+          "239": {
+            "description": "nullable bool, enum",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "enum": [
+                    true,
+                    null
+                  ],
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "240": {
+            "description": "array of ints",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          "241": {
+            "description": "array of strings, enum",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "enum": [
+                    [
+                      "a",
+                      "b",
+                      "c"
+                    ],
+                    [
+                      "d",
+                      "e",
+                      "f"
+                    ]
+                  ]
+                }
+              }
+            }
+          },
+          "242": {
+            "description": "nullable array of strings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "243": {
+            "description": "array of booleans, minItems",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "boolean"
+                  },
+                  "minItems": 5
+                }
+              }
+            }
+          },
+          "244": {
+            "description": "array of floats, maxItems",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "double"
+                  },
+                  "maxItems": 5
+                }
+              }
+            }
+          },
+          "245": {
+            "description": "array of numbers, maxItems",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "uniqueItems": true
+                }
+              }
+            }
+          },
+          "269": {
+            "description": "nullable array of nullable numbers, minItems, maxItems, uniqueItems",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "nullable": true
+                  },
+                  "enum": [
+                    [
+                      1,
+                      2.0,
+                      null
+                    ],
+                    [
+                      4.0,
+                      null,
+                      6
+                    ]
+                  ],
+                  "uniqueItems": true,
+                  "minItems": 2,
+                  "maxItems": 5,
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "270": {
+            "description": "object with (string) name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "271": {
+            "description": "object with (integer) id, enum",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    }
+                  },
+                  "enum": [
+                    {
+                      "id": 5
+                    },
+                    {
+                      "id": 10
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "272": {
+            "description": "nullable object with (float) price",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "price": {
+                      "type": "number",
+                      "format": "float"
+                    }
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "273": {
+            "description": "object with (string) name, (int) id, (bool) status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "status": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "274": {
+            "description": "object with (string) name, (int) id, (bool) status, required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "status": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "id"
+                  ]
+                }
+              }
+            }
+          },
+          "299": {
+            "description": "nullable object with (string) name, (int) id, (bool) status, enum, required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "status": {
+                      "type": "boolean"
+                    }
+                  },
+                  "enum": [
+                    {
+                      "name": "Ben",
+                      "id": 5,
+                      "status": true
+                    },
+                    {
+                      "name": "Blink",
+                      "id": 10,
+                      "status": true
+                    }
+                  ],
+                  "required": [
+                    "name",
+                    "id"
+                  ]
+                }
+              }
+            }
+          },
+          "300": {
+            "description": "allOf, one object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "301": {
+            "description": "allOf,two objects, identical parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "allOf, two objects, unique parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "303": {
+            "description": "allOf, two objects, conflicting parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "allOf, two objects, unique parameters, one requiredField",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "305": {
+            "description": "allOf, two objects, unique parameters, two requiredFields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "306": {
+            "description": "allOf, two objects, unique parameters, two requiredFields requiring the other schemas property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "320": {
+            "description": "anyOf, one object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "321": {
+            "description": "anyOf,two objects, identical parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "322": {
+            "description": "anyOf, two objects, unique parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "323": {
+            "description": "anyOf, two objects, conflicting parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "324": {
+            "description": "anyOf, two objects, unique parameters, one requiredField",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "325": {
+            "description": "anyOf, two objects, unique parameters, two requiredFields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "326": {
+            "description": "anyOf, two objects, unique parameters, two requiredFields requiring the other schemas property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "340": {
+            "description": "oneOf, one object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "341": {
+            "description": "oneOf,two objects, identical parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "342": {
+            "description": "oneOf, two objects, unique parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "343": {
+            "description": "oneOf, two objects, conflicting parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "344": {
+            "description": "oneOf, two objects, unique parameters, one requiredField",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "345": {
+            "description": "oneOf, two objects, unique parameters, two requiredFields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "346": {
+            "description": "oneOf, two objects, unique parameters, two requiredFields requiring the other schemas property",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "360": {
+            "description": "'not' a string",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "not": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "schema with no specified type",
+            "content": {
+              "application/json": {
+                "schema": {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/OpenAPI/references.json
+++ b/tests/fixtures/OpenAPI/references.json
@@ -1,0 +1,52 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://test.com"
+    }
+  ],
+  "paths": {
+    "/path": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "200": {
+        "description": "Successful Response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "id": {
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/tests/fixtures/OpenAPI/references.yaml
+++ b/tests/fixtures/OpenAPI/references.yaml
@@ -1,0 +1,30 @@
+---
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+servers:
+  - url: http://test.com
+paths:
+  "/path":
+    get:
+      parameters:
+        - name: id
+          in: header
+          required: true
+          schema:
+            "$ref": "#/components/schemas/id"
+      responses:
+        '200':
+          "$ref": "#/components/responses/200"
+components:
+  responses:
+    '200':
+      description: Successful Response
+      content:
+        application/json:
+          schema:
+            type: integer
+  schemas:
+    id:
+      type: integer

--- a/tests/fixtures/OpenAPI/simple.json
+++ b/tests/fixtures/OpenAPI/simple.json
@@ -1,0 +1,11 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/path": {
+    }
+  }
+}

--- a/tests/fixtures/OpenAPI/simple.yaml
+++ b/tests/fixtures/OpenAPI/simple.yaml
@@ -1,0 +1,6 @@
+openapi: 3.0.0
+info:
+  title: "Test API"
+  version: "1.0.0"
+paths:
+  /path:

--- a/tests/fixtures/OpenAPI/simple.yml
+++ b/tests/fixtures/OpenAPI/simple.yml
@@ -1,0 +1,6 @@
+openapi: 3.0.0
+info:
+  title: "Test API"
+  version: "1.0.0"
+paths:
+  /path:


### PR DESCRIPTION
composer.json

    + "cebe/php-openapi" required for OpenAPI Specifications
    + "psr/http-message required for Request Processor to deal with Server Requests
    +"guzzlehttp/psr7" dev-required to simulate Server Requests in tests.


Specifications:

    + `APISpec` abstract class extended by  `Request` and `Response`. 
    + `APISchema` abstract class extended by `Arrays`, `Numeric`, `Objects`, `Strings`, `TrueFalse` (each parameter schema 'type')

Builders:

    + `APIBuilder` abstract class extended by RequestBuilder`,  `ResponseBuilder`, `Arrays`, `Numeric`, `Objects`, `Strings` and `TrueFalse`.
        + `Numeric`,  `Strings` and `TrueFalse` do not need access to APIBuilder's fromSchema method, only the handleNullable method. Arrays and Objects need access in order to build for their 'items' or 'properties'.
