### PR TITLE
Objects Builder handles additionalProperties

### DIFF
--- a/docs/processors.md
+++ b/docs/processors.md
@@ -91,9 +91,8 @@ changes the datatype, those Processors will throw an Exception.
 
 ### After Set
 
-AfterSets are a specialized [Field](processors.md#field). They work on a List or Array as a whole and **will always be
-the final processor to
-act.**
+AfterSets are a specialized [Field](processors.md#field).  
+They work on a List or Array as a whole and **will always be the final processor to act.**
 
 ```php
 new AfterSet(...$chain)
@@ -108,9 +107,8 @@ they do not validate individual items within it.
 
 ### Before Set
 
-AfterSets are a specialized [Field](processors.md#field). They work on a List or Array as a whole and **will always be
-the first processor to
-act.**
+BeforeSets are a specialized [Field](processors.md#field).  
+They work on a List or Array as a whole and **will always be the first processor to act.**
 
 ```php
 new BeforeSet(...$chain)
@@ -122,6 +120,31 @@ new BeforeSet(...$chain)
 
 A BeforeSet takes a chain of [Filters](filters.md) or [Validators](validators.md) that act on the entire List/Array,
 they do not validate individual items within it.
+
+### Default Processor
+
+DefaultFields are a specialized [Field](processors.md#field).  
+They can be passed into a FieldSet to process individual items of data
+that are not processed by another [Field](processors.md#field).
+
+```php
+new DefaultProcessor($processor)
+```
+
+| Parameter  | Type      |
+|------------|-----------|
+| $processor | Processor |
+
+A DefaultField can instead be constructed from a chain of [Filters](filters.md) or [Validators](validators.md)
+using the following method.
+
+```php
+DefaultProcessor::fromFiltersAndValidators(...$chain)
+```
+
+| Parameter | Type                |
+|-----------|---------------------|
+| ...$chain | Filter or Validator |
 
 ## OpenAPI Processors
 

--- a/src/Exception/InvalidProcessorArguments.php
+++ b/src/Exception/InvalidProcessorArguments.php
@@ -21,11 +21,18 @@ class InvalidProcessorArguments extends RuntimeException
     public const NOT_ENOUGH_PROCESSORS = 1;
     public const TOO_MANY_BEFORESETS = 2;
     public const TOO_MANY_AFTERSETS = 3;
+    public const TOO_MANY_DEFAULTS = 4;
 
     public static function multipleProcessorsInCollection(): self
     {
         $message = 'Cannot use more than one Processor on a Collection';
         return new self($message, self::TOO_MANY_PROCESSORS);
+    }
+
+    public static function redundantProcessor(string $processorName): self
+    {
+        $message = sprintf('%s Processor expects at least two Processors', $processorName);
+        return new self($message, self::NOT_ENOUGH_PROCESSORS);
     }
 
     public static function multipleBeforeSetsInFieldSet(): self
@@ -40,9 +47,9 @@ class InvalidProcessorArguments extends RuntimeException
         return new self($message, self::TOO_MANY_AFTERSETS);
     }
 
-    public static function redundantProcessor(string $processorName): self
+    public static function multipleDefaultProcessorsInFieldSet(): self
     {
-        $message = sprintf('%s Processor expects at least two Processors', $processorName);
-        return new self($message, self::NOT_ENOUGH_PROCESSORS);
+        $message = 'Cannot use more than one DefaultProcessor on a FieldSet';
+        return new self($message, self::TOO_MANY_DEFAULTS);
     }
 }

--- a/src/OpenAPI/Specification/Objects.php
+++ b/src/OpenAPI/Specification/Objects.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Membrane\OpenAPI\Specification;
 
+use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
 use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
 
 class Objects extends APISchema
 {
     // @TODO support minProperties and maxProperties
+    public readonly bool|Schema $additionalProperties;
     /** @var Schema[] */
     public readonly array $properties;
     /** @var string[]|null */
@@ -20,6 +22,9 @@ class Objects extends APISchema
         if ($schema->type !== 'object') {
             throw CannotProcessOpenAPI::mismatchedType(self::class, 'object', $schema->type);
         }
+
+        assert(!$schema->additionalProperties instanceof Reference);
+        $this->additionalProperties = $schema->additionalProperties;
 
         $this->properties = array_filter($schema->properties ?? [], fn($p) => $p instanceof Schema);
 

--- a/src/Processor/DefaultProcessor.php
+++ b/src/Processor/DefaultProcessor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Processor;
+
+use Membrane\Filter;
+use Membrane\Processor;
+use Membrane\Result\FieldName;
+use Membrane\Result\Result;
+use Membrane\Validator;
+
+class DefaultProcessor implements Processor
+{
+    public function __construct(
+        private readonly Processor $processor
+    ) {
+    }
+
+    public static function fromFiltersAndValidators(Filter|Validator ...$chain): self
+    {
+        return new self(new Field('', ...$chain));
+    }
+
+    public function processes(): string
+    {
+        return $this->processor->processes();
+    }
+
+    public function process(FieldName $parentFieldName, mixed $value): Result
+    {
+        return $this->processor->process($parentFieldName, $value);
+    }
+}

--- a/src/Processor/FieldSet.php
+++ b/src/Processor/FieldSet.php
@@ -13,10 +13,11 @@ use Membrane\Result\Result;
 
 class FieldSet implements Processor
 {
-    /** @var Processor[] */
+    /** @var Processor[][] */
     private array $chain = [];
     private Processor $before;
     private Processor $after;
+    private Processor $default;
 
     public function __construct(
         private readonly string $processes,
@@ -33,8 +34,13 @@ class FieldSet implements Processor
                     throw InvalidProcessorArguments::multipleAfterSetsInFieldSet();
                 }
                 $this->after = $item;
+            } elseif ($item instanceof DefaultProcessor) {
+                if (isset($this->default)) {
+                    throw InvalidProcessorArguments::multipleDefaultProcessorsInFieldSet();
+                }
+                $this->default = $item;
             } else {
-                $this->chain[] = $item;
+                $this->chain[$item->processes()][] = $item;
             }
         }
     }
@@ -50,9 +56,7 @@ class FieldSet implements Processor
         $fieldSetResult = Result::noResult($value);
 
         if (isset($this->before)) {
-            $result = $this->before->process($fieldName, $value);
-            $value = $result->value;
-            $fieldSetResult = $fieldSetResult->merge($result);
+            $this->handleProcessor($this->before, $fieldName, $value, $fieldSetResult);
 
             if (!$fieldSetResult->isValid()) {
                 return $fieldSetResult;
@@ -79,12 +83,13 @@ class FieldSet implements Processor
                 );
             }
 
-            foreach ($this->chain as $item) {
-                $processes = $item->processes();
-                if (array_key_exists($processes, $value)) {
-                    $result = $item->process($fieldName, $value[$processes]);
-                    $value[$processes] = $result->value;
-                    $fieldSetResult = $fieldSetResult->merge($result);
+            foreach ($value as $fieldKey => $field) {
+                if (array_key_exists($fieldKey, $this->chain)) {
+                    foreach ($this->chain[$fieldKey] as $processor) {
+                        $this->handleProcessor($processor, $fieldName, $value[$fieldKey], $fieldSetResult);
+                    }
+                } elseif (isset($this->default)) {
+                    $this->handleProcessor($this->default, $fieldName, $value[$fieldKey], $fieldSetResult);
                 }
             }
         }
@@ -92,8 +97,7 @@ class FieldSet implements Processor
         $fieldSetResult = $fieldSetResult->merge(Result::noResult($value));
 
         if (isset($this->after) && $fieldSetResult->isValid()) {
-            $result = $this->after->process($fieldName, $value);
-            $fieldSetResult = $fieldSetResult->merge($result);
+            $this->handleProcessor($this->after, $fieldName, $value, $fieldSetResult);
 
             if (!$fieldSetResult->isValid()) {
                 return $fieldSetResult;
@@ -101,5 +105,16 @@ class FieldSet implements Processor
         }
 
         return $fieldSetResult;
+    }
+
+    private function handleProcessor(
+        Processor $processor,
+        FieldName $fieldName,
+        mixed &$value,
+        Result &$fieldSetResult
+    ): void {
+        $result = $processor->process($fieldName, $value);
+        $value = $result->value;
+        $fieldSetResult = $fieldSetResult->merge($result);
     }
 }

--- a/tests/OpenAPI/Builder/ObjectsTest.php
+++ b/tests/OpenAPI/Builder/ObjectsTest.php
@@ -10,9 +10,11 @@ use Membrane\OpenAPI\Processor\AnyOf;
 use Membrane\OpenAPI\Specification;
 use Membrane\Processor;
 use Membrane\Processor\BeforeSet;
+use Membrane\Processor\DefaultProcessor;
 use Membrane\Processor\Field;
 use Membrane\Processor\FieldSet;
 use Membrane\Validator\Collection\Contained;
+use Membrane\Validator\FieldSet\FixedFields;
 use Membrane\Validator\FieldSet\RequiredFields;
 use Membrane\Validator\Type\IsArray;
 use Membrane\Validator\Type\IsInt;
@@ -30,9 +32,11 @@ use PHPUnit\Framework\TestCase;
  * @uses   \Membrane\OpenAPI\Specification\Numeric
  * @uses   \Membrane\OpenAPI\Specification\Strings
  * @uses   \Membrane\Processor\BeforeSet
+ * @uses   \Membrane\Processor\DefaultProcessor
  * @uses   \Membrane\Processor\Field
  * @uses   \Membrane\Processor\FieldSet
  * @uses   \Membrane\Validator\Collection\Contained
+ * @uses   \Membrane\Validator\FieldSet\FixedFields
  * @uses   \Membrane\Validator\FieldSet\RequiredFields
  */
 class ObjectsTest extends TestCase
@@ -67,6 +71,18 @@ class ObjectsTest extends TestCase
                 new Specification\Objects('', new Schema(['type' => 'object'])),
                 new FieldSet('', new BeforeSet(new IsArray())),
             ],
+            'additionalProperties set to false' => [
+                new Specification\Objects(
+                    '', new Schema([
+                        'type' => 'object',
+                        'properties' => [
+                            'a' => new Schema(['type' => 'integer']),
+                        ],
+                        'additionalProperties' => false,
+                    ])
+                ),
+                new FieldSet('', new BeforeSet(new IsArray(), new FixedFields('a')), new Field('a', new IsInt())),
+            ],
             'detailed input' => [
                 new Specification\Objects(
                     '',
@@ -81,6 +97,7 @@ class ObjectsTest extends TestCase
                             'format' => 'pet',
                             'enum' => [['id' => 5, 'name' => 'Blink'], null],
                             'nullable' => true,
+                            'additionalProperties' => new Schema(['type' => 'string']),
                         ]
                     )
                 ),
@@ -94,6 +111,7 @@ class ObjectsTest extends TestCase
                             new Contained([['id' => 5, 'name' => 'Blink'], null]),
                             new RequiredFields('id', 'name')
                         ),
+                        DefaultProcessor::fromFiltersAndValidators(new IsString()),
                         new Field('id', new IsInt()),
                         new Field('name', new IsString())
                     )

--- a/tests/OpenAPI/Specification/ObjectsTest.php
+++ b/tests/OpenAPI/Specification/ObjectsTest.php
@@ -38,6 +38,7 @@ class ObjectsTest extends TestCase
             'default values' => [
                 new Schema(['type' => 'object',]),
                 [
+                    'additionalProperties' => true,
                     'properties' => [],
                     'required' => null,
                     'enum' => null,
@@ -45,9 +46,21 @@ class ObjectsTest extends TestCase
                     'nullable' => false,
                 ],
             ],
-            'assigned values' => [
+            'additionalProperties assigned false' => [
+                new Schema(['type' => 'object', 'additionalProperties' => false]),
+                [
+                    'additionalProperties' => false,
+                    'properties' => [],
+                    'required' => null,
+                    'enum' => null,
+                    'format' => null,
+                    'nullable' => false,
+                ],
+            ],
+            'all relevant keywords assigned values' => [
                 new Schema([
                     'type' => 'object',
+                    'additionalProperties' => new Schema(['type' => 'string']),
                     'properties' => ['id' => new Schema(['type' => 'integer'])],
                     'required' => ['id'],
                     'enum' => [false, null],
@@ -55,6 +68,7 @@ class ObjectsTest extends TestCase
                     'nullable' => true,
                 ]),
                 [
+                    'additionalProperties' => new Schema(['type' => 'string']),
                     'properties' => ['id' => new Schema(['type' => 'integer'])],
                     'required' => ['id'],
                     'enum' => [false, null],
@@ -74,11 +88,7 @@ class ObjectsTest extends TestCase
         $sut = new Objects('', $schema);
 
         foreach ($expected as $key => $value) {
-            if ($key === 'properties') {
-                self::assertEquals($value, $sut->$key, sprintf('%s does not meet expected value', $key));
-            } else {
-                self::assertSame($value, $sut->$key, sprintf('%s does not meet expected value', $key));
-            }
+            self::assertEquals($value, $sut->$key, sprintf('%s does not meet expected value', $key));
         }
     }
 }

--- a/tests/Processor/DefaultProcessorTest.php
+++ b/tests/Processor/DefaultProcessorTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Processor;
+
+use Membrane\Filter;
+use Membrane\Processor\DefaultProcessor;
+use Membrane\Result\FieldName;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Validator;
+use Membrane\Validator\Utility\Fails;
+use Membrane\Validator\Utility\Indifferent;
+use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Membrane\Processor\DefaultProcessor
+ * @uses   \Membrane\Processor\Field
+ * @uses   \Membrane\Result\FieldName
+ * @uses   \Membrane\Result\Message
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Validator\Utility\Fails
+ * @uses   \Membrane\Validator\Utility\Indifferent
+ * @uses   \Membrane\Validator\Utility\Passes
+ */
+class DefaultProcessorTest extends TestCase
+{
+    /** @test */
+    public function processesTest(): void
+    {
+        $expected = '';
+        $sut = DefaultProcessor::fromFiltersAndValidators();
+
+        $actual = $sut->processes();
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function dataSetsForFiltersOrValidators(): array
+    {
+        $incrementFilter = new class implements Filter {
+            public function filter(mixed $value): Result
+            {
+                foreach (array_keys($value) as $key) {
+                    $value[$key]++;
+                }
+
+                return Result::noResult($value);
+            }
+        };
+
+        $evenFilter = new class implements Filter {
+            public function filter(mixed $value): Result
+            {
+                foreach (array_keys($value) as $key) {
+                    $value[$key] *= 2;
+                }
+
+                return Result::noResult($value);
+            }
+        };
+
+        $evenValidator = new class implements Validator {
+            public function validate(mixed $value): Result
+            {
+                foreach (array_keys($value) as $key) {
+                    if ($value[$key] % 2 !== 0) {
+                        return Result::invalid(
+                            $value,
+                            new MessageSet(
+                                null,
+                                new Message('not even', [])
+                            )
+                        );
+                    }
+                }
+                return Result::valid($value);
+            }
+        };
+
+        return [
+            'checks it can return valid' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
+                new Passes(),
+            ],
+            'checks it can return invalid' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3],
+                    new MessageSet(
+                        new FieldName('', 'parent field'),
+                        new Message('I always fail', [])
+                    )),
+                new Fails(),
+            ],
+            'checks it can return noresult' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::noResult(['a' => 1, 'b' => 2, 'c' => 3]),
+                new Indifferent(),
+            ],
+            'checks it keeps track of previous results' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
+                new Passes(),
+                new Indifferent(),
+                new Indifferent(),
+            ],
+            'checks it can make changes to value' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::noResult(['a' => 2, 'b' => 3, 'c' => 4]),
+                $incrementFilter,
+            ],
+            'checks that changes made to value persist' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::noResult(['a' => 3, 'b' => 4, 'c' => 5]),
+                $incrementFilter,
+                $incrementFilter,
+            ],
+            'checks that chain runs in correct order' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3],
+                    new MessageSet(
+                        new FieldName('', 'parent field'),
+                        new Message('not even', [])
+                    )),
+                $evenValidator,
+                $evenFilter,
+            ],
+            'checks that chain stops as soon as result is invalid' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::invalid(['a' => 2, 'b' => 3, 'c' => 4],
+                    new MessageSet(
+                        new FieldName('', 'parent field'),
+                        new Message('not even', [])
+                    )),
+                $incrementFilter,
+                $evenValidator,
+                $incrementFilter,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsForFiltersOrValidators
+     */
+    public function processesCallsFilterOrValidatorMethods(
+        mixed $input,
+        Result $expected,
+        Filter|Validator ...$chain
+    ): void {
+        $afterSet = DefaultProcessor::fromFiltersAndValidators(...$chain);
+
+        $output = $afterSet->process(new FieldName('parent field'), $input);
+
+        self::assertEquals($expected, $output);
+    }
+}

--- a/tests/Processor/FieldsetTest.php
+++ b/tests/Processor/FieldsetTest.php
@@ -9,6 +9,7 @@ use Membrane\Filter;
 use Membrane\Processor;
 use Membrane\Processor\AfterSet;
 use Membrane\Processor\BeforeSet;
+use Membrane\Processor\DefaultProcessor;
 use Membrane\Processor\Field;
 use Membrane\Processor\FieldSet;
 use Membrane\Result\FieldName;
@@ -23,6 +24,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Membrane\Exception\InvalidProcessorArguments
  * @uses   \Membrane\Processor\AfterSet
  * @uses   \Membrane\Processor\BeforeSet
+ * @uses   \Membrane\Processor\DefaultProcessor
  * @uses   \Membrane\Result\Result
  * @uses   \Membrane\Result\MessageSet
  * @uses   \Membrane\Result\Message
@@ -60,9 +62,7 @@ class FieldsetTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function onlyAcceptsOneBeforeSet(): void
     {
         $beforeSet = new BeforeSet();
@@ -71,9 +71,7 @@ class FieldsetTest extends TestCase
         new FieldSet('field to process', $beforeSet, $beforeSet);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function onlyAcceptsOneAfterSet(): void
     {
         $afterSet = new AfterSet();
@@ -82,9 +80,16 @@ class FieldsetTest extends TestCase
         new FieldSet('field to process', $afterSet, $afterSet);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
+    public function onlyAcceptsOneDefaultField(): void
+    {
+        $defaultField = DefaultProcessor::fromFiltersAndValidators();
+        self::expectExceptionObject(InvalidProcessorArguments::multipleDefaultProcessorsInFieldSet());
+
+        new FieldSet('field to process', $defaultField, $defaultField);
+    }
+
+    /** @test */
     public function processesTest(): void
     {
         $fieldName = 'field to process';
@@ -95,9 +100,7 @@ class FieldsetTest extends TestCase
         self::assertEquals($fieldName, $output);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function processMethodWithNoChainReturnsNoResult(): void
     {
         $value = [];
@@ -109,9 +112,7 @@ class FieldsetTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function processMethodCallsFieldProcessesMethod(): void
     {
         $input = ['a' => 1, 'b' => 2, 'c' => 3];
@@ -123,9 +124,7 @@ class FieldsetTest extends TestCase
         $fieldset->process(new FieldName('Parent field'), $input);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function processCallsBeforeSetProcessOnceAndProcessesNever(): void
     {
         $input = ['a' => 1, 'b' => 2, 'c' => 3];
@@ -141,9 +140,7 @@ class FieldsetTest extends TestCase
         $fieldset->process(new FieldName('Parent field'), $input);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function processCallsAfterSetProcessOnceAndProcessesNever(): void
     {
         $input = ['a' => 1, 'b' => 2, 'c' => 3];
@@ -165,6 +162,13 @@ class FieldsetTest extends TestCase
             public function filter(mixed $value): Result
             {
                 return Result::noResult(++$value);
+            }
+        };
+
+        $decrementFilter = new class implements Filter {
+            public function filter(mixed $value): Result
+            {
+                return Result::noResult(--$value);
             }
         };
 
@@ -217,6 +221,12 @@ class FieldsetTest extends TestCase
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 Result::noResult(['a' => 2, 'b' => 2, 'c' => 3]),
                 new Field('a', $incrementFilter),
+            ],
+            'DefaultProcessor only processes fields not processed by other Field Processors' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                Result::noResult(['a' => 2, 'b' => 1, 'c' => 2]),
+                new Field('a', $incrementFilter),
+                DefaultProcessor::fromFiltersAndValidators($decrementFilter),
             ],
             'Field processed values persist' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],


### PR DESCRIPTION
- add Processor/DefaultProcessor
- refactor FieldSet to handle DefaultProcessor
- add additionalProperties to Object Specification
- add documentation for DefaultProcessor
- fix documentation error on BeforeSet