### PR TITLE
Refactored Processor tests to use test doubles

### DIFF
--- a/tests/Processor/AfterSetTest.php
+++ b/tests/Processor/AfterSetTest.php
@@ -58,98 +58,70 @@ class AfterSetTest extends TestCase
 
     public function dataSetsForFiltersOrValidators(): array
     {
-        $incrementFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key]++;
-                }
+        $filter1To2 = self::createMock(Filter::class);
+        $filter1To2->method('filter')
+            ->with(1)
+            ->willReturn(Result::noResult(2));
 
-                return Result::noResult($value);
-            }
-        };
+        $filter2To3 = self::createMock(Filter::class);
+        $filter2To3->method('filter')
+            ->with(2)
+            ->willReturn(Result::noResult(3));
 
-        $evenFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key] *= 2;
-                }
+        $validate1 = self::createMock(Validator::class);
+        $validate1->method('validate')
+            ->with(1)
+            ->willReturn(Result::valid(1));
 
-                return Result::noResult($value);
-            }
-        };
+        $validate2 = self::createMock(Validator::class);
+        $validate2->method('validate')
+            ->with(2)
+            ->willReturn(Result::valid(2));
 
-        $evenValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    if ($value[$key] % 2 !== 0) {
-                        return Result::invalid($value, new MessageSet(
-                            null,
-                            new Message('not even', [])
-                        ));
-                    }
-                }
-                return Result::valid($value);
-            }
-        };
+        $invalidate1 = self::createMock(Validator::class);
+        $invalidate1->method('validate')
+            ->with(1)
+            ->willReturn(Result::invalid(1, new MessageSet(null, new Message('oh no!', []))));
 
         return [
             'checks it can return valid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Passes(),
+                Result::valid(1),
+                new AfterSet(new Passes()),
+                1,
             ],
             'checks it can return invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3], new MessageSet(
-                    new FieldName('', 'parent field'),
-                    new Message('I always fail', [])
-                )),
-                new Fails(),
+                Result::invalid(
+                    1,
+                    new MessageSet(new FieldName('', 'parent field'), new Message('I always fail', []))
+                ),
+                new AfterSet(new Fails()),
+                1,
             ],
-            'checks it can return noresult' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Indifferent(),
+            'checks it can return noResult' => [
+                Result::noResult(1),
+                new AfterSet(new Indifferent()),
+                1,
             ],
             'checks it keeps track of previous results' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Passes(),
-                new Indifferent(),
-                new Indifferent(),
+                Result::valid(1),
+                new AfterSet(new Passes(), new Indifferent(), new Indifferent()),
+                1,
+
             ],
             'checks it can make changes to value' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 2, 'b' => 3, 'c' => 4]),
-                $incrementFilter,
+                Result::noResult(2),
+                new AfterSet($filter1To2),
+                1,
             ],
-            'checks that changes made to value persist' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 3, 'b' => 4, 'c' => 5]),
-                $incrementFilter,
-                $incrementFilter,
-            ],
-            'checks that chain runs in correct order' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3], new MessageSet(
-                    new FieldName('', 'parent field'),
-                    new Message('not even', [])
-                )),
-                $evenValidator,
-                $evenFilter,
+            'checks that changes made to value persist and chain runs in correct order' => [
+                Result::noResult(3),
+                new AfterSet($filter1To2, $filter2To3),
+                1,
             ],
             'checks that chain stops as soon as result is invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 2, 'b' => 3, 'c' => 4], new MessageSet(
-                    new FieldName('', 'parent field'),
-                    new Message('not even', [])
-                )),
-                $incrementFilter,
-                $evenValidator,
-                $incrementFilter,
+                Result::invalid(1, new MessageSet(new FieldName('', 'parent field'), new Message('oh no!', []))),
+                new AfterSet($invalidate1, $filter1To2),
+                1,
             ],
         ];
     }
@@ -158,15 +130,10 @@ class AfterSetTest extends TestCase
      * @test
      * @dataProvider dataSetsForFiltersOrValidators
      */
-    public function processesCallsFilterOrValidatorMethods(
-        mixed $input,
-        Result $expected,
-        Filter|Validator ...$chain
-    ): void {
-        $afterSet = new AfterSet(...$chain);
+    public function processesCallsFilterOrValidateMethods(Result $expected, AfterSet $sut, mixed $input): void
+    {
+        $actual = $sut->process(new FieldName('parent field'), $input);
 
-        $output = $afterSet->process(new FieldName('parent field'), $input);
-
-        self::assertEquals($expected, $output);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/Processor/DefaultProcessorTest.php
+++ b/tests/Processor/DefaultProcessorTest.php
@@ -42,104 +42,70 @@ class DefaultProcessorTest extends TestCase
 
     public function dataSetsForFiltersOrValidators(): array
     {
-        $incrementFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key]++;
-                }
+        $filter1To2 = self::createMock(Filter::class);
+        $filter1To2->method('filter')
+            ->with(1)
+            ->willReturn(Result::noResult(2));
 
-                return Result::noResult($value);
-            }
-        };
+        $filter2To3 = self::createMock(Filter::class);
+        $filter2To3->method('filter')
+            ->with(2)
+            ->willReturn(Result::noResult(3));
 
-        $evenFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key] *= 2;
-                }
+        $validate1 = self::createMock(Validator::class);
+        $validate1->method('validate')
+            ->with(1)
+            ->willReturn(Result::valid(1));
 
-                return Result::noResult($value);
-            }
-        };
+        $validate2 = self::createMock(Validator::class);
+        $validate2->method('validate')
+            ->with(2)
+            ->willReturn(Result::valid(2));
 
-        $evenValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    if ($value[$key] % 2 !== 0) {
-                        return Result::invalid(
-                            $value,
-                            new MessageSet(
-                                null,
-                                new Message('not even', [])
-                            )
-                        );
-                    }
-                }
-                return Result::valid($value);
-            }
-        };
+        $invalidate1 = self::createMock(Validator::class);
+        $invalidate1->method('validate')
+            ->with(1)
+            ->willReturn(Result::invalid(1, new MessageSet(null, new Message('oh no!', []))));
 
         return [
             'checks it can return valid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Passes(),
+                Result::valid(1),
+                DefaultProcessor::fromFiltersAndValidators(new Passes()),
+                1,
             ],
             'checks it can return invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3],
-                    new MessageSet(
-                        new FieldName('', 'parent field'),
-                        new Message('I always fail', [])
-                    )),
-                new Fails(),
+                Result::invalid(
+                    1,
+                    new MessageSet(new FieldName('', 'parent field'), new Message('I always fail', []))
+                ),
+                DefaultProcessor::fromFiltersAndValidators(new Fails()),
+                1,
             ],
-            'checks it can return noresult' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Indifferent(),
+            'checks it can return noResult' => [
+                Result::noResult(1),
+                DefaultProcessor::fromFiltersAndValidators(new Indifferent()),
+                1,
             ],
             'checks it keeps track of previous results' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Passes(),
-                new Indifferent(),
-                new Indifferent(),
+                Result::valid(1),
+                DefaultProcessor::fromFiltersAndValidators(new Passes(), new Indifferent(), new Indifferent()),
+                1,
+
             ],
             'checks it can make changes to value' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 2, 'b' => 3, 'c' => 4]),
-                $incrementFilter,
+                Result::noResult(2),
+                DefaultProcessor::fromFiltersAndValidators($filter1To2),
+                1,
             ],
-            'checks that changes made to value persist' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 3, 'b' => 4, 'c' => 5]),
-                $incrementFilter,
-                $incrementFilter,
-            ],
-            'checks that chain runs in correct order' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3],
-                    new MessageSet(
-                        new FieldName('', 'parent field'),
-                        new Message('not even', [])
-                    )),
-                $evenValidator,
-                $evenFilter,
+            'checks that changes made to value persist and chain runs in correct order' => [
+                Result::noResult(3),
+                DefaultProcessor::fromFiltersAndValidators($filter1To2, $filter2To3),
+                1,
             ],
             'checks that chain stops as soon as result is invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 2, 'b' => 3, 'c' => 4],
-                    new MessageSet(
-                        new FieldName('', 'parent field'),
-                        new Message('not even', [])
-                    )),
-                $incrementFilter,
-                $evenValidator,
-                $incrementFilter,
+                Result::invalid(1, new MessageSet(new FieldName('', 'parent field'), new Message('oh no!', []))),
+                DefaultProcessor::fromFiltersAndValidators($invalidate1, $filter1To2),
+                1,
             ],
         ];
     }
@@ -148,15 +114,10 @@ class DefaultProcessorTest extends TestCase
      * @test
      * @dataProvider dataSetsForFiltersOrValidators
      */
-    public function processesCallsFilterOrValidatorMethods(
-        mixed $input,
-        Result $expected,
-        Filter|Validator ...$chain
-    ): void {
-        $afterSet = DefaultProcessor::fromFiltersAndValidators(...$chain);
+    public function processesCallsFilterOrValidateMethods(Result $expected, DefaultProcessor $sut, mixed $input): void
+    {
+        $actual = $sut->process(new FieldName('parent field'), $input);
 
-        $output = $afterSet->process(new FieldName('parent field'), $input);
-
-        self::assertEquals($expected, $output);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/Processor/FieldTest.php
+++ b/tests/Processor/FieldTest.php
@@ -57,106 +57,70 @@ class FieldTest extends TestCase
 
     public function dataSetsForFiltersOrValidators(): array
     {
-        $incrementFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key]++;
-                }
+        $filter1To2 = self::createMock(Filter::class);
+        $filter1To2->method('filter')
+            ->with(1)
+            ->willReturn(Result::noResult(2));
 
-                return Result::noResult($value);
-            }
-        };
+        $filter2To3 = self::createMock(Filter::class);
+        $filter2To3->method('filter')
+            ->with(2)
+            ->willReturn(Result::noResult(3));
 
-        $evenFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key] *= 2;
-                }
+        $validate1 = self::createMock(Validator::class);
+        $validate1->method('validate')
+            ->with(1)
+            ->willReturn(Result::valid(1));
 
-                return Result::noResult($value);
-            }
-        };
+        $validate2 = self::createMock(Validator::class);
+        $validate2->method('validate')
+            ->with(2)
+            ->willReturn(Result::valid(2));
 
-        $evenValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    if ($value[$key] % 2 !== 0) {
-                        return Result::invalid($value, new MessageSet(
-                            null,
-                            new Message('not even', [])
-                        ));
-                    }
-                }
-                return Result::valid($value);
-            }
-        };
+        $invalidate1 = self::createMock(Validator::class);
+        $invalidate1->method('validate')
+            ->with(1)
+            ->willReturn(Result::invalid(1, new MessageSet(null, new Message('oh no!', []))));
 
         return [
             'checks it can return valid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                'field to process',
-                new Passes(),
+                Result::valid(1),
+                new Field('a', new Passes()),
+                1,
             ],
             'checks it can return invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3], new MessageSet(
-                    new FieldName('field to process', 'parent field'),
-                    new Message('I always fail', [])
-                )),
-                'field to process',
-                new Fails(),
+                Result::invalid(
+                    1,
+                    new MessageSet(new FieldName('b', 'parent field'), new Message('I always fail', []))
+                ),
+                new Field('b', new Fails()),
+                1,
             ],
             'checks it can return noResult' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 1, 'b' => 2, 'c' => 3]),
-                'field to process',
-                new Indifferent(),
+                Result::noResult(1),
+                new Field('c', new Indifferent()),
+                1,
             ],
             'checks it keeps track of previous results' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                'field to process',
-                new Passes(),
-                new Indifferent(),
-                new Indifferent(),
+                Result::valid(1),
+                new Field('d', new Passes(), new Indifferent(), new Indifferent()),
+                1,
+
             ],
             'checks it can make changes to value' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 2, 'b' => 3, 'c' => 4]),
-                'a',
-                $incrementFilter,
+                Result::noResult(2),
+                new Field('e', $filter1To2),
+                1,
             ],
-            'checks that changes made to value persist' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 3, 'b' => 4, 'c' => 5]),
-                'c',
-                $incrementFilter,
-                $incrementFilter,
-            ],
-            'checks that chain runs in correct order' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3], new MessageSet(
-                    new FieldName('b', 'parent field'),
-                    new Message('not even', [])
-                )),
-                'b',
-                $evenValidator,
-                $evenFilter,
+            'checks that changes made to value persist and chain runs in correct order' => [
+                Result::noResult(3),
+                new Field('f', $filter1To2, $filter2To3),
+                1,
             ],
             'checks that chain stops as soon as result is invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 2, 'b' => 3, 'c' => 4], new MessageSet(
-                    new FieldName('b', 'parent field'),
-                    new Message('not even', [])
-                )),
-                'b',
-                $incrementFilter,
-                $evenValidator,
-                $incrementFilter,
+                Result::invalid(1, new MessageSet(new FieldName('g', 'parent field'), new Message('oh no!', []))),
+                new Field('g', $invalidate1, $filter1To2),
+                1,
             ],
         ];
     }
@@ -165,16 +129,10 @@ class FieldTest extends TestCase
      * @test
      * @dataProvider dataSetsForFiltersOrValidators
      */
-    public function processesCallsFilterOrValidateMethods(
-        mixed $input,
-        Result $expected,
-        string $processes,
-        Filter|Validator ...$chain
-    ): void {
-        $field = new Field($processes, ...$chain);
+    public function processesCallsFilterOrValidateMethods(Result $expected, Field $sut, mixed $input): void
+    {
+        $actual = $sut->process(new FieldName('parent field'), $input);
 
-        $output = $field->process(new FieldName('parent field'), $input);
-
-        self::assertEquals($expected, $output);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/tests/Processor/FieldsetTest.php
+++ b/tests/Processor/FieldsetTest.php
@@ -158,131 +158,111 @@ class FieldsetTest extends TestCase
 
     public function dataSetsOfFields(): array
     {
-        $incrementFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                return Result::noResult(++$value);
-            }
-        };
+        $filter1To2 = self::createMock(Filter::class);
+        $filter1To2->method('filter')
+            ->with(1)
+            ->willReturn(Result::noResult(2));
 
-        $decrementFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                return Result::noResult(--$value);
-            }
-        };
+        $filter2To3 = self::createMock(Filter::class);
+        $filter2To3->method('filter')
+            ->with(2)
+            ->willReturn(Result::noResult(3));
 
-        $evenArrayFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key] *= 2;
-                }
-                return Result::noResult($value);
-            }
-        };
+        $filter123ArrayTo321Array = self::createMock(Filter::class);
+        $filter123ArrayTo321Array->method('filter')
+            ->with(['a' => 1, 'b' => 2, 'c' => 3])
+            ->willReturn(Result::noResult(['a' => 3, 'b' => 2, 'c' => 1]));
 
-        $evenValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                if ($value % 2 !== 0) {
-                    return Result::invalid(
-                        $value,
-                        new MessageSet(
-                            null,
-                            new Message('not even', [])
-                        )
-                    );
-                }
-                return Result::valid($value);
-            }
-        };
+        $validate111Array = self::createMock(Filter::class);
+        $validate111Array->method('filter')
+            ->with(['a' => 1, 'b' => 1, 'c' => 1])
+            ->willReturn(Result::valid(['a' => 1, 'b' => 1, 'c' => 1]));
 
-        $evenArrayValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    if ($value[$key] % 2 !== 0) {
-                        return Result::invalid(
-                            $value,
-                            new MessageSet(
-                                null,
-                                new Message('not even', [])
-                            )
-                        );
-                    }
-                }
-                return Result::valid($value);
-            }
-        };
+        $validate321Array = self::createMock(Filter::class);
+        $validate321Array->method('filter')
+            ->with(['a' => 3, 'b' => 2, 'c' => 1])
+            ->willReturn(Result::valid(['a' => 3, 'b' => 2, 'c' => 1]));
+
+        $validate1 = self::createMock(Validator::class);
+        $validate1->method('validate')
+            ->with(1)
+            ->willReturn(Result::valid(1));
+
+        $validate2 = self::createMock(Validator::class);
+        $validate2->method('validate')
+            ->with(2)
+            ->willReturn(Result::valid(2));
+
+        $invalidate3 = self::createMock(Validator::class);
+        $invalidate3->method('validate')
+            ->with(3)
+            ->willReturn(Result::invalid(3, new MessageSet(null, new Message('oh no!', []))));
 
         return [
             'Field only performs processes on defined processes field' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 Result::noResult(['a' => 2, 'b' => 2, 'c' => 3]),
-                new Field('a', $incrementFilter),
+                new Field('a', $filter1To2),
             ],
             'DefaultProcessor only processes fields not processed by other Field Processors' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 2, 'b' => 1, 'c' => 2]),
-                new Field('a', $incrementFilter),
-                DefaultProcessor::fromFiltersAndValidators($decrementFilter),
+                ['a' => 1, 'b' => 2, 'c' => 2],
+                Result::noResult(['a' => 2, 'b' => 3, 'c' => 3]),
+                new Field('a', $filter1To2),
+                DefaultProcessor::fromFiltersAndValidators($filter2To3),
             ],
             'Field processed values persist' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 1, 'b' => 4, 'c' => 3]),
-                new Field('b', $incrementFilter, $incrementFilter),
+                ['a' => 1, 'b' => 1, 'c' => 3],
+                Result::noResult(['a' => 1, 'b' => 3, 'c' => 3]),
+                new Field('b', $filter1To2, $filter2To3),
             ],
             'Field processed can return valid results' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Field('b', $evenValidator),
+                new Field('b', $validate2),
             ],
             'Field processed can return invalid results' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 Result::invalid(['a' => 1, 'b' => 2, 'c' => 3],
                     new MessageSet(
-                        new FieldName('a', 'parent field', 'field to process'),
-                        new Message('not even', [])
+                        new FieldName('c', 'parent field', 'field to process'),
+                        new Message('oh no!', [])
                     )),
-                new Field('a', $evenValidator),
+                new Field('c', $invalidate3),
             ],
             'Multiple Fields are accepted' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 Result::valid(['a' => 2, 'b' => 3, 'c' => 3]),
-                new Field('a', $incrementFilter),
-                new Field('a', $evenValidator),
-                new Field('b', $incrementFilter),
+                new Field('a', $filter1To2),
+                new Field('a', $validate2),
+                new Field('b', $filter2To3),
             ],
             'BeforeSetProcessesBeforeField' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 2, 'b' => 4, 'c' => 6]),
-                new BeforeSet($evenArrayFilter),
-                new Field('c', $evenValidator),
+                Result::valid(['a' => 3, 'b' => 2, 'c' => 1]),
+                new BeforeSet($filter123ArrayTo321Array),
+                new Field('c', $validate1),
             ],
             'BeforeSetProcessesBeforeAfterSet' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 2, 'b' => 4, 'c' => 6]),
-                new BeforeSet($evenArrayFilter),
-                new AfterSet($evenArrayValidator),
+                Result::valid(['a' => 3, 'b' => 2, 'c' => 1]),
+                new BeforeSet($filter123ArrayTo321Array),
+                new AfterSet($validate321Array),
             ],
             'AfterSetProcessesAfterField' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 2, 'b' => 2, 'c' => 4]),
-                new Field('a', $incrementFilter),
-                new Field('c', $incrementFilter),
-                new AfterSet($evenArrayValidator),
+                ['a' => 2, 'b' => 1, 'c' => 1],
+                Result::valid(['a' => 3, 'b' => 2, 'c' => 1]),
+                new Field('a', $filter2To3),
+                new Field('b', $filter1To2),
+                new AfterSet($validate321Array),
             ],
             'BeforeSetThenFieldThenAfterSet' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 2, 'b' => 5, 'c' => 6],
-                    new MessageSet(
-                        new FieldName('', 'parent field', 'field to process'),
-                        new Message('not even', [])
-                    )),
-                new BeforeSet($evenArrayFilter),
-                new Field('b', $incrementFilter),
-                new AfterSet($evenArrayValidator),
+                ['a' => 1, 'b' => 1, 'c' => 1],
+                Result::valid(['a' => 3, 'b' => 2, 'c' => 1]),
+                new BeforeSet($validate111Array),
+                new Field('a', $filter1To2),
+                new Field('a', $filter2To3),
+                new Field('b', $filter1To2),
+                new AfterSet($validate321Array),
             ],
         ];
     }


### PR DESCRIPTION
Anonymous classes implementing filter and validator interfaces in processor tests have been replaced with mocks instead

**Problem**
When adding new methods to the Validator and Filter interfaces, the Processor tests would explode because their anonymous classes needed to implement the new methods.

**Solution**
This PR replaces the anonymous classes with mocks so they do not need to implement every method being added. Which will save time developing and reduce amount of changes in PR reviews

**Merge before #82**