### PR TITLE
OpenAPI helper class: PathMatcher added

### DIFF
--- a/src/OpenAPI/Exception/InvalidOpenAPI.php
+++ b/src/OpenAPI/Exception/InvalidOpenAPI.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Exception;
+
+use RuntimeException;
+
+class InvalidOpenAPI extends RuntimeException
+{
+    public static function invalidPath(string $path): self
+    {
+        $message = sprintf('%s is an invalid OpenAPI path', $path);
+        return new self($message);
+    }
+}

--- a/src/OpenAPI/Filter/PathMatcher.php
+++ b/src/OpenAPI/Filter/PathMatcher.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Filter;
+
+use Exception;
+use Membrane\Filter;
+use Membrane\OpenAPI\PathMatcher as PathMatcherClass;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+
+class PathMatcher implements Filter
+{
+    public function __construct(private readonly PathMatcherClass $pathMatcher)
+    {
+    }
+
+    public function filter(mixed $value): Result
+    {
+        if (!is_string($value)) {
+            return Result::invalid(
+                $value,
+                new MessageSet(null, new Message('PathMatcher filter expects string, %s passed', [gettype($value)]))
+            );
+        }
+
+        try {
+            $pathParams = $this->pathMatcher->getPathParams($value);
+        } catch (Exception) {
+            return Result::invalid(
+                $value,
+                new MessageSet(null, new Message('requestPath does not match expected pattern', []))
+            );
+        }
+
+        return Result::noResult($pathParams);
+    }
+}

--- a/src/OpenAPI/PathMatcher.php
+++ b/src/OpenAPI/PathMatcher.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI;
+
+use Exception;
+use Membrane\OpenAPI\Exception\InvalidOpenAPI;
+
+class PathMatcher
+{
+    private readonly string $regex;
+    /** @var string[] */
+    private readonly array $parameters;
+    private readonly string $serverUrl;
+
+    public function __construct(string $serverUrl, string $apiPath)
+    {
+        $parseUrl = parse_url($serverUrl, PHP_URL_PATH);
+        $this->serverUrl = is_string($parseUrl) ? $parseUrl : '';
+
+        $parameterNames = [];
+        $pregParts = [];
+        $inParameter = false;
+
+        $parts = preg_split('#([{}])#', $apiPath, -1, PREG_SPLIT_DELIM_CAPTURE);
+        assert($parts !== false);
+        foreach ($parts as $part) {
+            switch ($part) {
+                case '{':
+                    $inParameter = !$inParameter ? true :
+                    throw InvalidOpenAPI::invalidPath($apiPath);
+                    continue 2;
+                case '}':
+                    $inParameter = $inParameter ? false :
+                    throw InvalidOpenAPI::invalidPath($apiPath);
+                    continue 2;
+            }
+
+            if ($inParameter) {
+                $pregParts[] = '(?<' . $part . '>[^/]+)';
+                $parameterNames[] = $part;
+            } else {
+                $pregParts[] = preg_quote($part, '#');
+            }
+        }
+
+        $this->regex = '#^' . implode($pregParts) . '$#';
+        $this->parameters = $parameterNames;
+    }
+
+    public function matches(string $requestPath): bool
+    {
+        $requestPath = $this->removeServerFromPath($requestPath);
+        return preg_match($this->regex, $requestPath) === 1;
+    }
+
+    /** @return array<string, string> */
+    public function getPathParams(string $requestPath): array
+    {
+        if (!$this->matches($requestPath)) {
+            throw new Exception('requestPath does not match expected pattern');
+        }
+
+        $requestPath = $this->removeServerFromPath($requestPath);
+
+        $parameters = [];
+        $requestPath = strtok($requestPath, '?');
+        assert(is_string($requestPath));
+
+        preg_match($this->regex, $requestPath, $parameters);
+
+        return array_filter($parameters, fn($key) => in_array($key, $this->parameters), ARRAY_FILTER_USE_KEY);
+    }
+
+    private function removeServerFromPath(string $requestPath): string
+    {
+        $parseUrl = parse_url($requestPath, PHP_URL_PATH);
+        $requestPath = is_string($parseUrl) ? $parseUrl : $requestPath;
+
+        return substr($requestPath, strlen($this->serverUrl));
+    }
+}

--- a/tests/OpenAPI/Filter/PathMatcherTest.php
+++ b/tests/OpenAPI/Filter/PathMatcherTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Filter;
+
+use Membrane\OpenAPI\Filter\PathMatcher;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Filter\PathMatcher
+ * @uses   \Membrane\Result\Message
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Result
+ */
+class PathMatcherTest extends TestCase
+{
+    /** @test */
+    public function invalidResultForNonStringValues(): void
+    {
+        $expected = Result::invalid(
+            false,
+            new MessageSet(null, new Message('PathMatcher filter expects string, %s passed', ['boolean']))
+        );
+        $sut = new PathMatcher(self::createStub(\Membrane\OpenAPI\PathMatcher::class));
+
+        $actual = $sut->filter(false);
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /** @test */
+    public function filterTest(): void
+    {
+        $expected = Result::noResult(['filtered value']);
+        $observer = self::createMock(\Membrane\OpenAPI\PathMatcher::class);
+        $observer->expects($this->once())
+            ->method('getPathParams')
+            ->with('value')
+            ->willReturn(['filtered value']);
+        $sut = new PathMatcher($observer);
+
+        $actual = $sut->filter('value');
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/OpenAPI/PathMatcherTest.php
+++ b/tests/OpenAPI/PathMatcherTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI;
+
+use Exception;
+use Membrane\OpenAPI\Exception\InvalidOpenAPI;
+use Membrane\OpenAPI\PathMatcher;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers   \Membrane\OpenAPI\PathMatcher
+ * @covers   \Membrane\OpenAPI\Exception\InvalidOpenAPI
+ */
+class PathMatcherTest extends TestCase
+{
+    public function dataSetsWithImbalancedBraces(): array
+    {
+        return [
+            ['/pets/{id{name}}'],
+            ['/pets/}{id}'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsWithImbalancedBraces
+     */
+    public function throwsExceptionsForImbalancedBracesInAPIPaths(string $apiPath): void
+    {
+        self::expectExceptionObject(InvalidOpenAPI::invalidPath($apiPath));
+
+        new PathMatcher('', $apiPath);
+    }
+
+    public function dataSetsToMatch(): array
+    {
+        return [
+            'path is identical, server missing, server path missing' => [
+                'https://www.server.com/api',
+                '/pets',
+                '/pets',
+                false,
+            ],
+            'path is identical, server missing' => [
+                'https://www.server.com',
+                '/pets',
+                '/pets',
+                true,
+            ],
+            'path is identical, default server' => [
+                '',
+                '/pets',
+                '/pets',
+                true,
+            ],
+            'path is identical, partial server match' => [
+                'https://www.server.com/api',
+                '/pets',
+                '/api/pets',
+                true,
+            ],
+            'path is identical, server is identical' => [
+                'https://www.server.com/api',
+                '/pets',
+                'https://www.server.com/api/pets',
+                true,
+            ],
+            'path matches pattern' => [
+                'https://www.server.com/api',
+                '/pets/{id}',
+                '/api/pets/23',
+                true,
+            ],
+            'path does not start with pattern' => [
+                'https://www.server.com/api',
+                '/pets/{id}',
+                '///pets/23',
+                false,
+            ],
+            'path does not end with pattern' => [
+                'https://www.server.com/api',
+                '/pets/{id}',
+                '/pets/23/',
+                false,
+            ],
+            'path does not match pattern' => [
+                'https://www.server.com/api',
+                '/pets/{id}',
+                '/pet/23',
+                false,
+            ],
+            'path matches complex pattern' => [
+                'https://www.server.com/api',
+                '/pets/{id}/photos/{photo_id}',
+                '/api/pets/23/photos/5',
+                true,
+            ],
+            'path does not match complex pattern' => [
+                'https://www.server.com/api',
+                '/pets/{id}/photos/{photo_id}',
+                '/pets/23/37/5',
+                false,
+            ],
+            'path matches petstore example' => [
+                'http://swagger.petstore.io/v1',
+                '/pets',
+                '/v1/pets',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToMatch
+     */
+    public function matchesTest(string $serverUrl, string $apiPath, string $requestPath, bool $expected): void
+    {
+        $sut = new PathMatcher($serverUrl, $apiPath);
+
+        $actual = $sut->matches($requestPath);
+
+        self::assertSame($expected, $actual);
+    }
+
+    /** @test */
+    public function throwsExceptionGettingParamsForNonMatchingPaths(): void
+    {
+        $sut = new PathMatcher('https://www.server.com', '/pets/{id}');
+
+        self::expectExceptionObject(new Exception('requestPath does not match expected pattern'));
+
+        $sut->getPathParams('/hats/23');
+    }
+
+    public function dataSetsToGetPathParams(): array
+    {
+        return [
+            [
+                '/pets/{id}',
+                '/pets/23',
+                ['id' => '23'],
+            ],
+            [
+                '/pets/{id}/{name}',
+                '/pets/23/Ben',
+                ['id' => '23', 'name' => 'Ben'],
+            ],
+            [
+                '/pets/{id}/{name}',
+                '/pets/23/Ben?page=2&count=10',
+                ['id' => '23', 'name' => 'Ben'],
+            ],
+            [
+                '/pets/{id}/photos/{photo_id}',
+                '/pets/1/photos/5',
+                ['id' => 1, 'photo_id' => 5],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToGetPathParams
+     */
+    public function getPathParamsTest(string $apiUrl, string $requestUrl, array $expected): void
+    {
+        $sut = new PathMatcher('https://www.server.com', $apiUrl);
+
+        $actual = $sut->getPathParams($requestUrl);
+
+        self::assertEquals($expected, $actual);
+    }
+
+}


### PR DESCRIPTION
OpenAPI/PathMatcher

Helper class designed to return an array of path parameters. 

expects paths to **match exactly from start to finish**

has a `matches($requestPath):bool` method to check if `$requestPath` matches regular expression.

throws Exception if you attempt to `getPathParams($requestPath)` with a path that does not match.

**Example**
```
$sut = new PathMatcher('/pets/{id}');

echo $sut->regex; // #^/pets/(?<id>[^/]+)$#

var_dump($sut->matches('/pets/23')); // (bool) true
var_dump($sut->getPathParams('/pets/23')); // ['id' => '23']

var_dump($sut->matches('/hats/23')); // (bool) false
var_dump($sut->getPathParams('/hats/23')); // This would throw an exception
```

OpenAPI/Filter/PathMatcher

A filter that takes in a string path and returns a result object containing path parameters

**Example**
```
$sut = new PathMatcherFilter(new PathMatcher('/pets/{id}'));

$result = $sut->filter('/pets/100')

var_dump($result->isValid()); // (bool) true
var_dump($result->value); // [ 'id' => 100 ]
```