### PR TITLE
OpenAPI Specifications: Type Specific Schema Specifications added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,14 @@
         }
     },
     "require": {
-        "php": "^8.1.0"
+        "php": "^8.1.0",
+        "cebe/php-openapi": "^1.7",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.8",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.7",
+        "guzzlehttp/psr7": "^2.4"
     }
 }

--- a/src/OpenAPI/Specification/APISchema.php
+++ b/src/OpenAPI/Specification/APISchema.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Membrane\Builder\Specification;
+
+abstract class APISchema implements Specification
+{
+    /** @var mixed[] */
+    public readonly ?array $enum;
+    public readonly ?string $format;
+    public readonly bool $nullable;
+
+    public function __construct(
+        public readonly string $fieldName,
+        Schema $schema
+    ) {
+        $this->enum = $schema->enum;
+        $this->format = $schema->format;
+        $this->nullable = $schema->nullable ?? false;
+    }
+}

--- a/src/OpenAPI/Specification/Arrays.php
+++ b/src/OpenAPI/Specification/Arrays.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\spec\Reference;
+use cebe\openapi\spec\Schema;
+use Exception;
+
+class Arrays extends APISchema
+{
+    public readonly ?Schema $items;
+    public readonly ?int $maxItems;
+    public readonly int $minItems;
+    public readonly bool $uniqueItems;
+
+    public function __construct(string $fieldName, Schema $schema)
+    {
+        if ($schema->type !== 'array') {
+            throw new Exception('Arrays Specification requires specified type of array');
+        }
+
+        assert(!$schema->items instanceof Reference);
+        $this->items = $schema->items;
+        $this->maxItems = $schema->maxItems;
+        $this->minItems = $schema->minItems ?? 0;
+        $this->uniqueItems = $schema->uniqueItems;
+
+        parent::__construct($fieldName, $schema);
+    }
+}

--- a/src/OpenAPI/Specification/Numeric.php
+++ b/src/OpenAPI/Specification/Numeric.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+
+class Numeric extends APISchema
+{
+    public readonly bool $exclusiveMaximum;
+    public readonly bool $exclusiveMinimum;
+    public readonly float|int|null $maximum;
+    public readonly float|int|null $minimum;
+    public readonly float|int|null $multipleOf;
+    public readonly string $type;
+
+    public function __construct(string $fieldName, Schema $schema, public readonly bool $strict = true)
+    {
+        if (!in_array($schema->type, ['number', 'integer'], true)) {
+            throw new Exception('Numeric Specification requires specified type of integer or number');
+        }
+
+        $this->type = $schema->type;
+        $this->exclusiveMaximum = $schema->exclusiveMaximum ?? false;
+        $this->exclusiveMinimum = $schema->exclusiveMinimum ?? false;
+        $this->maximum = $schema->maximum;
+        $this->minimum = $schema->minimum;
+        $this->multipleOf = $schema->multipleOf;
+
+        parent::__construct($fieldName, $schema);
+    }
+}

--- a/src/OpenAPI/Specification/Objects.php
+++ b/src/OpenAPI/Specification/Objects.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+
+class Objects extends APISchema
+{
+    // @TODO support minProperties and maxProperties
+    /** @var Schema[] */
+    public readonly array $properties;
+    /** @var string[]|null */
+    public readonly ?array $required;
+
+    public function __construct(string $fieldName, Schema $schema)
+    {
+        if ($schema->type !== 'object') {
+            throw new Exception('Objects Specification requires specified type of object');
+        }
+
+        $this->properties = array_filter($schema->properties ?? [], fn($p) => $p instanceof Schema);
+
+        $this->required = $schema->required;
+
+        parent::__construct($fieldName, $schema);
+    }
+}

--- a/src/OpenAPI/Specification/Strings.php
+++ b/src/OpenAPI/Specification/Strings.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+
+class Strings extends APISchema
+{
+    public readonly ?int $maxLength;
+    public readonly int $minLength;
+    public readonly ?string $pattern;
+
+    public function __construct(string $fieldName, Schema $schema)
+    {
+        if ($schema->type !== 'string') {
+            throw new Exception('Strings Specification requires specified type of string');
+        }
+
+        $this->maxLength = $schema->maxLength;
+        $this->minLength = $schema->minLength ?? 0;
+        $this->pattern = $schema->pattern;
+
+        parent::__construct($fieldName, $schema);
+    }
+}

--- a/src/OpenAPI/Specification/TrueFalse.php
+++ b/src/OpenAPI/Specification/TrueFalse.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+
+class TrueFalse extends APISchema
+{
+    public function __construct(string $fieldName, Schema $schema, public readonly bool $strict = true)
+    {
+        if ($schema->type !== 'boolean') {
+            throw new Exception('TrueFalse Specification requires specified type of boolean');
+        }
+
+        parent::__construct($fieldName, $schema);
+    }
+}

--- a/tests/OpenAPI/Specification/ArraysTest.php
+++ b/tests/OpenAPI/Specification/ArraysTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\OpenAPI\Specification\Arrays;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Specification\Arrays
+ * @covers \Membrane\OpenAPI\Specification\APISchema
+ */
+class ArraysTest extends TestCase
+{
+    /** @test */
+    public function throwsExceptionForInvalidType(): void
+    {
+        self::expectExceptionObject(
+            new Exception('Arrays Specification requires specified type of array')
+        );
+
+        new Arrays('', new Schema([]));
+    }
+
+    public function dataSetsToConstruct(): array
+    {
+        return [
+            'default values' => [
+                new Schema(['type' => 'array',]),
+                [
+                    'items' => null,
+                    'maxItems' => null,
+                    'minItems' => 0,
+                    'uniqueItems' => false,
+                    'enum' => null,
+                    'format' => null,
+                    'nullable' => false,
+                ],
+            ],
+            'assigned values' => [
+                new Schema([
+                    'type' => 'array',
+                    'items' => new Schema(['type' => 'integer']),
+                    'maxItems' => 5,
+                    'minItems' => 2,
+                    'uniqueItems' => true,
+                    'enum' => [[1, 2, 3], [5, 6, 7]],
+                    'format' => 'array of ints',
+                    'nullable' => true,
+                ]),
+                [
+                    'items' => new Schema(['type' => 'integer']),
+                    'maxItems' => 5,
+                    'minItems' => 2,
+                    'uniqueItems' => true,
+                    'enum' => [[1, 2, 3], [5, 6, 7]],
+                    'format' => 'array of ints',
+                    'nullable' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConstruct
+     */
+    public function constructTest(Schema $schema, array $expected): void
+    {
+        $sut = new Arrays('', $schema);
+
+        foreach ($expected as $key => $value) {
+            if ($key === 'items') {
+                self::assertEquals($value, $sut->$key, sprintf('%s does not meet expected value', $key));
+            } else {
+                self::assertSame($value, $sut->$key, sprintf('%s does not meet expected value', $key));
+            }
+        }
+    }
+}

--- a/tests/OpenAPI/Specification/NumericTest.php
+++ b/tests/OpenAPI/Specification/NumericTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\OpenAPI\Specification\Numeric;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Specification\Numeric
+ * @covers \Membrane\OpenAPI\Specification\APISchema
+ */
+class NumericTest extends TestCase
+{
+    /** @test */
+    public function throwsExceptionForInvalidType(): void
+    {
+        self::expectExceptionObject(
+            new Exception('Numeric Specification requires specified type of integer or number')
+        );
+
+        new Numeric('', new Schema([]));
+    }
+
+    public function dataSetsToConstruct(): array
+    {
+        return [
+            'default values for number' => [
+                new Schema(['type' => 'number',]),
+                [
+                    'type' => 'number',
+                    'maximum' => null,
+                    'minimum' => null,
+                    'exclusiveMaximum' => false,
+                    'exclusiveMinimum' => false,
+                    'multipleOf' => null,
+                    'enum' => null,
+                    'nullable' => false,
+                ],
+            ],
+            'default values for integer' => [
+                new Schema(['type' => 'integer',]),
+                [
+                    'type' => 'integer',
+                    'maximum' => null,
+                    'minimum' => null,
+                    'exclusiveMaximum' => false,
+                    'exclusiveMinimum' => false,
+                    'multipleOf' => null,
+                    'enum' => null,
+                    'nullable' => false,
+                ],
+            ],
+            'assigned values for number' => [
+                new Schema([
+                    'type' => 'number',
+                    'maximum' => 10,
+                    'minimum' => 1,
+                    'exclusiveMaximum' => true,
+                    'exclusiveMinimum' => true,
+                    'multipleOf' => 3,
+                    'enum' => [3, 9],
+                    'format' => 'float',
+                    'nullable' => true,
+                ]),
+                [
+                    'type' => 'number',
+                    'maximum' => 10,
+                    'minimum' => 1,
+                    'exclusiveMaximum' => true,
+                    'exclusiveMinimum' => true,
+                    'multipleOf' => 3,
+                    'enum' => [3, 9],
+                    'format' => 'float',
+                    'nullable' => true,
+                ],
+            ],
+            'assigned values for integer' => [
+                new Schema([
+                    'type' => 'integer',
+                    'maximum' => 10,
+                    'minimum' => 1,
+                    'exclusiveMaximum' => true,
+                    'exclusiveMinimum' => true,
+                    'multipleOf' => 3,
+                    'enum' => [3, 9],
+                    'format' => 'square numbers',
+                    'nullable' => true,
+                ]),
+                [
+                    'type' => 'integer',
+                    'maximum' => 10,
+                    'minimum' => 1,
+                    'exclusiveMaximum' => true,
+                    'exclusiveMinimum' => true,
+                    'multipleOf' => 3,
+                    'enum' => [3, 9],
+                    'format' => 'square numbers',
+                    'nullable' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConstruct
+     */
+    public function constructTest(Schema $schema, array $expected): void
+    {
+        $sut = new Numeric('', $schema);
+
+        foreach ($expected as $key => $value) {
+            self::assertSame($value, $sut->$key, sprintf('%s did not meet expected value', $key));
+        }
+    }
+}

--- a/tests/OpenAPI/Specification/ObjectsTest.php
+++ b/tests/OpenAPI/Specification/ObjectsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\OpenAPI\Specification\Objects;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Specification\Objects
+ * @covers \Membrane\OpenAPI\Specification\APISchema
+ */
+class ObjectsTest extends TestCase
+{
+    /** @test */
+    public function throwsExceptionForInvalidType(): void
+    {
+        self::expectExceptionObject(
+            new Exception('Objects Specification requires specified type of object')
+        );
+
+        new Objects('', new Schema([]));
+    }
+
+    public function dataSetsToConstruct(): array
+    {
+        return [
+            'default values' => [
+                new Schema(['type' => 'object',]),
+                [
+                    'properties' => [],
+                    'required' => null,
+                    'enum' => null,
+                    'format' => null,
+                    'nullable' => false,
+                ],
+            ],
+            'assigned values' => [
+                new Schema([
+                    'type' => 'object',
+                    'properties' => ['id' => new Schema(['type' => 'integer'])],
+                    'required' => ['id'],
+                    'enum' => [false, null],
+                    'format' => 'you cannot say yes',
+                    'nullable' => true,
+                ]),
+                [
+                    'properties' => ['id' => new Schema(['type' => 'integer'])],
+                    'required' => ['id'],
+                    'enum' => [false, null],
+                    'format' => 'you cannot say yes',
+                    'nullable' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConstruct
+     */
+    public function constructTest(Schema $schema, array $expected): void
+    {
+        $sut = new Objects('', $schema);
+
+        foreach ($expected as $key => $value) {
+            if ($key === 'properties') {
+                self::assertEquals($value, $sut->$key, sprintf('%s does not meet expected value', $key));
+            } else {
+                self::assertSame($value, $sut->$key, sprintf('%s does not meet expected value', $key));
+            }
+        }
+    }
+}

--- a/tests/OpenAPI/Specification/StringsTest.php
+++ b/tests/OpenAPI/Specification/StringsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\OpenAPI\Specification\Strings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Specification\Strings
+ * @covers \Membrane\OpenAPI\Specification\APISchema
+ */
+class StringsTest extends TestCase
+{
+    /** @test */
+    public function throwsExceptionForInvalidType(): void
+    {
+        self::expectExceptionObject(
+            new Exception('Strings Specification requires specified type of string')
+        );
+
+        new Strings('', new Schema([]));
+    }
+
+    public function dataSetsToConstruct(): array
+    {
+        return [
+            'default values' => [
+                new Schema(['type' => 'string',]),
+                [
+                    'maxLength' => null,
+                    'minLength' => 0,
+                    'pattern' => null,
+                    'enum' => null,
+                    'format' => null,
+                    'nullable' => false,
+                ],
+            ],
+            'assigned values' => [
+                new Schema([
+                    'type' => 'string',
+                    'maxLength' => 20,
+                    'minLength' => 6,
+                    'pattern' => '#.+#',
+                    'enum' => ['This is a string', 'So is this'],
+                    'format' => 'arbitrary',
+                    'nullable' => true,
+                ]),
+                [
+                    'maxLength' => 20,
+                    'minLength' => 6,
+                    'pattern' => '#.+#',
+                    'enum' => ['This is a string', 'So is this'],
+                    'format' => 'arbitrary',
+                    'nullable' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConstruct
+     */
+    public function constructTest(Schema $schema, array $expected): void
+    {
+        $sut = new Strings('', $schema);
+
+        foreach ($expected as $key => $value) {
+            self::assertSame($value, $sut->$key, sprintf('%s does not meet expected value', $key));
+        }
+    }
+}

--- a/tests/OpenAPI/Specification/TrueFalseTest.php
+++ b/tests/OpenAPI/Specification/TrueFalseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Specification;
+
+use cebe\openapi\spec\Schema;
+use Exception;
+use Membrane\OpenAPI\Specification\TrueFalse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\OpenAPI\Specification\TrueFalse
+ * @covers \Membrane\OpenAPI\Specification\APISchema
+ */
+class TrueFalseTest extends TestCase
+{
+    /** @test */
+    public function throwsExceptionForInvalidType(): void
+    {
+        self::expectExceptionObject(
+            new Exception('TrueFalse Specification requires specified type of boolean')
+        );
+
+        new TrueFalse('', new Schema([]));
+    }
+
+    public function dataSetsToConstruct(): array
+    {
+        return [
+            'default values' => [
+                new Schema(['type' => 'boolean',]),
+                [
+                    'enum' => null,
+                    'format' => null,
+                    'nullable' => false,
+                ],
+            ],
+            'assigned values' => [
+                new Schema([
+                    'type' => 'boolean',
+                    'enum' => [false, null],
+                    'format' => 'you cannot say yes',
+                    'nullable' => true,
+                ]),
+                [
+                    'enum' => [false, null],
+                    'format' => 'you cannot say yes',
+                    'nullable' => true,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConstruct
+     */
+    public function constructTest(Schema $schema, array $expected): void
+    {
+        $sut = new TrueFalse('', $schema);
+
+        foreach ($expected as $key => $value) {
+            self::assertSame($value, $sut->$key, sprintf('%s does not meet expected value', $key));
+        }
+    }
+}


### PR DESCRIPTION
`Arrays($fieldName, $schema)` supports schemas with `'type' : 'array'`

`Numeric($fieldName, $schema, $strict = false)` supports schemas with `'type' : 'number'` or `'type' : 'integer'`. 
`$strict` parameter will let NumericBuilder determine if it should use a Filter or stick exclusively to Validators.

`Objects($fieldName, $schema)` supports schemas with `'type' : 'object'`

`Strings($fieldName, $schema)` supports schemas with `'type' : 'string'`

`TrueFalse($fieldName, $schema, $strict = false)` supports schemas with `'type' : 'boolean'`. 
`$strict` parameter will let TrueFalseBuilder determine if it should use a Filter or stick exclusively to Validators.