### PR TITLE
Validator and Filter: IsNumber and ToNumber

### DIFF
--- a/src/Filter/Type/ToNumber.php
+++ b/src/Filter/Type/ToNumber.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Type;
+
+use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+
+class ToNumber implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        if (!is_numeric($value)) {
+            return Result::invalid(
+                $value,
+                new MessageSet(
+                    null,
+                    new Message('ToNumber filter expects numeric values, %s passed', [gettype($value)])
+                )
+            );
+        }
+
+        $value = (string)$value === (string)(int)$value ? (int)$value : (double)$value;
+
+        return Result::valid($value);
+    }
+}

--- a/src/Validator/Type/IsNumber.php
+++ b/src/Validator/Type/IsNumber.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Validator\Type;
+
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Validator;
+
+class IsNumber implements Validator
+{
+    public function validate(mixed $value): Result
+    {
+        if (!(is_int($value) || is_float($value))) {
+            return Result::invalid(
+                $value,
+                new MessageSet(null, new Message('Value must be int or float, %s passed', [gettype($value)]))
+            );
+        }
+
+        return Result::valid($value);
+    }
+}

--- a/tests/Filter/Type/ToNumberTest.php
+++ b/tests/Filter/Type/ToNumberTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Type;
+
+use Membrane\Filter\Type\ToNumber;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Filter\Type\ToNumber
+ * @uses   \Membrane\Result\Message
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Result
+ */
+class ToNumberTest extends TestCase
+{
+    public function dataSetsToFilter(): array
+    {
+        $class = new class {
+        };
+
+        return [
+            'filters integer' => [
+                1,
+                Result::valid(1),
+            ],
+            'filters float' => [
+                2.3,
+                Result::valid(2.3),
+            ],
+            'filters integer string' => [
+                '4',
+                Result::valid(4),
+            ],
+            'filters float string' => [
+                '5.6',
+                Result::valid(5.6),
+            ],
+            'invalidates non-numeric string' => [
+                'six',
+                Result::invalid(
+                    'six',
+                    new MessageSet(null, new Message('ToNumber filter expects numeric values, %s passed', ['string']))
+                ),
+            ],
+            'invalidates bool' => [
+                true,
+                Result::invalid(
+                    true,
+                    new MessageSet(null, new Message('ToNumber filter expects numeric values, %s passed', ['boolean']))
+                ),
+            ],
+            'invalidates null' => [
+                null,
+                Result::invalid(
+                    null,
+                    new MessageSet(null, new Message('ToNumber filter expects numeric values, %s passed', ['NULL']))
+                ),
+            ],
+            'invalidates array' => [
+                [1, 2, 3],
+                Result::invalid([1, 2, 3],
+                    new MessageSet(null, new Message('ToNumber filter expects numeric values, %s passed', ['array']))),
+            ],
+            'invalidates object' => [
+                $class,
+                Result::invalid(
+                    $class,
+                    new MessageSet(null, new Message('ToNumber filter expects numeric values, %s passed', ['object']))
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToFilter
+     */
+    public function validateTest(mixed $value, Result $expected): void
+    {
+        $sut = new ToNumber();
+
+        $actual = $sut->filter($value);
+
+        self::assertSame($expected->value, $actual->value);
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/Validator/Type/IsNumberTest.php
+++ b/tests/Validator/Type/IsNumberTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Validator\Type;
+
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Validator\Type\IsNumber;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Validator\Type\IsNumber
+ * @uses   \Membrane\Result\Message
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Result
+ */
+class IsNumberTest extends TestCase
+{
+
+    public function dataSetsToValidate(): array
+    {
+        $class = new class {
+        };
+
+        return [
+            'validates integer' => [
+                1,
+                Result::valid(1),
+            ],
+            'validates float' => [
+                2.3,
+                Result::valid(2.3),
+            ],
+            'invalidates integer string' => [
+                '4',
+                Result::invalid(
+                    '4',
+                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['string']))
+                ),
+            ],
+            'invalidates float string' => [
+                '5.6',
+                Result::invalid(
+                    '5.6',
+                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['string']))
+                ),
+            ],
+            'invalidates non-numeric string' => [
+                'six',
+                Result::invalid(
+                    'six',
+                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['string']))
+                ),
+            ],
+            'invalidates bool' => [
+                true,
+                Result::invalid(
+                    true,
+                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['boolean']))
+                ),
+            ],
+            'invalidates null' => [
+                null,
+                Result::invalid(
+                    null,
+                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['NULL']))
+                ),
+            ],
+            'invalidates array' => [
+                [1, 2, 3],
+                Result::invalid([1, 2, 3],
+                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['array']))),
+            ],
+            'invalidates object' => [
+                $class,
+                Result::invalid(
+                    $class,
+                    new MessageSet(null, new Message('Value must be int or float, %s passed', ['object']))
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToValidate
+     */
+    public function validateTest(mixed $value, Result $expected): void
+    {
+        $sut = new IsNumber();
+
+        $actual = $sut->validate($value);
+
+        self::assertEquals($expected, $actual);
+    }
+
+}


### PR DESCRIPTION
Originally for OpenAPI type: number with unspecified format we used: 

```new AnyOf(new IsInt(), new IsFloat())```

This became more complicated when trying to implement a `$strict` boolean in the RequestBuilder.
```
$chain = $strict ?
    [new AnyOf(new IsInt(), new IsFloat())]
    :
    [new AnyOf(new AllOf(new ToInt(), new IsInt()), new AllOf(new ToFloat(), new IsFloat());
```

By adding the Number filter/validators it becomes this:
````
$chain = $strict ?
    [new IsNumber()]
    :
    [new ToNumber(), new IsNumber()];
```
