### PR TITLE
Regex Validator updated to correctly handle OpenAPI keyword: pattern

### DIFF
--- a/docs/builder-attributes.md
+++ b/docs/builder-attributes.md
@@ -334,7 +334,7 @@ class BlogPost
     public function __construct(
         #[FilterOrValidator(new ToString())]
         #[FilterOrValidator(new Length(5, 50))]
-        #[FilterOrValidator(new Regex('#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#'))]
+        #[FilterOrValidator(new Regex('^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$'))]
         public string $title,
         #[FilterOrValidator(new ToString())]
         public string $body,
@@ -403,7 +403,7 @@ class BlogPost
 {
     public function __construct(
         #[FilterOrValidator(new ToString())]
-        #[FilterOrValidator(new AllOf(new Length(5,50), new Regex('#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#')))]
+        #[FilterOrValidator(new AllOf(new Length(5,50), new Regex('^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$')))]
         public string $title,
         #[FilterOrValidator(new ToString())]
         public string $body,
@@ -457,7 +457,7 @@ foreach ($examples as $example) {
 ['title' => 'My Title', 'body' => '', 'tags' => ['a', 'b', 'c']] is valid
 ['title' => 'mY tItLe tHat iS uNnEcEsSaRiLlY lOnG wItH InCoRrEcT cApItIlIzAtIoN', 'body' => '', 'tags' => ['a', 'b', 'c']] is invalid
 String is expected to be a maximum of 50 characters
-String does not match the required pattern ^([A-Z][a-z]*\s){1,10}$
+String does not match the required pattern #^([A-Z][a-z]*\s){1,10}$#u
 ```
 
 Brilliant, now if a user makes an error with their title,
@@ -474,7 +474,7 @@ class BlogPost
 {
     public function __construct(
         #[FilterOrValidator(new ToString())]
-        #[FilterOrValidator(new AllOf(new Length(5,50), new Regex('#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#')))]
+        #[FilterOrValidator(new AllOf(new Length(5,50), new Regex('^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$')))]
         public string $title,
         #[FilterOrValidator(new ToString())]
         public string $body,

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -433,7 +433,7 @@ new Regex($pattern)
 
 ```php
 <?php
-$regex = new Regex('/\d{3}/');
+$regex = new Regex('\d{3}');
 $string = '123';
 
 $result = $regex->validate($string);

--- a/src/Validator/String/Regex.php
+++ b/src/Validator/String/Regex.php
@@ -11,8 +11,11 @@ use Membrane\Validator;
 
 class Regex implements Validator
 {
-    public function __construct(private readonly string $pattern)
+    private readonly string $pattern;
+
+    public function __construct(string $pattern)
     {
+        $this->pattern = sprintf('#%s#u', str_replace('#', '\#', $pattern));
     }
 
     public function validate(mixed $value): Result

--- a/tests/Attribute/BuilderTest.php
+++ b/tests/Attribute/BuilderTest.php
@@ -501,7 +501,7 @@ class BuilderTest extends TestCase
                         ),
                         new Message(
                             'String does not match the required pattern %s',
-                            ['#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#']
+                            ['#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#u']
                         )
                     ),
                 ),

--- a/tests/Validator/String/RegexTest.php
+++ b/tests/Validator/String/RegexTest.php
@@ -36,7 +36,9 @@ class RegexTest extends TestCase
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $regex = new Regex('');
-        $expected = Result::invalid($input, new MessageSet(
+        $expected = Result::invalid(
+            $input,
+            new MessageSet(
                 null,
                 new Message('Regex Validator requires a string, %s given', [$expectedVars])
             )
@@ -50,9 +52,18 @@ class RegexTest extends TestCase
     public function dataSetsThatPass(): array
     {
         return [
-            ['//', ''],
-            ['/[abc]/i', 'B'],
-            ['/\d{3}/', '123'],
+            'empty regex' => ['', ''],
+            'one digit' => ['\d', '1'],
+            'one lower-case letter' => ['[a-z]', 'f'],
+            'one letter' => ['[a-zA-Z]', 'F'],
+            '? quantifier, none provided' => ['^\d?$', ''],
+            '? quantifier, one provided' => ['^\d?$', '1'],
+            '* quantifier, none provided' => ['^\d*$', ''],
+            '* quantifier, many provided' => ['^\d*$', '123456789'],
+            '+ quantifier, one provided' => ['^\d+$', '1'],
+            '+ quantifier, many provided' => ['^\d+$', '123456789'],
+            '{min,max} quantifier, one provided' => ['^\d{2,5}$', '12'],
+            '{min,max} quantifier, many provided' => ['^\d{2,5}$', '12345'],
         ];
     }
 
@@ -73,9 +84,9 @@ class RegexTest extends TestCase
     public function dataSetsThatFail(): array
     {
         return [
-            ['/abc/', 'ABC'],
-            ['/[abc]/', 'd'],
-            ['/d{3}/', '12'],
+            ['abc', 'ABC'],
+            ['[abc]', 'd'],
+            ['\d{3}', '12'],
         ];
     }
 
@@ -86,7 +97,8 @@ class RegexTest extends TestCase
     public function stringsThatDoNotMatchPatternReturnInvalid(string $pattern, string $input): void
     {
         $regex = new Regex($pattern);
-        $expectedMessage = new Message('String does not match the required pattern %s', [$pattern]);
+        $expectedPattern = sprintf('#%s#u', str_replace('#', '\#', $pattern));
+        $expectedMessage = new Message('String does not match the required pattern %s', [$expectedPattern]);
         $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
 
         $result = $regex->validate($input);

--- a/tests/fixtures/Attribute/Docs/BlogPostFromNamedArguments.php
+++ b/tests/fixtures/Attribute/Docs/BlogPostFromNamedArguments.php
@@ -22,7 +22,7 @@ class BlogPostFromNamedArguments
 {
     public function __construct(
         #[FilterOrValidator(new ToString())]
-        #[FilterOrValidator(new AllOf(new Length(5, 50), new Regex('#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#')))]
+        #[FilterOrValidator(new AllOf(new Length(5, 50), new Regex('^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$')))]
         public string $title,
         #[FilterOrValidator(new ToString())]
         public string $body,

--- a/tests/fixtures/Attribute/Docs/BlogPostRegexAndMaxLength.php
+++ b/tests/fixtures/Attribute/Docs/BlogPostRegexAndMaxLength.php
@@ -21,7 +21,7 @@ class BlogPostRegexAndMaxLength
     public function __construct(
         #[FilterOrValidator(new ToString())]
         #[FilterOrValidator(new Length(5, 50))]
-        #[FilterOrValidator(new Regex('#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#'))]
+        #[FilterOrValidator(new Regex('^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$'))]
         public string $title,
         #[FilterOrValidator(new ToString())]
         public string $body,

--- a/tests/fixtures/Attribute/Docs/BlogPostWithAllOf.php
+++ b/tests/fixtures/Attribute/Docs/BlogPostWithAllOf.php
@@ -20,7 +20,7 @@ class BlogPostWithAllOf
 {
     public function __construct(
         #[FilterOrValidator(new ToString())]
-        #[FilterOrValidator(new AllOf(new Length(5, 50), new Regex('#^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$#')))]
+        #[FilterOrValidator(new AllOf(new Length(5, 50), new Regex('^([A-Z][a-z]*\s){0,9}([A-Z][a-z]*)$')))]
         public string $title,
         #[FilterOrValidator(new ToString())]
         public string $body,


### PR DESCRIPTION
Regex Validator now takes a regexbody without delimiters or flags, as this [seems to be the expected input for OpenAPI](https://github.com/OAI/OpenAPI-Specification/issues/1985).

Docs and tests updated to reflect this change.