### PR TITLE
RequiredFields property set to readonly

### DIFF
--- a/src/Validator/FieldSet/RequiredFields.php
+++ b/src/Validator/FieldSet/RequiredFields.php
@@ -12,7 +12,7 @@ use Membrane\Validator;
 class RequiredFields implements Validator
 {
     /** @var string[] */
-    private array $fields;
+    private readonly array $fields;
 
     public function __construct(string ...$fields)
     {

--- a/tests/Validator/FieldSet/RequiredFieldsTest.php
+++ b/tests/Validator/FieldSet/RequiredFieldsTest.php
@@ -33,18 +33,18 @@ class RequiredFieldsTest extends TestCase
      * @test
      * @dataProvider dataSetsWithIncorrectTypes
      */
-    public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
+    public function incorrectTypesReturnInvalidResults($input, $inputType): void
     {
-        $requiredFields = new RequiredFields();
+        $sut = new RequiredFields();
         $expected = Result::invalid(
             $input,
             new MessageSet(
                 null,
-                new Message('RequiredFields Validator requires an array, %s given', [$expectedVars])
+                new Message('RequiredFields Validator requires an array, %s given', [$inputType])
             )
         );
 
-        $result = $requiredFields->validate($input);
+        $result = $sut->validate($input);
 
         self::assertEquals($expected, $result);
     }


### PR DESCRIPTION
Changed fields property to readonly as it is never intended to be written to after construction.

Also small change to naming convention on test arguments to better communicate what is being tested.