### PR TITLE
FixedFields validator added

### DIFF
--- a/docs/validators.md
+++ b/docs/validators.md
@@ -221,6 +221,59 @@ Result was valid
 
 ## FieldSet
 
+### FixedFields
+
+Checks that array does not contain any additional fields.
+
+```php
+new Membrane\Validator\FieldSet\FixedFields(...$fields);
+```
+
+| Parameter  | Type   |
+|------------|--------|
+| ...$fields | string |
+
+```php
+<?php
+use Membrane\Validator\FieldSet\FixedFields;
+
+$fixedFields = new FixedFields('a', 'b');
+$arrayOfFields = [
+        [],
+        ['a' => 1],
+        ['a' => 1, 'b' => 2],
+        ['c' => 3],
+        ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5],
+    ]
+
+foreach ($arrayOfFields as $fields) {
+    $result = $fixedFields->validate($fields);
+    
+    if ($result->isValid()) {
+        echo json_encode($result->value) . ' is valid \n';
+    } else {
+        echo json_encode($result->value) . ' is invalid \n';
+        foreach($result->messageSets[0]->messages as $message) {
+            echo '\t' . $message->rendered() . '\n';
+        }
+    }
+}
+```
+
+The above example will output the following
+
+```text
+{} is valid
+{"a":1} is valid
+{"a":1,"b":2} is valid
+{c":3} is invalid
+    c is not a fixed field
+{"a":1,"b":2,"c":3, "d": 4, "e": 5} is invalid
+    c is not a fixed field
+    d is not a fixed field
+    e is not a fixed field
+```
+
 ### RequiredFields
 
 Checks if array contains keys corresponding to all required fields.

--- a/src/Validator/FieldSet/FixedFields.php
+++ b/src/Validator/FieldSet/FixedFields.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Validator\FieldSet;
+
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Validator;
+
+class FixedFields implements Validator
+{
+    /** @var string[] */
+    private readonly array $fields;
+
+    public function __construct(string ...$fields)
+    {
+        $this->fields = $fields;
+    }
+
+    public function validate(mixed $value): Result
+    {
+        if (!is_array($value)) {
+            $message = new Message('FixedFields Validator requires an array, %s given', [gettype($value)]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        $messages = [];
+        foreach ($value as $key => $item) {
+            if (!in_array($key, $this->fields)) {
+                $messages[] = new Message('%s is not a fixed field', [$key]);
+            }
+        }
+
+        if (!empty($messages)) {
+            return new Result($value, Result::INVALID, new MessageSet(null, ...$messages));
+        }
+
+        return new Result($value, Result::VALID);
+    }
+}

--- a/tests/Validator/FieldSet/FixedFieldsTest.php
+++ b/tests/Validator/FieldSet/FixedFieldsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Validator\FieldSet;
+
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Validator\FieldSet\FixedFields;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Validator\FieldSet\FixedFields
+ * @uses   \Membrane\Result\Message
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Result
+ */
+class FixedFieldsTest extends TestCase
+{
+    public function dataSetsWithIncorrectTypes(): array
+    {
+        return [
+            [123, 'integer'],
+            [1.23, 'double'],
+            ['string', 'string'],
+            [true, 'boolean'],
+            [null, 'NULL'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsWithIncorrectTypes
+     */
+    public function incorrectTypesReturnInvalidResults($input, $inputType): void
+    {
+        $expected = Result::invalid(
+            $input,
+            new MessageSet(
+                null,
+                new Message('FixedFields Validator requires an array, %s given', [$inputType])
+            )
+        );
+        $sut = new FixedFields();
+
+        $result = $sut->validate($input);
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function dataSetsToValidate(): array
+    {
+        return [
+            'no fixed fields, no input' => [
+                [],
+                [],
+                Result::valid([]),
+            ],
+            'no fixed fields, additional input' => [
+                [],
+                ['a' => 1],
+                Result::invalid(
+                    ['a' => 1],
+                    new MessageSet(null, new Message('%s is not a fixed field', ['a']))
+                ),
+            ],
+            'fixed fields, no input' => [
+                ['a', 'b', 'c'],
+                [],
+                Result::valid([]),
+            ],
+            'fixed fields, input for some fixed fields' => [
+                ['a', 'b', 'c'],
+                ['a' => 1, 'b' => 2],
+                Result::valid(['a' => 1, 'b' => 2]),
+            ],
+            'fixed fields, input for all fixed fields' => [
+                ['a', 'b', 'c'],
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
+            ],
+            'fixed fields, additional input only' => [
+                ['a', 'b', 'c'],
+                ['d' => 4, 'e' => 5],
+                Result::invalid(['d' => 4, 'e' => 5],
+                    new MessageSet(
+                        null,
+                        new Message('%s is not a fixed field', ['d']),
+                        new Message('%s is not a fixed field', ['e'])
+                    )),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToValidate
+     */
+    public function validateTest(array $fields, array $input, Result $expected): void
+    {
+        $sut = new FixedFields(...$fields);
+
+        $actual = $sut->validate($input);
+
+        self::assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
`FixedFields(...$fields)` validates that only fixed fields have been provided. 

This is work towards the Object Builder handling when additionalProperties is set to false.

i.e.

```php
$beforeChain = [];

...

if ($specification->additionalProperties === false) {
    $beforeChain[] = new FixedFields(...$specification->properties);
}

...

$beforeSet = new BeforeSet(...$beforeChain)
```