### PR TITLE
MultipleOf Validator

### DIFF
--- a/src/Validator/Numeric/MultipleOf.php
+++ b/src/Validator/Numeric/MultipleOf.php
@@ -14,17 +14,24 @@ class MultipleOf implements Validator
 {
     private readonly float|int $multiple;
 
-    public function __construct(float|int $multiple)
+    public function __construct(float|int $factor)
     {
-        if ($multiple <= 0) {
+        if ($factor <= 0) {
             throw new Exception('MultipleOf validator does not support numbers of zero or less');
         }
-        $this->multiple = $multiple;
+        $this->multiple = $factor;
     }
 
     public function validate(mixed $value): Result
     {
-        if (fmod($value, $this->multiple) == 0) {
+        if (!is_numeric($value)) {
+            return Result::invalid(
+                $value,
+                new MessageSet(null, new Message('MultipleOf validator requires a number, %s given', [gettype($value)]))
+            );
+        }
+
+        if (abs(fmod((float)$value, $this->multiple)) === 0.0) {
             return Result::valid($value);
         }
 

--- a/src/Validator/Numeric/MultipleOf.php
+++ b/src/Validator/Numeric/MultipleOf.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Validator\Numeric;
+
+use Exception;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Validator;
+
+class MultipleOf implements Validator
+{
+    private readonly float|int $multiple;
+
+    public function __construct(float|int $multiple)
+    {
+        if ($multiple <= 0) {
+            throw new Exception('MultipleOf validator does not support numbers of zero or less');
+        }
+        $this->multiple = $multiple;
+    }
+
+    public function validate(mixed $value): Result
+    {
+        if (fmod($value, $this->multiple) == 0) {
+            return Result::valid($value);
+        }
+
+        return Result::invalid(
+            $value,
+            new MessageSet(
+                null,
+                new Message('Number is expected to be a multiple of %d', [$this->multiple])
+            )
+        );
+    }
+}

--- a/src/Validator/Numeric/Range.php
+++ b/src/Validator/Numeric/Range.php
@@ -19,6 +19,13 @@ class Range implements Validator
 
     public function validate(mixed $value): Result
     {
+        if (!is_numeric($value)) {
+            return Result::invalid(
+                $value,
+                new MessageSet(null, new Message('Range validator requires a number, %s given', [gettype($value)]))
+            );
+        }
+
         if ($this->min !== null && $value < $this->min) {
             $message = new Message('Number is expected to be a minimum of %d', [$this->min]);
             return Result::invalid($value, new MessageSet(null, $message));

--- a/tests/Validator/Numeric/MultipleOfTest.php
+++ b/tests/Validator/Numeric/MultipleOfTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Validator\Numeric;
+
+use Exception;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Validator\Numeric\MultipleOf;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Validator\Numeric\MultipleOf
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
+ */
+class MultipleOfTest extends TestCase
+{
+    public function dataSetsThatThrowExceptions(): array
+    {
+        return [
+            [0],
+            [0.0],
+            [-5],
+            [-5.5],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsThatThrowExceptions
+     */
+    public function throwsExceptionForZeroOrNegatives(int|float $multiple): void
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage('MultipleOf validator does not support numbers of zero or less');
+
+        new MultipleOf($multiple);
+    }
+
+    public function dataSetsToValidate(): array
+    {
+        return [
+            'not a multiple (integer)' => [
+                10,
+                7,
+                Result::invalid(
+                    10,
+                    new MessageSet(null, new Message('Number is expected to be a multiple of %d', [7]))
+                ),
+            ],
+            'positive multiple (integer)' => [
+                10,
+                5,
+                Result::valid(10),
+            ],
+            'negative multiple (integer)' => [
+                -10,
+                5,
+                Result::valid(-10),
+            ],
+            'not a multiple (float)' => [
+                10,
+                7.5,
+                Result::invalid(
+                    10,
+                    new MessageSet(null, new Message('Number is expected to be a multiple of %d', [7.5]))
+                ),
+            ],
+            'positive multiple (float)' => [
+                1,
+                0.5,
+                Result::valid(1),
+            ],
+            'negative multiple (float)' => [
+                -1,
+                0.5,
+                Result::valid(-1),
+            ],
+            'factor and multiple the wrong way round' => [
+                10,
+                100,
+                Result::invalid(
+                    10,
+                    new MessageSet(null, new Message('Number is expected to be a multiple of %d', [100]))
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToValidate
+     */
+    public function validateTest(float|int $value, float|int $multiple, $expected): void
+    {
+        $multipleOf = new MultipleOf($multiple);
+
+        $actual = $multipleOf->validate($value);
+
+        self::assertEquals($expected, $actual);
+    }
+
+
+}

--- a/tests/Validator/Numeric/MultipleOfTest.php
+++ b/tests/Validator/Numeric/MultipleOfTest.php
@@ -43,14 +43,35 @@ class MultipleOfTest extends TestCase
 
     public function dataSetsToValidate(): array
     {
+        $notNumMessage = 'MultipleOf validator requires a number, %s given';
+
+
+        $notMultipleMessage = 'Number is expected to be a multiple of %d';
         return [
+            'array values are not numeric' => [
+                [1, 2, 3],
+                5,
+                Result::invalid([1, 2, 3], new MessageSet(null, new Message($notNumMessage, ['array']))),
+            ],
+            'boolean values are not numeric' => [
+                true,
+                5,
+                Result::invalid(true, new MessageSet(null, new Message($notNumMessage, ['boolean']))),
+            ],
+            'non-numeric strings are not numeric' => [
+                'non-numeric string',
+                5,
+                Result::invalid('non-numeric string', new MessageSet(null, new Message($notNumMessage, ['string']))),
+            ],
+            'null values are not numeric' => [
+                null,
+                5,
+                Result::invalid(null, new MessageSet(null, new Message($notNumMessage, ['NULL']))),
+            ],
             'not a multiple (integer)' => [
                 10,
                 7,
-                Result::invalid(
-                    10,
-                    new MessageSet(null, new Message('Number is expected to be a multiple of %d', [7]))
-                ),
+                Result::invalid(10, new MessageSet(null, new Message($notMultipleMessage, [7]))),
             ],
             'positive multiple (integer)' => [
                 10,
@@ -65,10 +86,7 @@ class MultipleOfTest extends TestCase
             'not a multiple (float)' => [
                 10,
                 7.5,
-                Result::invalid(
-                    10,
-                    new MessageSet(null, new Message('Number is expected to be a multiple of %d', [7.5]))
-                ),
+                Result::invalid(10, new MessageSet(null, new Message($notMultipleMessage, [7.5]))),
             ],
             'positive multiple (float)' => [
                 1,
@@ -80,13 +98,25 @@ class MultipleOfTest extends TestCase
                 0.5,
                 Result::valid(-1),
             ],
+            'not a multiple (string)' => [
+                '10',
+                7,
+                Result::invalid('10', new MessageSet(null, new Message($notMultipleMessage, [7]))),
+            ],
+            'positive multiple (string)' => [
+                '10',
+                5,
+                Result::valid('10'),
+            ],
+            'negative multiple (string)' => [
+                '-10',
+                5,
+                Result::valid('-10'),
+            ],
             'factor and multiple the wrong way round' => [
                 10,
                 100,
-                Result::invalid(
-                    10,
-                    new MessageSet(null, new Message('Number is expected to be a multiple of %d', [100]))
-                ),
+                Result::invalid(10, new MessageSet(null, new Message($notMultipleMessage, [100]))),
             ],
         ];
     }
@@ -95,7 +125,7 @@ class MultipleOfTest extends TestCase
      * @test
      * @dataProvider dataSetsToValidate
      */
-    public function validateTest(float|int $value, float|int $multiple, $expected): void
+    public function validateTest(mixed $value, float|int $multiple, $expected): void
     {
         $multipleOf = new MultipleOf($multiple);
 

--- a/tests/Validator/Numeric/RangeTest.php
+++ b/tests/Validator/Numeric/RangeTest.php
@@ -16,6 +16,44 @@ use PHPUnit\Framework\TestCase;
  */
 class RangeTest extends TestCase
 {
+    public function dataSetsOfNonNumericValues(): array
+    {
+        $notNumMessage = 'Range validator requires a number, %s given';
+
+        return [
+            'array values are not numeric' => [
+                [1, 2, 3],
+                Result::invalid([1, 2, 3], new MessageSet(null, new Message($notNumMessage, ['array']))),
+            ],
+            'boolean values are not numeric' => [
+                true,
+                Result::invalid(true, new MessageSet(null, new Message($notNumMessage, ['boolean']))),
+            ],
+            'non-numeric strings are not numeric' => [
+                'non-numeric string',
+                Result::invalid('non-numeric string', new MessageSet(null, new Message($notNumMessage, ['string']))),
+            ],
+            'null values are not numeric' => [
+                null,
+                Result::invalid(null, new MessageSet(null, new Message($notNumMessage, ['NULL']))),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsOfNonNumericValues
+     */
+    public function invalidForNonNumericValues(mixed $value, Result $expected): void
+    {
+        $sut = new Range();
+
+        $actual = $sut->validate($value);
+
+        self::assertEquals($expected, $actual);
+    }
+
+
     /**
      * @test
      */


### PR DESCRIPTION
`MultipleOf(float|int $factor)` Validator checks if given `$value` is a multiple of `$factor`

Currently using fmod to allow for floats since they're technically allowed:

> [multipleOf may be used with floating-point numbers, but in practice this can be unreliable due to the limited precision or floating point math. ](https://swagger.io/docs/specification/data-models/data-types/)

also added a similar is_numeric check to the Numeric/Range validator.
