### PR TITLE
Filters, Processors and Validators can be cast to string

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -3,19 +3,42 @@
 Filters attempt to change data to the correct format.  
 If you do not want to change incoming data; See [Validators](validators.md)
 
-All Filters implement the Membrane\Filter interface:
+## Interface
+
+All Filters implement the `Membrane\Filter` interface:
 
 ```php
 interface Filter
 {
     public function filter(mixed $value): Result;
+    
+    public function __toString(): string;
 }
 ```
+
+## Methods
+
+### Filter
+
+```php
+public function filter(mixed $value): Result
+```
+
+`filter()` will return a [Result](result.md) object detailing if and how the given value was filtered.
 
 [Results](result.md) returned from Filters will always be [Result::NO_RESULT or Result::INVALID](result.md#result).  
 Filters cannot validate data, they can only invalidate data.
 
 Best practice is to use Filters in combination with Validators to ensure data is returned in the correct format.
+
+### __ToString
+
+```php
+__toString(): string
+```
+
+`__toString()` returns a plain english description of what the filter does, you may find this useful for debugging.
+This method can also be called implicitly by typecasting your filter as string. i.e. `(string) $filter`
 
 ## Create Object
 

--- a/docs/processors.md
+++ b/docs/processors.md
@@ -4,14 +4,34 @@ For most use-cases you will not need to interact with Processors directly,
 Membrane will build a Processor object for you behind the scenes
 tailored to validating data against your Specification(s).
 
-Each Processor is unique, designed with a specific purpose in mind.  
-That said, all Processors have two methods in common:
+## Interface
+
+All Processors implement the `Membrane\Processor` interface:
+
+```php
+interface Processor
+{
+    public function processes(): string;
+
+    public function process(FieldName $parentFieldName, mixed $value): Result;
+    
+    public function __toString(): string;
+}
+```
+
+## Methods
+
+All Processors contain the following methods:
+
+### Processes
 
 ```php
 processes(): string
 ```
 
 `processes()` returns the name of the field it processes
+
+### Process
 
 ```php
 process(FieldName $parentFieldName, mixed $value): Result
@@ -21,6 +41,15 @@ process(FieldName $parentFieldName, mixed $value): Result
 It also asks for the `$parentFieldName` in the case of nested Processors this will make
 your [MessageSet's](result.md#message-set) [FieldName](result.md#field-name)
 more precise.
+
+### __ToString
+
+```php
+__toString(): string
+```
+
+`__toString()` returns a plain english description of what the processor does, you may find this useful for debugging.
+This method can also be called implicitly by typecasting your processor as string. i.e. `(string) $processor`
 
 ## General-Use Processors
 

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -3,16 +3,42 @@
 Validators check data is in the correct format, Validators will never change data.  
 If you expect that you'll need to change incoming data; See [Filters](filters.md).
 
-All Validators implement the Membrane\Validator interface:
+## Interface
+
+All Validators implement the `Membrane\Validator` interface:
 
 ```php
 interface Validator
 {
     public function validate(mixed $value): Result;
+    
+    public function __toString(): string;
 }
 ```
 
-[Results](result.md) returned from Validators will always be [Result::VALID or Result::INVALID](result.md#result).
+## Methods
+
+All Validators contain the following methods:
+
+### Validate
+
+```php
+public function validate(mixed $value): Result
+```
+
+`validate()` will return a [Result](result.md) object detailing if and how the given value was validated.
+
+[Results](result.md) returned from Validators will always be [Result::VALID or Result::INVALID](result.md#result).  
+(Only the `Validators\Utility` namespace contains exceptions to this rule).
+
+### __ToString
+
+```php
+__toString(): string
+```
+
+`__toString()` returns a plain english description of what the validator does, you may find this useful for debugging.
+This method can also be called implicitly by typecasting your validator as string. i.e. `(string) $validator`
 
 ## Collection
 

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -9,4 +9,6 @@ use Membrane\Result\Result;
 interface Filter
 {
     public function filter(mixed $value): Result;
+
+    public function __toString();
 }

--- a/src/Filter/CreateObject/FromArray.php
+++ b/src/Filter/CreateObject/FromArray.php
@@ -16,6 +16,11 @@ class FromArray implements Filter
     ) {
     }
 
+    public function __toString(): string
+    {
+        return sprintf('calls %s::fromArray', $this->className);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!method_exists($this->className, 'fromArray')) {

--- a/src/Filter/CreateObject/WithNamedArguments.php
+++ b/src/Filter/CreateObject/WithNamedArguments.php
@@ -17,6 +17,11 @@ class WithNamedArguments implements Filter
     ) {
     }
 
+    public function __toString(): string
+    {
+        return sprintf('construct an instance of "%s" from named arguments contained in self', $this->className);
+    }
+
     public function filter(mixed $value): Result
     {
         try {

--- a/src/Filter/Shape/Collect.php
+++ b/src/Filter/Shape/Collect.php
@@ -21,6 +21,20 @@ class Collect implements Filter
         $this->fields = $fields;
     }
 
+    public function __toString(): string
+    {
+        if ($this->fields === []) {
+            return '';
+        }
+
+        return sprintf(
+            'collect "' .
+            implode('", "', $this->fields) .
+            '" from self and append their values to a nested collection "%s"',
+            $this->newField
+        );
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Delete.php
+++ b/src/Filter/Shape/Delete.php
@@ -19,6 +19,15 @@ class Delete implements Filter
         $this->fieldNames = $fieldNames;
     }
 
+    public function __toString(): string
+    {
+        if ($this->fieldNames === []) {
+            return '';
+        }
+
+        return sprintf('delete "' . implode('", "', $this->fieldNames) . '" from self');
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Nest.php
+++ b/src/Filter/Shape/Nest.php
@@ -21,6 +21,20 @@ class Nest implements Filter
         $this->fields = $fields;
     }
 
+    public function __toString(): string
+    {
+        if ($this->fields === []) {
+            return '';
+        }
+
+        return sprintf(
+            'collect "' .
+            implode('", "', $this->fields) .
+            '" from self and append them to a nested field set "%s"',
+            $this->newField
+        );
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Pluck.php
+++ b/src/Filter/Shape/Pluck.php
@@ -21,6 +21,18 @@ class Pluck implements Filter
         $this->fieldNames = $fieldNames;
     }
 
+    public function __toString(): string
+    {
+        if ($this->fieldNames === []) {
+            return '';
+        }
+
+        return sprintf(
+            'collect "' . implode('", "', $this->fieldNames) . '" from "%s" and append them to self',
+            $this->fieldSet
+        );
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Rename.php
+++ b/src/Filter/Shape/Rename.php
@@ -24,6 +24,11 @@ class Rename implements Filter
         $this->new = $new;
     }
 
+    public function __toString(): string
+    {
+        return sprintf('rename "%s" to "%s"', $this->old, $this->new);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Truncate.php
+++ b/src/Filter/Shape/Truncate.php
@@ -19,6 +19,11 @@ class Truncate implements Filter
         }
     }
 
+    public function __toString(): string
+    {
+        return sprintf('truncate self to %d fields or less', $this->maxLength);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/String/JsonDecode.php
+++ b/src/Filter/String/JsonDecode.php
@@ -11,6 +11,11 @@ use Membrane\Result\Result;
 
 class JsonDecode implements Filter
 {
+    public function __toString(): string
+    {
+        return 'convert from json to a PHP value';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Filter/Type/ToBool.php
+++ b/src/Filter/Type/ToBool.php
@@ -11,6 +11,11 @@ use Membrane\Result\Result;
 
 class ToBool implements Filter
 {
+    public function __toString(): string
+    {
+        return 'convert to a boolean';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_scalar($value)) {

--- a/src/Filter/Type/ToDateTime.php
+++ b/src/Filter/Type/ToDateTime.php
@@ -19,6 +19,11 @@ class ToDateTime implements Filter
     ) {
     }
 
+    public function __toString(): string
+    {
+        return 'convert to a DateTime';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Filter/Type/ToFloat.php
+++ b/src/Filter/Type/ToFloat.php
@@ -11,6 +11,12 @@ use Membrane\Result\Result;
 
 class ToFloat implements Filter
 {
+    public function __toString(): string
+    {
+        return 'convert to a float';
+    }
+
+
     public function filter(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Filter/Type/ToInt.php
+++ b/src/Filter/Type/ToInt.php
@@ -11,6 +11,11 @@ use Membrane\Result\Result;
 
 class ToInt implements Filter
 {
+    public function __toString(): string
+    {
+        return 'convert to an integer';
+    }
+
     public function filter(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Filter/Type/ToList.php
+++ b/src/Filter/Type/ToList.php
@@ -11,6 +11,11 @@ use Membrane\Result\Result;
 
 class ToList implements Filter
 {
+    public function __toString(): string
+    {
+        return 'convert to a list';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Type/ToNumber.php
+++ b/src/Filter/Type/ToNumber.php
@@ -11,6 +11,11 @@ use Membrane\Result\Result;
 
 class ToNumber implements Filter
 {
+    public function __toString(): string
+    {
+        return 'convert to a number';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_numeric($value)) {

--- a/src/Filter/Type/ToString.php
+++ b/src/Filter/Type/ToString.php
@@ -11,6 +11,11 @@ use Membrane\Result\Result;
 
 class ToString implements Filter
 {
+    public function __toString(): string
+    {
+        return 'convert to a string';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!(is_object($value) || is_null($value) || is_scalar($value))) {
@@ -26,6 +31,6 @@ class ToString implements Filter
             return Result::invalid($value, new MessageSet(null, $message));
         }
 
-        return Result::noResult((string) $value);
+        return Result::noResult((string)$value);
     }
 }

--- a/src/OpenAPI/Filter/HTTPParameters.php
+++ b/src/OpenAPI/Filter/HTTPParameters.php
@@ -11,6 +11,11 @@ use Membrane\Result\Result;
 
 class HTTPParameters implements Filter
 {
+    public function __toString(): string
+    {
+        return 'convert query string to a field set of query parameters';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/OpenAPI/Filter/PathMatcher.php
+++ b/src/OpenAPI/Filter/PathMatcher.php
@@ -17,6 +17,11 @@ class PathMatcher implements Filter
     {
     }
 
+    public function __toString(): string
+    {
+        return 'convert url to a field set of path parameters';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/OpenAPI/Processor/AllOf.php
+++ b/src/OpenAPI/Processor/AllOf.php
@@ -24,6 +24,12 @@ class AllOf implements Processor
         $this->processors = $processors;
     }
 
+    public function __toString(): string
+    {
+        return "All of the following:\n\t" .
+            implode(".\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->processors)) . '.';
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/OpenAPI/Processor/AnyOf.php
+++ b/src/OpenAPI/Processor/AnyOf.php
@@ -24,6 +24,12 @@ class AnyOf implements Processor
         $this->fieldSets = $fieldSets;
     }
 
+    public function __toString(): string
+    {
+        return "Any of the following:\n\t" .
+            implode(".\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->fieldSets)) . '.';
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/OpenAPI/Processor/Json.php
+++ b/src/OpenAPI/Processor/Json.php
@@ -19,6 +19,15 @@ class Json implements Processor
         $this->jsonDecode = new Field('', new JsonDecode());
     }
 
+    public function __toString()
+    {
+        $processes = $this->processes();
+
+        return sprintf('"%s":', $processes) .
+            (string)$this->jsonDecode .
+            str_replace(sprintf('"%s":', $processes), '', (string)$this->wrapped);
+    }
+
     public function processes(): string
     {
         return $this->wrapped->processes();

--- a/src/OpenAPI/Processor/OneOf.php
+++ b/src/OpenAPI/Processor/OneOf.php
@@ -24,6 +24,12 @@ class OneOf implements Processor
         $this->fieldSets = $fieldSets;
     }
 
+    public function __toString(): string
+    {
+        return "One of the following:\n\t" .
+            implode(".\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->fieldSets)) . '.';
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/OpenAPI/Processor/Request.php
+++ b/src/OpenAPI/Processor/Request.php
@@ -20,6 +20,16 @@ class Request implements Processor
     ) {
     }
 
+    public function __toString()
+    {
+        if ($this->processors === []) {
+            return 'Parse PSR-7 request';
+        }
+
+        return "Parse PSR-7 request:\n\t" .
+            implode(".\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->processors)) . '.';
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -12,4 +12,6 @@ interface Processor
     public function processes(): string;
 
     public function process(FieldName $parentFieldName, mixed $value): Result;
+
+    public function __toString();
 }

--- a/src/Processor/AfterSet.php
+++ b/src/Processor/AfterSet.php
@@ -19,6 +19,11 @@ class AfterSet implements Processor
         $this->field = new Field('', ...$chain);
     }
 
+    public function __toString(): string
+    {
+        return (string)$this->field;
+    }
+
     public function processes(): string
     {
         return $this->field->processes();

--- a/src/Processor/BeforeSet.php
+++ b/src/Processor/BeforeSet.php
@@ -19,6 +19,11 @@ class BeforeSet implements Processor
         $this->field = new Field('', ...$chain);
     }
 
+    public function __toString(): string
+    {
+        return (string)$this->field;
+    }
+
     public function processes(): string
     {
         return $this->field->processes();

--- a/src/Processor/Collection.php
+++ b/src/Processor/Collection.php
@@ -44,6 +44,39 @@ class Collection implements Processor
         }
     }
 
+    public function __toString(): string
+    {
+        if ($this->processes === '') {
+            return '';
+        }
+
+        $conditions = [];
+
+        if (isset($this->before)) {
+            $condition = (string)$this->before;
+            if ($condition !== '') {
+                $conditions[] = sprintf('Firstly "%s":', $this->processes) . $condition;
+            }
+        }
+
+        if (isset($this->each)) {
+            $condition = (string)$this->each;
+            if ($condition !== '') {
+                $conditions[] = sprintf('Each field in "%s":', $this->processes) .
+                    str_replace(sprintf('"%s":', $this->each->processes()), '', $condition);
+            }
+        }
+
+        if (isset($this->after)) {
+            $condition = (string)$this->after;
+            if ($condition !== '') {
+                $conditions[] = sprintf('Lastly "%s":', $this->processes) . $condition;
+            }
+        }
+
+        return $conditions === [] ? '' : implode("\n", $conditions);
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/Processor/DefaultProcessor.php
+++ b/src/Processor/DefaultProcessor.php
@@ -22,6 +22,11 @@ class DefaultProcessor implements Processor
         return new self(new Field('', ...$chain));
     }
 
+    public function __toString(): string
+    {
+        return (string)$this->processor;
+    }
+
     public function processes(): string
     {
         return $this->processor->processes();

--- a/src/Processor/Field.php
+++ b/src/Processor/Field.php
@@ -23,6 +23,25 @@ class Field implements Processor
         $this->chain = $chain;
     }
 
+    public function __toString(): string
+    {
+        $conditions = [];
+        foreach ($this->chain as $item) {
+            $condition = (string)$item;
+            if ($condition !== '') {
+                $conditions[] = sprintf("\n\t- %s", $item);
+            }
+        }
+
+        if ($conditions === []) {
+            return '';
+        } else {
+            return ($this->processes === '' ? '' : sprintf('"%s":', $this->processes)) .
+                implode('.', $conditions) .
+                '.';
+        }
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/Processor/FieldSet.php
+++ b/src/Processor/FieldSet.php
@@ -45,6 +45,49 @@ class FieldSet implements Processor
         }
     }
 
+    public function __toString(): string
+    {
+        if ($this->processes === '') {
+            return '';
+        }
+
+        $conditions = [];
+
+        if (isset($this->before)) {
+            $condition = (string)$this->before;
+            if ($condition !== '') {
+                $conditions[] = sprintf('Firstly "%s":', $this->processes) . $condition;
+            }
+        }
+
+        if ($this->chain !== []) {
+            foreach ($this->chain as $processors) {
+                foreach ($processors as $processor) {
+                    $condition = $processor->processes() === '' ? '' : (string)$processor;
+                    if ($condition !== '') {
+                        $conditions[] = sprintf('"%s"->', $this->processes) . $condition;
+                    }
+                }
+            }
+        }
+
+        if (isset($this->default)) {
+            $condition = (string)$this->default;
+            if ($condition !== '') {
+                $conditions[] = sprintf('Any other fields in "%s":', $this->processes) . $condition;
+            }
+        }
+
+        if (isset($this->after)) {
+            $condition = (string)$this->after;
+            if ($condition !== '') {
+                $conditions[] = sprintf('Lastly "%s":', $this->processes) . $condition;
+            }
+        }
+
+        return $conditions === [] ? '' : implode("\n", $conditions);
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -9,4 +9,6 @@ use Membrane\Result\Result;
 interface Validator
 {
     public function validate(mixed $value): Result;
+
+    public function __toString(): string;
 }

--- a/src/Validator/Collection/Contained.php
+++ b/src/Validator/Collection/Contained.php
@@ -17,6 +17,16 @@ class Contained implements Validator
     ) {
     }
 
+    public function __toString(): string
+    {
+        if ($this->enum === []) {
+            return 'will return invalid';
+        }
+
+        return sprintf('is one of the following values: ') .
+            implode(', ', array_map(fn($p) => json_encode($p), $this->enum));
+    }
+
     public function validate(mixed $value): Result
     {
         if (!in_array($value, $this->enum, true)) {

--- a/src/Validator/Collection/Count.php
+++ b/src/Validator/Collection/Count.php
@@ -20,6 +20,23 @@ class Count implements Validator
     ) {
     }
 
+    public function __toString(): string
+    {
+        if ($this->min <= 0 && $this->max === null) {
+            return 'will return valid';
+        }
+
+        $conditions = [];
+        if ($this->min > 0) {
+            $conditions[] = sprintf('greater than %d', $this->min);
+        }
+        if ($this->max !== null) {
+            $conditions[] = sprintf('fewer than %d', $this->max);
+        }
+
+        return 'has ' . implode(' and ', $conditions) . ' values';
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Collection/Identical.php
+++ b/src/Validator/Collection/Identical.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class Identical implements Validator
 {
+    public function __toString(): string
+    {
+        return 'contains only identical values';
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Collection/Unique.php
+++ b/src/Validator/Collection/Unique.php
@@ -11,8 +11,9 @@ use Membrane\Validator;
 
 class Unique implements Validator
 {
-    public function __construct()
+    public function __toString(): string
     {
+        return 'contains only unique values';
     }
 
     public function validate(mixed $value): Result

--- a/src/Validator/DateTime/Range.php
+++ b/src/Validator/DateTime/Range.php
@@ -18,6 +18,23 @@ class Range implements Validator
     ) {
     }
 
+    public function __toString(): string
+    {
+        if ($this->min === null && $this->max === null) {
+            return 'will return valid';
+        }
+
+        $conditions = [];
+        if ($this->min !== null) {
+            $conditions[] = sprintf('after %s', $this->min->format('D, d M Y H:i:s'));
+        }
+        if ($this->max !== null) {
+            $conditions[] = sprintf('before %s', $this->max->format('D, d M Y H:i:s'));
+        }
+
+        return 'is ' . implode(' and ', $conditions);
+    }
+
     public function validate(mixed $value): Result
     {
         if ($this->min !== null && $value < $this->min) {

--- a/src/Validator/DateTime/RangeDelta.php
+++ b/src/Validator/DateTime/RangeDelta.php
@@ -22,6 +22,23 @@ class RangeDelta implements Validator
         $this->max = $max === null ? null : (new DateTime())->add($max);
     }
 
+    public function __toString(): string
+    {
+        if ($this->min === null && $this->max === null) {
+            return 'will return valid';
+        }
+
+        $conditions = [];
+        if ($this->min !== null) {
+            $conditions[] = sprintf('after %s', $this->min->format('D, d M Y H:i:s'));
+        }
+        if ($this->max !== null) {
+            $conditions[] = sprintf('before %s', $this->max->format('D, d M Y H:i:s'));
+        }
+
+        return 'is ' . implode(' and ', $conditions);
+    }
+
     public function validate(mixed $value): Result
     {
         if ($this->min !== null && $value < $this->min) {

--- a/src/Validator/FieldSet/FixedFields.php
+++ b/src/Validator/FieldSet/FixedFields.php
@@ -19,6 +19,15 @@ class FixedFields implements Validator
         $this->fields = $fields;
     }
 
+    public function __toString(): string
+    {
+        if ($this->fields === []) {
+            return 'does not contain any fields';
+        }
+
+        return 'only contains the following fields: "' . implode('", "', $this->fields) . '"';
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/FieldSet/RequiredFields.php
+++ b/src/Validator/FieldSet/RequiredFields.php
@@ -19,6 +19,15 @@ class RequiredFields implements Validator
         $this->fields = $fields;
     }
 
+    public function __toString(): string
+    {
+        if ($this->fields === []) {
+            return 'will return valid';
+        }
+
+        return 'contains the following fields: "' . implode('", "', $this->fields) . '"';
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Numeric/Maximum.php
+++ b/src/Validator/Numeric/Maximum.php
@@ -17,6 +17,11 @@ class Maximum implements Validator
     ) {
     }
 
+    public function __toString(): string
+    {
+        return 'is less than ' . ($this->exclusive ? '' : 'or equal to ') . $this->max;
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_numeric($value)) {

--- a/src/Validator/Numeric/Minimum.php
+++ b/src/Validator/Numeric/Minimum.php
@@ -17,6 +17,11 @@ class Minimum implements Validator
     ) {
     }
 
+    public function __toString(): string
+    {
+        return 'is greater than ' . ($this->exclusive ? '' : 'or equal to ') . $this->min;
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_numeric($value)) {

--- a/src/Validator/Numeric/MultipleOf.php
+++ b/src/Validator/Numeric/MultipleOf.php
@@ -12,14 +12,19 @@ use Membrane\Validator;
 
 class MultipleOf implements Validator
 {
-    private readonly float|int $multiple;
+    private readonly float|int $factor;
 
     public function __construct(float|int $factor)
     {
         if ($factor <= 0) {
             throw new Exception('MultipleOf validator does not support numbers of zero or less');
         }
-        $this->multiple = $factor;
+        $this->factor = $factor;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('is a multiple of %d', $this->factor);
     }
 
     public function validate(mixed $value): Result
@@ -31,7 +36,7 @@ class MultipleOf implements Validator
             );
         }
 
-        if (abs(fmod((float)$value, $this->multiple)) === 0.0) {
+        if (abs(fmod((float)$value, $this->factor)) === 0.0) {
             return Result::valid($value);
         }
 
@@ -39,7 +44,7 @@ class MultipleOf implements Validator
             $value,
             new MessageSet(
                 null,
-                new Message('Number is expected to be a multiple of %d', [$this->multiple])
+                new Message('Number is expected to be a multiple of %d', [$this->factor])
             )
         );
     }

--- a/src/Validator/String/DateString.php
+++ b/src/Validator/String/DateString.php
@@ -16,6 +16,11 @@ class DateString implements Validator
     {
     }
 
+    public function __toString(): string
+    {
+        return sprintf('matches the DateTime format: "%s"', $this->format);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Validator/String/Length.php
+++ b/src/Validator/String/Length.php
@@ -17,6 +17,23 @@ class Length implements Validator
     ) {
     }
 
+    public function __toString(): string
+    {
+        if ($this->min === 0 && $this->max === null) {
+            return 'will return valid';
+        }
+
+        $conditions = [];
+        if ($this->min > 0) {
+            $conditions[] = sprintf('is %d characters or more', $this->min);
+        }
+        if ($this->max !== null) {
+            $conditions[] = sprintf('is %d characters or less', $this->max);
+        }
+
+        return implode(' and ', $conditions);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Validator/String/Regex.php
+++ b/src/Validator/String/Regex.php
@@ -15,6 +15,11 @@ class Regex implements Validator
     {
     }
 
+    public function __toString(): string
+    {
+        return sprintf('matches the regex: "%s"', $this->pattern);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Validator/Type/IsArray.php
+++ b/src/Validator/Type/IsArray.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class IsArray implements Validator
 {
+    public function __toString(): string
+    {
+        return 'is an array with string keys';
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Type/IsBool.php
+++ b/src/Validator/Type/IsBool.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class IsBool implements Validator
 {
+    public function __toString(): string
+    {
+        return 'is a boolean';
+    }
+
     public function validate(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Validator/Type/IsFloat.php
+++ b/src/Validator/Type/IsFloat.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class IsFloat implements Validator
 {
+    public function __toString(): string
+    {
+        return 'is a float';
+    }
+
     public function validate(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Validator/Type/IsInt.php
+++ b/src/Validator/Type/IsInt.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class IsInt implements Validator
 {
+    public function __toString(): string
+    {
+        return 'is an integer';
+    }
+
     public function validate(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Validator/Type/IsList.php
+++ b/src/Validator/Type/IsList.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class IsList implements Validator
 {
+    public function __toString(): string
+    {
+        return 'is a list';
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Type/IsNull.php
+++ b/src/Validator/Type/IsNull.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class IsNull implements Validator
 {
+    public function __toString(): string
+    {
+        return 'is null';
+    }
+
     public function validate(mixed $value): Result
     {
         if ($value !== null) {

--- a/src/Validator/Type/IsNumber.php
+++ b/src/Validator/Type/IsNumber.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class IsNumber implements Validator
 {
+    public function __toString(): string
+    {
+        return 'is a number';
+    }
+
     public function validate(mixed $value): Result
     {
         if (!(is_int($value) || is_float($value))) {

--- a/src/Validator/Type/IsString.php
+++ b/src/Validator/Type/IsString.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class IsString implements Validator
 {
+    public function __toString(): string
+    {
+        return 'is a string';
+    }
+
     public function validate(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Validator/Utility/AllOf.php
+++ b/src/Validator/Utility/AllOf.php
@@ -18,6 +18,16 @@ class AllOf implements Validator
         $this->chain = $chain;
     }
 
+    public function __toString(): string
+    {
+        if ($this->chain === []) {
+            return '';
+        }
+
+        return "must satisfy all of the following:\n\t" .
+            implode("\n\t", array_map(fn($p) => '- ' . (string)$p . '.', $this->chain));
+    }
+
     public function validate(mixed $value): Result
     {
         $resultChain = [];

--- a/src/Validator/Utility/AnyOf.php
+++ b/src/Validator/Utility/AnyOf.php
@@ -18,6 +18,16 @@ class AnyOf implements Validator
         $this->chain = $chain;
     }
 
+    public function __toString(): string
+    {
+        if ($this->chain === []) {
+            return '';
+        }
+
+        return "must satisfy at least one of the following:\n\t" .
+            implode("\n\t", array_map(fn($p) => '- ' . (string)$p . '.', $this->chain));
+    }
+
     public function validate(mixed $value): Result
     {
         $resultChain = [];

--- a/src/Validator/Utility/Fails.php
+++ b/src/Validator/Utility/Fails.php
@@ -11,6 +11,11 @@ use Membrane\Validator;
 
 class Fails implements Validator
 {
+    public function __toString(): string
+    {
+        return 'will return invalid';
+    }
+
     public function validate(mixed $value): Result
     {
         return Result::invalid($value, new MessageSet(null, new Message('I always fail', [])));

--- a/src/Validator/Utility/Indifferent.php
+++ b/src/Validator/Utility/Indifferent.php
@@ -9,6 +9,11 @@ use Membrane\Validator;
 
 class Indifferent implements Validator
 {
+    public function __toString(): string
+    {
+        return '';
+    }
+
     public function validate(mixed $value): Result
     {
         return Result::noResult($value);

--- a/src/Validator/Utility/Not.php
+++ b/src/Validator/Utility/Not.php
@@ -16,15 +16,23 @@ class Not implements Validator
     ) {
     }
 
+    public function __toString(): string
+    {
+        return sprintf('must satisfy the opposite of the following: "%s"', $this->invertedValidator->__toString());
+    }
+
     public function validate(mixed $value): Result
     {
         $result = $this->invertedValidator->validate($value);
-        $messageSet = new MessageSet(null, new Message('Inner validator was valid', []));
+        $messageSet = new MessageSet(
+            null,
+            new Message('Inverted validator: %s returned valid', [$this->invertedValidator::class])
+        );
 
         return new Result(
             $result->value,
             $result->result * -1,
-            ...($result->isValid() ? [$messageSet] : [])
+            ...($result->result === Result::VALID ? [$messageSet] : [])
         );
     }
 }

--- a/src/Validator/Utility/Passes.php
+++ b/src/Validator/Utility/Passes.php
@@ -9,6 +9,11 @@ use Membrane\Validator;
 
 class Passes implements Validator
 {
+    public function __toString(): string
+    {
+        return 'will return valid';
+    }
+
     public function validate(mixed $value): Result
     {
         return Result::valid($value);

--- a/tests/Filter/CreateObject/FromArrayTest.php
+++ b/tests/Filter/CreateObject/FromArrayTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class FromArrayTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'calls \a\b::fromArray';
+        $sut = new FromArray('\a\b');
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Filter/CreateObject/WithNamedArgumentsTest.php
+++ b/tests/Filter/CreateObject/WithNamedArgumentsTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class WithNamedArgumentsTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'construct an instance of "\a\b" from named arguments contained in self';
+        $sut = new WithNamedArguments('\a\b');
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsThatPass(): array
     {
         $classWithNamedArguments = new class (a: 'default', b: 'arguments') {

--- a/tests/Filter/Shape/CollectTest.php
+++ b/tests/Filter/Shape/CollectTest.php
@@ -18,6 +18,37 @@ use PHPUnit\Framework\TestCase;
  */
 class CollectTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no fields' => [
+                [],
+                '',
+            ],
+            'single field' => [
+                ['a'],
+                'collect "a" from self and append their values to a nested collection "new collection"',
+            ],
+            'multiple fields' => [
+                ['a', 'b', 'c'],
+                'collect "a", "b", "c" from self and append their values to a nested collection "new collection"',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(array $fields, string $expected): void
+    {
+        $sut = new Collect('new collection', ...$fields);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Filter/Shape/DeleteTest.php
+++ b/tests/Filter/Shape/DeleteTest.php
@@ -18,6 +18,37 @@ use PHPUnit\Framework\TestCase;
  */
 class DeleteTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no fields' => [
+                [],
+                '',
+            ],
+            'single field' => [
+                ['a'],
+                'delete "a" from self',
+            ],
+            'multiple fields' => [
+                ['a', 'b', 'c'],
+                'delete "a", "b", "c" from self',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(array $fields, string $expected): void
+    {
+        $sut = new Delete(...$fields);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectInputs(): array
     {
         $notArrayMessage = 'Delete filter requires arrays, %s given';

--- a/tests/Filter/Shape/NestTest.php
+++ b/tests/Filter/Shape/NestTest.php
@@ -18,6 +18,37 @@ use PHPUnit\Framework\TestCase;
  */
 class NestTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no fields' => [
+                [],
+                '',
+            ],
+            'single field' => [
+                ['a'],
+                'collect "a" from self and append them to a nested field set "new field set"',
+            ],
+            'multiple fields' => [
+                ['a', 'b', 'c'],
+                'collect "a", "b", "c" from self and append them to a nested field set "new field set"',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(array $fields, string $expected): void
+    {
+        $sut = new Nest('new field set', ...$fields);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Filter/Shape/PluckTest.php
+++ b/tests/Filter/Shape/PluckTest.php
@@ -18,6 +18,37 @@ use PHPUnit\Framework\TestCase;
  */
 class PluckTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no fields' => [
+                [],
+                '',
+            ],
+            'single field' => [
+                ['a'],
+                'collect "a" from "existing field set" and append them to self',
+            ],
+            'multiple fields' => [
+                ['a', 'b', 'c'],
+                'collect "a", "b", "c" from "existing field set" and append them to self',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(array $fields, string $expected): void
+    {
+        $sut = new Pluck('existing field set', ...$fields);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectInputs(): array
     {
         $notArrayMessage = 'Pluck filter requires arrays, %s given';

--- a/tests/Filter/Shape/RenameTest.php
+++ b/tests/Filter/Shape/RenameTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class RenameTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'rename "a" to "b"';
+        $sut = new Rename('a', 'b');
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Filter/Shape/TruncateTest.php
+++ b/tests/Filter/Shape/TruncateTest.php
@@ -19,6 +19,17 @@ use PHPUnit\Framework\TestCase;
  */
 class TruncateTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'truncate self to 5 fields or less';
+        $sut = new Truncate(5);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      * @throws Exception

--- a/tests/Filter/String/JsonDecodeTest.php
+++ b/tests/Filter/String/JsonDecodeTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonDecodeTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert from json to a PHP value';
+        $sut = new JsonDecode();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsToFilter(): array
     {
         return [

--- a/tests/Filter/Type/ToBoolTest.php
+++ b/tests/Filter/Type/ToBoolTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class ToBoolTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert to a boolean';
+        $sut = new ToBool();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         return [

--- a/tests/Filter/Type/ToDateTimeTest.php
+++ b/tests/Filter/Type/ToDateTimeTest.php
@@ -20,6 +20,17 @@ use PHPUnit\Framework\TestCase;
  */
 class ToDateTimeTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert to a DateTime';
+        $sut = new ToDateTime('');
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [
@@ -38,7 +49,9 @@ class ToDateTimeTest extends TestCase
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $toDateTime = new ToDateTime('');
-        $expected = Result::invalid($input, new MessageSet(
+        $expected = Result::invalid(
+            $input,
+            new MessageSet(
                 null,
                 new Message('ToDateTime filter requires a string, %s given', [$expectedVars])
             )

--- a/tests/Filter/Type/ToFloatTest.php
+++ b/tests/Filter/Type/ToFloatTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class ToFloatTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert to a float';
+        $sut = new ToFloat();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         return [

--- a/tests/Filter/Type/ToIntTest.php
+++ b/tests/Filter/Type/ToIntTest.php
@@ -12,12 +12,23 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Membrane\Filter\Type\ToInt
- * @uses \Membrane\Result\Result
- * @uses \Membrane\Result\MessageSet
- * @uses \Membrane\Result\Message
+ * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Result\MessageSet
+ * @uses   \Membrane\Result\Message
  */
 class ToIntTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert to an integer';
+        $sut = new ToInt();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         return [

--- a/tests/Filter/Type/ToListTest.php
+++ b/tests/Filter/Type/ToListTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class ToListTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert to a list';
+        $sut = new ToList();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         return [

--- a/tests/Filter/Type/ToNumberTest.php
+++ b/tests/Filter/Type/ToNumberTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class ToNumberTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert to a number';
+        $sut = new ToNumber();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsToFilter(): array
     {
         $class = new class {

--- a/tests/Filter/Type/ToStringTest.php
+++ b/tests/Filter/Type/ToStringTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class ToStringTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert to a string';
+        $sut = new ToString();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         $classWithMethod = new class () {

--- a/tests/OpenAPI/Filter/HTTPParametersTest.php
+++ b/tests/OpenAPI/Filter/HTTPParametersTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class HTTPParametersTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert query string to a field set of query parameters';
+        $sut = new HTTPParameters();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsToFilter(): array
     {
         return [

--- a/tests/OpenAPI/Filter/PathMatcherTest.php
+++ b/tests/OpenAPI/Filter/PathMatcherTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAPI\Filter;
 
 use Membrane\OpenAPI\Filter\PathMatcher;
+use Membrane\OpenAPI\PathMatcher as PathMatcherClass;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
@@ -20,6 +21,17 @@ use PHPUnit\Framework\TestCase;
  */
 class PathMatcherTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'convert url to a field set of path parameters';
+        $sut = new PathMatcher(self::createStub(PathMatcherClass::class));
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /** @test */
     public function invalidResultForNonStringValues(): void
     {

--- a/tests/OpenAPI/Processor/AllOfTest.php
+++ b/tests/OpenAPI/Processor/AllOfTest.php
@@ -6,6 +6,7 @@ namespace OpenAPI\Processor;
 
 use Membrane\Exception\InvalidProcessorArguments;
 use Membrane\OpenAPI\Processor\AllOf;
+use Membrane\Processor;
 use Membrane\Processor\BeforeSet;
 use Membrane\Processor\Field;
 use Membrane\Processor\FieldSet;
@@ -42,6 +43,26 @@ use PHPUnit\Framework\TestCase;
  */
 class AllOfTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = <<<END
+            All of the following:
+            \t"id":
+            \t\t- condition.
+            \t"id":
+            \t\t- condition.
+            END;
+        $processor = self::createMock(Processor::class);
+        $processor->method('__toString')
+            ->willReturn("\"id\":\n\t- condition");
+        $sut = new AllOf('id', $processor, $processor);
+
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
+
     /** @test */
     public function throwsExceptionIfLessThanTwoProcessors(): void
     {

--- a/tests/OpenAPI/Processor/AnyOfTest.php
+++ b/tests/OpenAPI/Processor/AnyOfTest.php
@@ -6,6 +6,7 @@ namespace OpenAPI\Processor;
 
 use Membrane\Exception\InvalidProcessorArguments;
 use Membrane\OpenAPI\Processor\AnyOf;
+use Membrane\Processor;
 use Membrane\Processor\BeforeSet;
 use Membrane\Processor\Field;
 use Membrane\Processor\FieldSet;
@@ -42,6 +43,26 @@ use PHPUnit\Framework\TestCase;
  */
 class AnyOfTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = <<<END
+            Any of the following:
+            \t"id":
+            \t\t- condition.
+            \t"id":
+            \t\t- condition.
+            END;
+        $processor = self::createMock(Processor::class);
+        $processor->method('__toString')
+            ->willReturn("\"id\":\n\t- condition");
+        $sut = new AnyOf('id', $processor, $processor);
+
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
+
     /** @test */
     public function throwsExceptionIfLessThanTwoProcessors(): void
     {

--- a/tests/OpenAPI/Processor/JsonTest.php
+++ b/tests/OpenAPI/Processor/JsonTest.php
@@ -23,6 +23,25 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = "\"pet\":\n\t- convert from json to a PHP value.\n\t- condition";
+        $wrapped = self::createMock(Processor\Field::class);
+        $sut = new Json($wrapped);
+
+        $wrapped->expects($this->once())
+            ->method('processes')
+            ->willReturn('pet');
+
+        $wrapped->expects(($this->once()))
+            ->method('__toString')
+            ->willReturn("\"pet\":\n\t- condition");
+
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
 
     /** @test */
     public function processesTest(): void

--- a/tests/OpenAPI/Processor/OneOfTest.php
+++ b/tests/OpenAPI/Processor/OneOfTest.php
@@ -6,6 +6,7 @@ namespace OpenAPI\Processor;
 
 use Membrane\Exception\InvalidProcessorArguments;
 use Membrane\OpenAPI\Processor\OneOf;
+use Membrane\Processor;
 use Membrane\Processor\BeforeSet;
 use Membrane\Processor\Field;
 use Membrane\Processor\FieldSet;
@@ -42,6 +43,26 @@ use PHPUnit\Framework\TestCase;
  */
 class OneOfTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = <<<END
+            One of the following:
+            \t"id":
+            \t\t- condition.
+            \t"id":
+            \t\t- condition.
+            END;
+        $processor = self::createMock(Processor::class);
+        $processor->method('__toString')
+            ->willReturn("\"id\":\n\t- condition");
+        $sut = new OneOf('id', $processor, $processor);
+
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
+
     /** @test */
     public function throwsExceptionIfLessThanTwoProcessors(): void
     {

--- a/tests/OpenAPI/Processor/RequestTest.php
+++ b/tests/OpenAPI/Processor/RequestTest.php
@@ -30,6 +30,43 @@ use Psr\Http\Message\UriInterface;
  */
 class RequestTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        $processor = self::createMock(Processor::class);
+        $processor->method('__toString')
+            ->willReturn("\"id\":\n\t- condition");
+
+        return [
+            'request with no processors' => [
+                'Parse PSR-7 request',
+                [],
+            ],
+            'request with processors inside' => [
+                <<<END
+                Parse PSR-7 request:
+                \t"id":
+                \t\t- condition.
+                \t"id":
+                \t\t- condition.
+                END,
+                [$processor, $processor],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(string $expected, array $processors): void
+    {
+        $sut = new Request('test', $processors);
+
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
+
     /** @test */
     public function processesTest(): void
     {

--- a/tests/OpenAPI/Processor/RequestTest.php
+++ b/tests/OpenAPI/Processor/RequestTest.php
@@ -7,20 +7,26 @@ namespace OpenAPI\Processor;
 use GuzzleHttp\Psr7\ServerRequest;
 use Membrane\OpenAPI\Processor\Request;
 use Membrane\Processor;
+use Membrane\Processor\Field;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use Membrane\Validator\Utility\Fails;
+use Membrane\Validator\Utility\Passes;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
  * @covers \Membrane\OpenAPI\Processor\Request
+ * @uses   \Membrane\Processor\Field
  * @uses   \Membrane\Result\FieldName
  * @uses   \Membrane\Result\MessageSet
  * @uses   \Membrane\Result\Message
  * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Validator\Utility\Fails
+ * @uses   \Membrane\Validator\Utility\Passes
  */
 class RequestTest extends TestCase
 {
@@ -61,29 +67,9 @@ class RequestTest extends TestCase
 
     public function dataSetsToProcess(): array
     {
-        $validProcessor = new class() implements Processor {
-            public function processes(): string
-            {
-                return '';
-            }
+        $validProcessor = new Field('', new Passes());
 
-            public function process(FieldName $parentFieldName, mixed $value): Result
-            {
-                return Result::valid($value);
-            }
-        };
-
-        $invalidProcessor = new class() implements Processor {
-            public function processes(): string
-            {
-                return '';
-            }
-
-            public function process(FieldName $parentFieldName, mixed $value): Result
-            {
-                return Result::invalid($value, new MessageSet(null, new Message('invalid result', [])));
-            }
-        };
+        $invalidProcessor = new Field('', new Fails());
 
         $uri = self::createMock(UriInterface::class);
         $uri->method('getPath')
@@ -143,8 +129,8 @@ class RequestTest extends TestCase
                     'cookie' => [],
                     'body' => '',
                 ],
-                    new MessageSet(null, new Message('invalid result', [])),
-                    new MessageSet(null, new Message('invalid result', []))
+                    new MessageSet(new FieldName('', ''), new Message('I always fail', [])),
+                    new MessageSet(new FieldName('', ''), new Message('I always fail', []))
                 ),
             ],
             'mock server request, no processors' => [
@@ -191,8 +177,8 @@ class RequestTest extends TestCase
                     'cookie' => [],
                     'body' => 'request body',
                 ],
-                    new MessageSet(null, new Message('invalid result', [])),
-                    new MessageSet(null, new Message('invalid result', []))
+                    new MessageSet(new FieldName('', ''), new Message('I always fail', [])),
+                    new MessageSet(new FieldName('', ''), new Message('I always fail', []))
                 ),
             ],
             'guzzle server request, valid processors' => [

--- a/tests/Processor/AfterSetTest.php
+++ b/tests/Processor/AfterSetTest.php
@@ -31,6 +31,37 @@ use PHPUnit\Framework\TestCase;
  */
 class AfterSetTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'No chain returns empty string' => [
+                '',
+                new AfterSet(),
+            ],
+            'Single item in chain returns one bullet point' => [
+                "\n\t- will return valid.",
+                new AfterSet(new Passes()),
+            ],
+            'guaranteed noResult in chain is ignored' => [
+                '',
+                new AfterSet(new Indifferent()),
+            ],
+            'Three items in chain returns three bullet points' => [
+                "\n\t- will return valid.\n\t- will return invalid.\n\t- will return valid.",
+                new AfterSet(new Passes(), new Fails(), new Passes()),
+            ],
+        ];
+    }
+
+    /** @test * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(string $expected, AfterSet $sut): void
+    {
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
+
     /** @test */
     public function processesMethodReturnsEmptyString(): void
     {

--- a/tests/Processor/BeforeSetTest.php
+++ b/tests/Processor/BeforeSetTest.php
@@ -31,6 +31,39 @@ use PHPUnit\Framework\TestCase;
  */
 class BeforeSetTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'No chain returns empty string' => [
+                '',
+                new BeforeSet(),
+            ],
+            'Single item in chain returns one bullet point' => [
+                "\n\t- will return valid.",
+                new BeforeSet(new Passes()),
+            ],
+            'guaranteed noResult in chain is ignored' => [
+                '',
+                new BeforeSet(new Indifferent()),
+            ],
+            'Three items in chain returns three bullet points' => [
+                "\n\t- will return valid.\n\t- will return invalid.\n\t- will return valid.",
+                new BeforeSet(new Passes(), new Fails(), new Passes()),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(string $expected, BeforeSet $sut): void
+    {
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
+
     /**  @test */
     public function processesMethodReturnsEmptyString(): void
     {

--- a/tests/Processor/BeforeSetTest.php
+++ b/tests/Processor/BeforeSetTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Processor;
 
-use Membrane\Filter;
+use Membrane\Filter\Type\ToFloat;
 use Membrane\Processor\BeforeSet;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
-use Membrane\Validator;
+use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
  * @uses   \Membrane\Result\Result
  * @uses   \Membrane\Result\MessageSet
  * @uses   \Membrane\Result\Message
+ * @uses   \Membrane\Filter\Type\ToFloat
+ * @uses   \Membrane\Validator\Type\IsFloat
  * @uses   \Membrane\Validator\Utility\Fails
  * @uses   \Membrane\Validator\Utility\Indifferent
  * @uses   \Membrane\Validator\Utility\Passes
@@ -29,9 +31,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BeforeSetTest extends TestCase
 {
-    /**
-     * @test
-     */
+    /**  @test */
     public function processesMethodReturnsEmptyString(): void
     {
         $expected = '';
@@ -42,114 +42,58 @@ class BeforeSetTest extends TestCase
         self::assertSame($expected, $result);
     }
 
-    /**
-     * @test
-     */
-    public function noChainReturnsNoResult(): void
-    {
-        $input = ['a' => 1, 'b' => 2, 'c' => 3];
-        $expected = Result::noResult($input);
-        $field = new BeforeSet();
-
-        $result = $field->process(new Fieldname('Parent FieldName'), $input);
-
-        self::assertEquals($expected, $result);
-    }
-
     public function dataSetsForFiltersOrValidators(): array
     {
-        $incrementFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key]++;
-                }
-
-                return Result::noResult($value);
-            }
-        };
-
-        $evenFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key] *= 2;
-                }
-
-                return Result::noResult($value);
-            }
-        };
-
-        $evenValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    if ($value[$key] % 2 !== 0) {
-                        return Result::invalid($value, new MessageSet(
-                            null,
-                            new Message('not even', [])
-                        ));
-                    }
-                }
-                return Result::valid($value);
-            }
-        };
-
         return [
-            'checks it can return valid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Passes(),
+            'no chain returns noResult' => [
+                Result::noResult(1),
+                new BeforeSet(),
+                1,
             ],
-            'checks it can return invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3], new MessageSet(
-                    new FieldName('', 'parent field'),
-                    new Message('I always fail', [])
-                )),
-                new Fails(),
+            'can return valid' => [
+                Result::valid(1),
+                new BeforeSet(new Passes()),
+                1,
             ],
-            'checks it can return noresult' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Indifferent(),
+            'can return invalid' => [
+                Result::invalid(
+                    1,
+                    new MessageSet(new FieldName('', 'parent field'), new Message('I always fail', []))
+                ),
+                new BeforeSet(new Fails()),
+                1,
+            ],
+            'can return noResult' => [
+                Result::noResult(1),
+                new BeforeSet(new Indifferent()),
+                1,
             ],
             'checks it keeps track of previous results' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Passes(),
-                new Indifferent(),
-                new Indifferent(),
+                Result::valid(1),
+                new BeforeSet(new Passes(), new Indifferent(), new Indifferent()),
+                1,
+
             ],
             'checks it can make changes to value' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 2, 'b' => 3, 'c' => 4]),
-                $incrementFilter,
+                Result::noResult(5.0),
+                new BeforeSet(new ToFloat()),
+                '5',
             ],
-            'checks that changes made to value persist' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 3, 'b' => 4, 'c' => 5]),
-                $incrementFilter,
-                $incrementFilter,
-            ],
-            'checks that chain runs in correct order' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3], new MessageSet(
-                    new FieldName('', 'parent field'),
-                    new Message('not even', [])
-                )),
-                $evenValidator,
-                $evenFilter,
+            'checks that changes made to value persist and chain runs in correct order' => [
+                Result::valid(5.0),
+                new BeforeSet(new ToFloat(), new IsFloat()),
+                '5',
             ],
             'checks that chain stops as soon as result is invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 2, 'b' => 3, 'c' => 4], new MessageSet(
-                    new FieldName('', 'parent field'),
-                    new Message('not even', [])
-                )),
-                $incrementFilter,
-                $evenValidator,
-                $incrementFilter,
+                Result::invalid(
+                    '5',
+                    new MessageSet(
+                        new FieldName('', 'parent field'),
+                        new Message('IsFloat expects float value, %s passed instead', ['string'])
+                    )
+                ),
+                new BeforeSet(new IsFloat(), new ToFloat()),
+                '5',
             ],
         ];
     }
@@ -158,15 +102,11 @@ class BeforeSetTest extends TestCase
      * @test
      * @dataProvider dataSetsForFiltersOrValidators
      */
-    public function processesCallsFilterOrValidatorMethods(
-        mixed $input,
-        Result $expected,
-        Filter|Validator ...$chain
-    ): void {
-        $beforeSet = new BeforeSet(...$chain);
+    public function processesCallsFilterOrValidateMethods(Result $expected, BeforeSet $sut, mixed $input): void
+    {
+        $actual = $sut->process(new FieldName('parent field'), $input);
 
-        $output = $beforeSet->process(new FieldName('parent field'), $input);
-
-        self::assertEquals($expected, $output);
+        self::assertEquals($expected, $actual);
+        self::assertSame($expected->value, $actual->value);
     }
 }

--- a/tests/Processor/CollectionTest.php
+++ b/tests/Processor/CollectionTest.php
@@ -43,6 +43,68 @@ use PHPUnit\Framework\TestCase;
  */
 class CollectionTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'No chain returns empty string' => [
+                '',
+                new Collection('a'),
+            ],
+            'Chain with no conditions returns empty string' => [
+                '',
+                new Collection('a', new Field('')),
+            ],
+            'Chain with guaranteed noResult returns empty string' => [
+                '',
+                new Collection('a', new Field('', new Indifferent())),
+            ],
+            'Chain with conditions but processes empty string returns empty string' => [
+                '',
+                new Collection('', new Field('', new Passes())),
+            ],
+            'Chain with one condition returns one bullet point' => [
+                "Each field in \"a\":\n\t- will return valid.",
+                new Collection('a', new Field('', new Passes())),
+            ],
+            'Chain with three condition returns three bullet points' => [
+                "Each field in \"a\":\n\t- will return valid.\n\t- will return valid.\n\t- will return invalid.",
+                new Collection('a', new Field('', new Passes(), new Passes(), new Fails())),
+            ],
+            'BeforeSet adds a Firstly: section' => [
+                "Firstly \"a\":\n\t- will return valid.",
+                new Collection('a', new BeforeSet(new Passes())),
+            ],
+            'AfterSet adds a Lastly: section' => [
+                "Lastly \"a\":\n\t- will return valid.",
+                new Collection('a', new AfterSet(new Passes())),
+            ],
+            'Chain with BeforeSet, Field and AfterSet' => [
+                <<<END
+                Firstly "a":
+                \t- will return invalid.
+                Each field in "a":
+                \t- will return valid.
+                Lastly "a":
+                \t- will return valid.
+                END,
+                new Collection(
+                    'a', new BeforeSet(new Fails()), new Field('', new Passes()), new AfterSet(new Passes())
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(string $expected, Collection $sut): void
+    {
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectValues(): array
     {
         $notArrayMessage = 'Value passed to %s in Collection chain must be a list, %s passed instead';

--- a/tests/Processor/CollectionTest.php
+++ b/tests/Processor/CollectionTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Processor;
 
 use Membrane\Exception\InvalidProcessorArguments;
-use Membrane\Filter;
+use Membrane\Filter\Shape\Truncate;
+use Membrane\Filter\Type\ToFloat;
 use Membrane\Processor;
 use Membrane\Processor\AfterSet;
 use Membrane\Processor\BeforeSet;
@@ -15,12 +16,18 @@ use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
-use Membrane\Validator;
+use Membrane\Validator\Collection\Count;
+use Membrane\Validator\Type\IsFloat;
+use Membrane\Validator\Utility\Fails;
+use Membrane\Validator\Utility\Indifferent;
+use Membrane\Validator\Utility\Passes;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Membrane\Processor\Collection
  * @covers \Membrane\Exception\InvalidProcessorArguments
+ * @uses   \Membrane\Filter\Shape\Truncate
+ * @uses   \Membrane\Filter\Type\ToFloat
  * @uses   \Membrane\Processor\BeforeSet
  * @uses   \Membrane\Processor\Field
  * @uses   \Membrane\Processor\AfterSet
@@ -28,6 +35,11 @@ use PHPUnit\Framework\TestCase;
  * @uses   \Membrane\Result\Result
  * @uses   \Membrane\Result\MessageSet
  * @uses   \Membrane\Result\Message
+ * @uses   \Membrane\Validator\Collection\Count
+ * @uses   \Membrane\Validator\Type\IsFloat
+ * @uses   \Membrane\Validator\Utility\Passes
+ * @uses   \Membrane\Validator\Utility\Indifferent
+ * @uses   \Membrane\Validator\Utility\Fails
  */
 class CollectionTest extends TestCase
 {
@@ -59,9 +71,7 @@ class CollectionTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function onlyAcceptsOneField(): void
     {
         $field = new Field('field to process');
@@ -70,9 +80,7 @@ class CollectionTest extends TestCase
         new Collection('field to process', $field, $field);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function processesTest(): void
     {
         $fieldName = 'field to process';
@@ -83,9 +91,7 @@ class CollectionTest extends TestCase
         self::assertEquals($fieldName, $output);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function processMethodWithNoChainReturnsNoResult(): void
     {
         $value = [];
@@ -99,107 +105,66 @@ class CollectionTest extends TestCase
 
     public function dataSetsOfFields(): array
     {
-        $incrementFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                return Result::noResult(++$value);
-            }
-        };
-
-        $evenFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                return Result::noResult($value * 2);
-            }
-        };
-
-        $evenArrayFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key] *= 2;
-                }
-                return Result::noResult($value);
-            }
-        };
-
-        $evenValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                if ($value % 2 !== 0) {
-                    return Result::invalid(
-                        $value,
-                        new MessageSet(
-                            null,
-                            new Message('not even', [])
-                        )
-                    );
-                }
-                return Result::valid($value);
-            }
-        };
-
-        $evenArrayValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    if ($value[$key] % 2 !== 0) {
-                        return Result::invalid(
-                            $value,
-                            new MessageSet(
-                                null,
-                                new Message('not even', [])
-                            )
-                        );
-                    }
-                }
-                return Result::valid($value);
-            }
-        };
-
         return [
-            'Field process method is called for every item in array' => [
+            'No chain returns noResult' => [
                 [1, 2, 3],
-                Result::noResult([2, 3, 4]),
-                new Field('a', $incrementFilter),
+                Result::noResult([1, 2, 3]),
             ],
-            'Field processed values persist' => [
+            'Return valid result' => [
                 [1, 2, 3],
-                Result::noResult([3, 4, 5]),
-                new Field('b', $incrementFilter, $incrementFilter),
+                Result::valid([1, 2, 3]),
+                new Field('a', new Passes()),
             ],
-            'Field processed can return valid results' => [
+            'Return noResult' => [
                 [1, 2, 3],
-                Result::valid([2, 4, 6]),
-                new Field('b', $evenFilter, $evenValidator),
+                Result::noResult([1, 2, 3]),
+                new Field('b', new Indifferent()),
             ],
-            'Field processed can return invalid results' => [
+            'Return invalid result' => [
                 [1, 2, 3],
                 Result::invalid(
                     [1, 2, 3],
                     new MessageSet(
-                        new FieldName('a', 'parent field', 'field to process', '0'),
-                        new Message('not even', [])
+                        new FieldName('c', 'parent field', 'field to process', '0'),
+                        new Message('I always fail', [])
                     ),
                     new MessageSet(
-                        new FieldName('a', 'parent field', 'field to process', '2'),
-                        new Message('not even', [])
+                        new FieldName('c', 'parent field', 'field to process', '1'),
+                        new Message('I always fail', [])
+                    ),
+                    new MessageSet(
+                        new FieldName('c', 'parent field', 'field to process', '2'),
+                        new Message('I always fail', [])
                     )
                 ),
-
-                new Field('a', $evenValidator),
+                new Field('c', new Fails()),
+            ],
+            'Field processes every item in array' => [
+                [1, 2, 3],
+                Result::noResult([1.0, 2.0, 3.0]),
+                new Field('d', new ToFloat()),
+            ],
+            'Field processed values persist' => [
+                [1, 2, 3],
+                Result::valid([1.0, 2.0, 3.0]),
+                new Field('e', new ToFloat(), new IsFloat()),
             ],
             'BeforeSet processes before Field' => [
-                [1, 2, 3],
-                Result::valid([2, 4, 6]),
-                new BeforeSet($evenArrayFilter),
-                new Field('c', $evenValidator),
+                [1.0, 2.0, 3.0],
+                Result::noResult([]),
+                new BeforeSet(new Truncate(0)),
+                new Field('f', new IsFloat()),
             ],
             'BeforeSet processes before AfterSet' => [
                 [1, 2, 3],
-                Result::valid([2, 4, 6]),
-                new BeforeSet($evenArrayFilter),
-                new AfterSet($evenArrayValidator),
+                Result::invalid([1, 2],
+                    new MessageSet(
+                        new FieldName('', 'parent field', 'field to process'),
+                        new Message('Array is expected have a minimum of %d values', [3])
+                    )
+                ),
+                new BeforeSet(new Truncate(2)),
+                new AfterSet(new Count(3)),
             ],
             'AfterSet does not process if BeforeSet returns invalid' => [
                 [1, 2, 3],
@@ -207,34 +172,24 @@ class CollectionTest extends TestCase
                     [1, 2, 3],
                     new MessageSet(
                         new FieldName('', 'parent field', 'field to process'),
-                        new Message('not even', [])
+                        new Message('Array is expected have a minimum of %d values', [4])
                     )
                 ),
-                new BeforeSet($evenArrayValidator),
-                new AfterSet($evenArrayFilter),
+                new BeforeSet(new Count(4)),
+                new AfterSet(new Truncate(2)),
             ],
             'AfterSet processes after Field' => [
-                [1, 2, 3],
-                Result::invalid(
-                    [2, 3, 4],
-                    new MessageSet(
-                        new FieldName('', 'parent field', 'field to process'),
-                        new Message('not even', [])
-                    )
-                ),
-                new Field('a', $incrementFilter),
-                new AfterSet($evenArrayValidator),
+                [1.0, 2.0, 3.0],
+                Result::valid([]),
+                new Field('i', new IsFloat()),
+                new AfterSet(new Truncate(0)),
             ],
             'BeforeSet then Field then AfterSet' => [
                 [1, 2, 3],
-                Result::invalid([3, 5, 7],
-                    new MessageSet(
-                        new FieldName('', 'parent field', 'field to process'),
-                        new Message('not even', [])
-                    )),
-                new BeforeSet($evenArrayFilter),
-                new Field('b', $incrementFilter),
-                new AfterSet($evenArrayValidator),
+                Result::valid([]),
+                new BeforeSet(new Truncate(0)),
+                new Field('j', new IsFloat()),
+                new AfterSet(new Count(0, 0)),
             ],
         ];
     }
@@ -245,10 +200,11 @@ class CollectionTest extends TestCase
      */
     public function processTest(array $input, Result $expected, Processor ...$chain): void
     {
-        $fieldset = new Collection('field to process', ...$chain);
+        $sut = new Collection('field to process', ...$chain);
 
-        $result = $fieldset->process(new FieldName('parent field'), $input);
+        $actual = $sut->process(new FieldName('parent field'), $input);
 
-        self::assertEquals($expected, $result);
+        self::assertEquals($expected, $actual);
+        self::assertSame($expected->value, $actual->value);
     }
 }

--- a/tests/Processor/DefaultProcessorTest.php
+++ b/tests/Processor/DefaultProcessorTest.php
@@ -31,6 +31,39 @@ use PHPUnit\Framework\TestCase;
  */
 class DefaultProcessorTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'No chain returns empty string' => [
+                '',
+                DefaultProcessor::fromFiltersAndValidators(),
+            ],
+            'Single item in chain returns one bullet point' => [
+                "\n\t- will return valid.",
+                DefaultProcessor::fromFiltersAndValidators(new Passes()),
+            ],
+            'guaranteed noResult in chain is ignored' => [
+                '',
+                DefaultProcessor::fromFiltersAndValidators(new Indifferent()),
+            ],
+            'Three items in chain returns three bullet points' => [
+                "\n\t- will return valid.\n\t- will return invalid.\n\t- will return valid.",
+                DefaultProcessor::fromFiltersAndValidators(new Passes(), new Fails(), new Passes()),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(string $expected, DefaultProcessor $sut): void
+    {
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
+
     /** @test */
     public function processesTest(): void
     {

--- a/tests/Processor/FieldTest.php
+++ b/tests/Processor/FieldTest.php
@@ -30,6 +30,43 @@ use PHPUnit\Framework\TestCase;
  */
 class FieldTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'No chain returns empty string' => [
+                '',
+                new Field('a'),
+            ],
+            'Single item in chain returns bulletpoint on own if processes empty string' => [
+                "\n\t- will return valid.",
+                new Field('', new Passes()),
+            ],
+            'Single item in chain returns one bullet point' => [
+                "\"c\":\n\t- will return valid.",
+                new Field('c', new Passes()),
+            ],
+            'guaranteed noResult in chain is ignored' => [
+                '',
+                new Field('d', new Indifferent()),
+            ],
+            'Three items in chain returns three bullet points' => [
+                "\"e\":\n\t- will return valid.\n\t- will return invalid.\n\t- will return valid.",
+                new Field('e', new Passes(), new Fails(), new Passes()),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(string $expected, Field $sut): void
+    {
+        $actual = (string)$sut;
+
+        self::assertSame($expected, $actual);
+    }
+
     /** @test */
     public function processesMethodReturnsProcessesString(): void
     {

--- a/tests/Validator/Collection/ContainedTest.php
+++ b/tests/Validator/Collection/ContainedTest.php
@@ -18,6 +18,41 @@ use PHPUnit\Framework\TestCase;
  */
 class ContainedTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no values' => [
+                [],
+                'will return invalid',
+            ],
+            'single integer value' => [
+                [1],
+                'is one of the following values: 1',
+            ],
+            'single string value' => [
+                ['a'],
+                'is one of the following values: "a"',
+            ],
+            'multiple fixed values' => [
+                [1, 'a', true],
+                'is one of the following values: 1, "a", true',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(array $enum, string $expected): void
+    {
+        $sut = new Contained($enum);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsToValidate(): array
     {
         return [

--- a/tests/Validator/Collection/CountTest.php
+++ b/tests/Validator/Collection/CountTest.php
@@ -18,6 +18,45 @@ use PHPUnit\Framework\TestCase;
  */
 class CountTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no minimum or maximum' => [
+                0,
+                null,
+                'will return valid',
+            ],
+            'a non-zero minimum' => [
+                5,
+                null,
+                'has greater than 5 values',
+            ],
+            'a maximum' => [
+                0,
+                10,
+                'has fewer than 10 values',
+            ],
+            'a minimum and maximum' => [
+                4,
+                8,
+                'has greater than 4 and fewer than 8 values',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(int $min, ?int $max, string $expected): void
+    {
+        $sut = new Count($min, $max);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/Collection/IdenticalTest.php
+++ b/tests/Validator/Collection/IdenticalTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class IdenticalTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'contains only identical values';
+        $sut = new Identical();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [
@@ -36,7 +47,9 @@ class IdenticalTest extends TestCase
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $identical = new Identical();
-        $expected = Result::invalid($input, new MessageSet(
+        $expected = Result::invalid(
+            $input,
+            new MessageSet(
                 null,
                 new Message('Identical Validator requires an array, %s given', [$expectedVars])
             )

--- a/tests/Validator/Collection/UniqueTest.php
+++ b/tests/Validator/Collection/UniqueTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class UniqueTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'contains only unique values';
+        $sut = new Unique();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/DateTime/RangeDeltaTest.php
+++ b/tests/Validator/DateTime/RangeDeltaTest.php
@@ -20,6 +20,45 @@ use PHPUnit\Framework\TestCase;
  */
 class RangeDeltaTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no minimum or maximum' => [
+                null,
+                null,
+                'will return valid',
+            ],
+            'minimum' => [
+                new DateInterval('P1Y'),
+                null,
+                'is after %s, %d %s %d %d:%d:%d',
+            ],
+            'maximum' => [
+                null,
+                new DateInterval('P1Y2M3D'),
+                'is before %s, %d %s %d %d:%d:%d',
+            ],
+            'minimum and maximum' => [
+                new DateInterval('P1Y'),
+                new DateInterval('P1Y2M3D'),
+                'is after %s, %d %s %d %d:%d:%d and before %s, %d %s %d %d:%d:%d',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(?DateInterval $min, ?DateInterval $max, string $expected): void
+    {
+        $sut = new RangeDelta($min, $max);
+
+        $actual = $sut->__toString();
+
+        self::assertStringMatchesFormat($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/DateTime/RangeTest.php
+++ b/tests/Validator/DateTime/RangeTest.php
@@ -19,6 +19,45 @@ use PHPUnit\Framework\TestCase;
  */
 class RangeTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no minimum or maximum' => [
+                null,
+                null,
+                'will return valid',
+            ],
+            'minimum' => [
+                DateTime::createFromFormat(DATE_ATOM, '1970-01-01T00:00:00Z'),
+                null,
+                'is after Thu, 01 Jan 1970 00:00:00',
+            ],
+            'maximum' => [
+                null,
+                DateTime::createFromFormat(DATE_ATOM, '2023-01-16T18:19:57Z'),
+                'is before Mon, 16 Jan 2023 18:19:57',
+            ],
+            'minimum and maximum' => [
+                DateTime::createFromFormat(DATE_ATOM, '1970-01-01T00:00:00Z'),
+                DateTime::createFromFormat(DATE_ATOM, '2023-01-16T18:19:57Z'),
+                'is after Thu, 01 Jan 1970 00:00:00 and before Mon, 16 Jan 2023 18:19:57',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(?DateTime $min, ?DateTime $max, string $expected): void
+    {
+        $sut = new Range($min, $max);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/FieldSet/FixedFieldsTest.php
+++ b/tests/Validator/FieldSet/FixedFieldsTest.php
@@ -18,6 +18,37 @@ use PHPUnit\Framework\TestCase;
  */
 class FixedFieldsTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no fixed fields' => [
+                [],
+                'does not contain any fields',
+            ],
+            'single fixed field' => [
+                ['a'],
+                'only contains the following fields: "a"',
+            ],
+            'multiple fixed fields' => [
+                ['a', 'b', 'c'],
+                'only contains the following fields: "a", "b", "c"',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(array $fields, string $expected): void
+    {
+        $sut = new FixedFields(...$fields);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/FieldSet/RequiredFieldsTest.php
+++ b/tests/Validator/FieldSet/RequiredFieldsTest.php
@@ -18,6 +18,37 @@ use PHPUnit\Framework\TestCase;
  */
 class RequiredFieldsTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no required fields' => [
+                [],
+                'will return valid',
+            ],
+            'single required field' => [
+                ['a'],
+                'contains the following fields: "a"',
+            ],
+            'multiple required fields' => [
+                ['a', 'b', 'c'],
+                'contains the following fields: "a", "b", "c"',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(array $fields, string $expected): void
+    {
+        $sut = new RequiredFields(...$fields);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/Numeric/MaximumTest.php
+++ b/tests/Validator/Numeric/MaximumTest.php
@@ -18,6 +18,35 @@ use PHPUnit\Framework\TestCase;
  */
 class MaximumTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'inclusive max' => [
+                5,
+                false,
+                'is less than or equal to 5',
+            ],
+            'exclusive max' => [
+                7,
+                true,
+                'is less than 7',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(int $max, bool $exclusive, string $expected): void
+    {
+        $sut = new Maximum($max, $exclusive);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsOfNonNumericValues(): array
     {
         return [

--- a/tests/Validator/Numeric/MinimumTest.php
+++ b/tests/Validator/Numeric/MinimumTest.php
@@ -18,6 +18,35 @@ use PHPUnit\Framework\TestCase;
  */
 class MinimumTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'inclusive min' => [
+                5,
+                false,
+                'is greater than or equal to 5',
+            ],
+            'exclusive min' => [
+                7,
+                true,
+                'is greater than 7',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(int $min, bool $exclusive, string $expected): void
+    {
+        $sut = new Minimum($min, $exclusive);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsOfNonNumericValues(): array
     {
         return [

--- a/tests/Validator/Numeric/MultipleOfTest.php
+++ b/tests/Validator/Numeric/MultipleOfTest.php
@@ -19,6 +19,17 @@ use PHPUnit\Framework\TestCase;
  */
 class MultipleOfTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'is a multiple of 5';
+        $sut = new MultipleOf(5);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsThatThrowExceptions(): array
     {
         return [

--- a/tests/Validator/String/DateStringTest.php
+++ b/tests/Validator/String/DateStringTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class DateStringTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'matches the DateTime format: "#^[a-zA-Z]+$#"';
+        $sut = new DateString('#^[a-zA-Z]+$#');
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [
@@ -36,7 +47,9 @@ class DateStringTest extends TestCase
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $dateString = new DateString('');
-        $expected = Result::invalid($input, new MessageSet(
+        $expected = Result::invalid(
+            $input,
+            new MessageSet(
                 null,
                 new Message('DateString Validator requires a string, %s given', [$expectedVars])
             )

--- a/tests/Validator/String/LengthTest.php
+++ b/tests/Validator/String/LengthTest.php
@@ -18,6 +18,45 @@ use PHPUnit\Framework\TestCase;
  */
 class LengthTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        return [
+            'no conditions' => [
+                0,
+                null,
+                'will return valid',
+            ],
+            'non-zero minimum provided' => [
+                1,
+                null,
+                'is 1 characters or more',
+            ],
+            'maximum provided' => [
+                0,
+                5,
+                'is 5 characters or less',
+            ],
+            'minimum and maximum provided' => [
+                2,
+                4,
+                'is 2 characters or more and is 4 characters or less',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringTest(int $min, ?int $max, string $expected): void
+    {
+        $sut = new Length($min, $max);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [
@@ -36,7 +75,9 @@ class LengthTest extends TestCase
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $length = new Length();
-        $expected = Result::invalid($input, new MessageSet(
+        $expected = Result::invalid(
+            $input,
+            new MessageSet(
                 null,
                 new Message('Length Validator requires a string, %s given', [$expectedVars])
             )

--- a/tests/Validator/String/RegexTest.php
+++ b/tests/Validator/String/RegexTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class RegexTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'matches the regex: "#^[a-zA-Z]+$#"';
+        $sut = new Regex('#^[a-zA-Z]+$#');
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [
@@ -36,7 +47,9 @@ class RegexTest extends TestCase
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $regex = new Regex('');
-        $expected = Result::invalid($input, new MessageSet(
+        $expected = Result::invalid(
+            $input,
+            new MessageSet(
                 null,
                 new Message('Regex Validator requires a string, %s given', [$expectedVars])
             )

--- a/tests/Validator/Type/IsArrayTest.php
+++ b/tests/Validator/Type/IsArrayTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class IsArrayTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'is an array with string keys';
+        $sut = new IsArray();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsThatPass(): array
     {
         return [

--- a/tests/Validator/Type/IsBoolTest.php
+++ b/tests/Validator/Type/IsBoolTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class IsBoolTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'is a boolean';
+        $sut = new IsBool();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Type/IsFloatTest.php
+++ b/tests/Validator/Type/IsFloatTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class IsFloatTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'is a float';
+        $sut = new IsFloat();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Type/IsIntTest.php
+++ b/tests/Validator/Type/IsIntTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class IsIntTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'is an integer';
+        $sut = new IsInt();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Type/IsListTest.php
+++ b/tests/Validator/Type/IsListTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class IsListTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'is a list';
+        $sut = new IsList();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSetsThatPass(): array
     {
         return [

--- a/tests/Validator/Type/IsNullTest.php
+++ b/tests/Validator/Type/IsNullTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class IsNullTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'is null';
+        $sut = new IsNull();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Type/IsNumberTest.php
+++ b/tests/Validator/Type/IsNumberTest.php
@@ -18,6 +18,16 @@ use PHPUnit\Framework\TestCase;
  */
 class IsNumberTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'is a number';
+        $sut = new IsNumber();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
 
     public function dataSetsToValidate(): array
     {

--- a/tests/Validator/Type/IsStringTest.php
+++ b/tests/Validator/Type/IsStringTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class IsStringTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'is a string';
+        $sut = new IsString();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Utility/AllOfTest.php
+++ b/tests/Validator/Utility/AllOfTest.php
@@ -7,6 +7,7 @@ namespace Validator\Utility;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use Membrane\Validator;
 use Membrane\Validator\Utility\AllOf;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Passes;
@@ -22,6 +23,49 @@ use PHPUnit\Framework\TestCase;
  */
 class AllOfTest extends TestCase
 {
+    public function dataSetsToConvertToString(): array
+    {
+        $validator = self::createMock(Validator::class);
+        $validator->method('__toString')
+            ->willReturn('condition');
+
+        return [
+            'no validators' => [
+                [],
+                '',
+            ],
+            'single validator' => [
+                [$validator],
+                <<<END
+                must satisfy all of the following:
+                \t- condition.
+                END,
+            ],
+            'multiple validators' => [
+                [$validator, $validator, $validator],
+                <<<END
+                must satisfy all of the following:
+                \t- condition.
+                \t- condition.
+                \t- condition.
+                END,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
+     */
+    public function toStringtest(array $chain, string $expected): void
+    {
+        $sut = new AllOf(...$chain);
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Utility/FailsTest.php
+++ b/tests/Validator/Utility/FailsTest.php
@@ -18,6 +18,17 @@ use PHPUnit\Framework\TestCase;
  */
 class FailsTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'will return invalid';
+        $sut = new Fails();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSets(): array
     {
         return [[1], [1.1], ['one'], [true], [null],];
@@ -30,9 +41,9 @@ class FailsTest extends TestCase
     public function failsAlwaysReturnsInvalid(mixed $input): void
     {
         $expected = Result::invalid($input, new MessageSet(null, new Message('I always fail', [])));
-        $fail = new Fails();
+        $sut = new Fails();
 
-        $result = $fail->validate($input);
+        $result = $sut->validate($input);
 
         self::assertEquals($expected, $result);
     }

--- a/tests/Validator/Utility/IndifferentTest.php
+++ b/tests/Validator/Utility/IndifferentTest.php
@@ -14,6 +14,17 @@ use PHPUnit\Framework\TestCase;
  */
 class IndifferentTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = '';
+        $sut = new Indifferent();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSets(): array
     {
         return [[1], [1.1], ['one'], [false], [null],];
@@ -25,10 +36,10 @@ class IndifferentTest extends TestCase
      */
     public function indifferentAlwaysReturnsNoResult(mixed $input): void
     {
-        $indifferent = new Indifferent();
+        $sut = new Indifferent();
         $expected = Result::noResult($input);
 
-        $result = $indifferent->validate($input);
+        $result = $sut->validate($input);
 
         self::assertEquals($expected, $result);
     }

--- a/tests/Validator/Utility/NotTest.php
+++ b/tests/Validator/Utility/NotTest.php
@@ -7,7 +7,9 @@ namespace Validator\Utility;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use Membrane\Validator;
 use Membrane\Validator\Utility\Fails;
+use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Not;
 use Membrane\Validator\Utility\Passes;
 use PHPUnit\Framework\TestCase;
@@ -15,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \Membrane\Validator\Utility\Not
  * @uses   \Membrane\Validator\Utility\Fails
+ * @uses   \Membrane\Validator\Utility\Indifferent
  * @uses   \Membrane\Validator\Utility\Passes
  * @uses   \Membrane\Result\Result
  * @uses   \Membrane\Result\MessageSet
@@ -22,31 +25,56 @@ use PHPUnit\Framework\TestCase;
  */
 class NotTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function notFailsAlwaysReturnsValid(): void
+    /** @test */
+    public function toStringTest(): void
     {
-        $input = 'any input will not fail';
-        $expected = Result::valid($input);
-        $notFail = new Not(new Fails());
+        $expected = 'must satisfy the opposite of the following: "inverted condition"';
+        $invertedValidator = self::createMock(Validator::class);
+        $sut = new Not($invertedValidator);
 
-        $result = $notFail->validate($input);
+        $invertedValidator->expects($this->once())
+            ->method('__toString')
+            ->willReturn('inverted condition');
 
-        self::assertEquals($expected, $result);
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function dataSetsToValidate(): array
+    {
+        return [
+            'inverted invalid results will be valid' => [
+                'a',
+                new Fails(),
+                Result::valid('a'),
+            ],
+            'inverted noResult results will stay noResult' => [
+                'b',
+                new Indifferent(),
+                Result::noResult('b'),
+            ],
+            'inverted valid results will be invalid' => [
+                'c',
+                new Passes(),
+                Result::invalid(
+                    'c',
+                    new MessageSet(null, new Message('Inverted validator: %s returned valid', [Passes::class]))
+                ),
+            ],
+        ];
     }
 
     /**
      * @test
+     * @dataProvider dataSetsToValidate
      */
-    public function notPassesAlwaysReturnsInvalid(): void
+    public function notInvertsInnerValidator(mixed $input, Validator $invertedValidator, Result $expected): void
     {
-        $input = 'any input will not pass';
-        $expected = Result::invalid($input, new MessageSet(null, new Message('Inner validator was valid', [])));
-        $notPasses = new Not(new Passes());
+        $sut = new Not($invertedValidator);
 
-        $result = $notPasses->validate('any input will not pass');
+        $actual = $sut->validate($input);
 
-        self::assertEquals($expected, $result);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/Validator/Utility/PassesTest.php
+++ b/tests/Validator/Utility/PassesTest.php
@@ -14,6 +14,17 @@ use PHPUnit\Framework\TestCase;
  */
 class PassesTest extends TestCase
 {
+    /** @test */
+    public function toStringTest(): void
+    {
+        $expected = 'will return valid';
+        $sut = new Passes();
+
+        $actual = $sut->__toString();
+
+        self::assertSame($expected, $actual);
+    }
+
     public function dataSets(): array
     {
         return [[1], [1.1], ['one'], [false], [null],];
@@ -26,9 +37,9 @@ class PassesTest extends TestCase
     public function passesAlwaysReturnsValid(mixed $input): void
     {
         $expected = Result::valid($input);
-        $pass = new Passes();
+        $sut = new Passes();
 
-        $result = $pass->validate($input);
+        $result = $sut->validate($input);
 
         self::assertEquals($expected, $result);
     }

--- a/tests/fixtures/Attribute/ArraySumFilter.php
+++ b/tests/fixtures/Attribute/ArraySumFilter.php
@@ -13,4 +13,9 @@ class ArraySumFilter implements Filter
     {
         return Result::noResult(array_reduce($value, fn($x, $y) => $x + $y));
     }
+
+    public function __toString()
+    {
+        return 'return a sum of all numbers in given value';
+    }
 }


### PR DESCRIPTION
close #78 

**merge #84 and #85 first**

- Filter, Validator interfaces now must have the `__toString()` method.

I've added `__toString()` to the interface rather than extending `\Stringable` so that it's more consistent with the next feature: `__toPHP()`