### PR TITLE
Cleanup: Annotation Corrections

### DIFF
--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -10,7 +10,7 @@ class Result
     public const NO_RESULT = 0;
     public const INVALID = -1;
 
-    /** @var array|MessageSet[] */
+    /** @var MessageSet[] */
     public readonly array $messageSets;
 
     public function __construct(

--- a/tests/Attribute/BuilderTest.php
+++ b/tests/Attribute/BuilderTest.php
@@ -51,30 +51,30 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers   \Membrane\Attribute\Builder
  * @covers   \Membrane\Exception\CannotProcessProperty
- * @uses     ClassWithAttributes
+ * @uses     \Membrane\Attribute\ClassWithAttributes
  * @uses     \Membrane\Attribute\FilterOrValidator
  * @uses     \Membrane\Attribute\SetFilterOrValidator
  * @uses     \Membrane\Attribute\OverrideProcessorType
  * @uses     \Membrane\Attribute\Subtype
- * @uses     Result
- * @uses     MessageSet
- * @uses     Message
- * @uses     FieldName
- * @uses     Collection
- * @uses     FieldSet
- * @uses     Field
- * @uses     BeforeSet
- * @uses     AfterSet
- * @uses     RequiredFields
- * @uses     IsList
- * @uses     IsInt
+ * @uses     \Membrane\Result\Result
+ * @uses     \Membrane\Result\MessageSet
+ * @uses     \Membrane\Result\Message
+ * @uses     \Membrane\Result\FieldName
+ * @uses     \Membrane\Processor\Collection
+ * @uses     \Membrane\Processor\FieldSet
+ * @uses     \Membrane\Processor\Field
+ * @uses     \Membrane\Processor\BeforeSet
+ * @uses     \Membrane\Processor\AfterSet
+ * @uses     \Membrane\Validator\FieldSet\RequiredFields
+ * @uses     \Membrane\Validator\Type\IsList
+ * @uses     \Membrane\Validator\Type\IsInt
  * @uses     \Membrane\Validator\Type\IsString
  * @uses     \Membrane\Filter\Type\ToString
  * @uses     \Membrane\Validator\String\Length
  * @uses     \Membrane\Validator\String\Regex
  * @uses     \Membrane\Validator\Utility\AllOf
  * @uses     \Membrane\Validator\Collection\Count
- * @uses     WithNamedArguments
+ * @uses     \Membrane\Filter\CreateObject\WithNamedArguments
  */
 class BuilderTest extends TestCase
 {


### PR DESCRIPTION
Unfortunately my phpstorm settings incorrectly simplified the usage annotations on the AttributeBuilderTest.

This PR reverts them back to correct annotations.

Also simplifies the messageSet annotation on Result.