### PR TITLE
Objects Builder handles additionalProperties

### DIFF
--- a/src/OpenAPI/Specification/Objects.php
+++ b/src/OpenAPI/Specification/Objects.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Membrane\OpenAPI\Specification;
 
+use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
 use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
 
 class Objects extends APISchema
 {
     // @TODO support minProperties and maxProperties
+    public readonly bool|Schema $additionalProperties;
     /** @var Schema[] */
     public readonly array $properties;
     /** @var string[]|null */
@@ -20,6 +22,9 @@ class Objects extends APISchema
         if ($schema->type !== 'object') {
             throw CannotProcessOpenAPI::mismatchedType(self::class, 'object', $schema->type);
         }
+
+        assert(!$schema->additionalProperties instanceof Reference);
+        $this->additionalProperties = $schema->additionalProperties;
 
         $this->properties = array_filter($schema->properties ?? [], fn($p) => $p instanceof Schema);
 

--- a/tests/OpenAPI/Specification/ObjectsTest.php
+++ b/tests/OpenAPI/Specification/ObjectsTest.php
@@ -38,6 +38,7 @@ class ObjectsTest extends TestCase
             'default values' => [
                 new Schema(['type' => 'object',]),
                 [
+                    'additionalProperties' => true,
                     'properties' => [],
                     'required' => null,
                     'enum' => null,
@@ -45,9 +46,21 @@ class ObjectsTest extends TestCase
                     'nullable' => false,
                 ],
             ],
-            'assigned values' => [
+            'additionalProperties assigned false' => [
+                new Schema(['type' => 'object', 'additionalProperties' => false]),
+                [
+                    'additionalProperties' => false,
+                    'properties' => [],
+                    'required' => null,
+                    'enum' => null,
+                    'format' => null,
+                    'nullable' => false,
+                ],
+            ],
+            'all relevant keywords assigned values' => [
                 new Schema([
                     'type' => 'object',
+                    'additionalProperties' => new Schema(['type' => 'string']),
                     'properties' => ['id' => new Schema(['type' => 'integer'])],
                     'required' => ['id'],
                     'enum' => [false, null],
@@ -55,6 +68,7 @@ class ObjectsTest extends TestCase
                     'nullable' => true,
                 ]),
                 [
+                    'additionalProperties' => new Schema(['type' => 'string']),
                     'properties' => ['id' => new Schema(['type' => 'integer'])],
                     'required' => ['id'],
                     'enum' => [false, null],
@@ -74,11 +88,7 @@ class ObjectsTest extends TestCase
         $sut = new Objects('', $schema);
 
         foreach ($expected as $key => $value) {
-            if ($key === 'properties') {
-                self::assertEquals($value, $sut->$key, sprintf('%s does not meet expected value', $key));
-            } else {
-                self::assertSame($value, $sut->$key, sprintf('%s does not meet expected value', $key));
-            }
+            self::assertEquals($value, $sut->$key, sprintf('%s does not meet expected value', $key));
         }
     }
 }


### PR DESCRIPTION
Object Specification now has `public readonly $additionalProperties`. 
This is the first step in allowing the Object Builder to process additionalProperties.

additionalProperties can be a boolean or a Schema Object ([if not provided, default is true according to OpenAPI](https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.2.md#schemaObject)):

- if Schema Object, then the APIBuilder can handles this already
- if true, then no action is required, additional fields on objects are ignored already.
- if false, then new behaviour will need to be added to ensure objects do not contain additional fields.