### PR TITLE
Refactored Processor tests to use existing classes

### DIFF
--- a/tests/OpenAPI/Processor/RequestTest.php
+++ b/tests/OpenAPI/Processor/RequestTest.php
@@ -7,20 +7,26 @@ namespace OpenAPI\Processor;
 use GuzzleHttp\Psr7\ServerRequest;
 use Membrane\OpenAPI\Processor\Request;
 use Membrane\Processor;
+use Membrane\Processor\Field;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use Membrane\Validator\Utility\Fails;
+use Membrane\Validator\Utility\Passes;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
  * @covers \Membrane\OpenAPI\Processor\Request
+ * @uses   \Membrane\Processor\Field
  * @uses   \Membrane\Result\FieldName
  * @uses   \Membrane\Result\MessageSet
  * @uses   \Membrane\Result\Message
  * @uses   \Membrane\Result\Result
+ * @uses   \Membrane\Validator\Utility\Fails
+ * @uses   \Membrane\Validator\Utility\Passes
  */
 class RequestTest extends TestCase
 {
@@ -61,29 +67,9 @@ class RequestTest extends TestCase
 
     public function dataSetsToProcess(): array
     {
-        $validProcessor = new class() implements Processor {
-            public function processes(): string
-            {
-                return '';
-            }
+        $validProcessor = new Field('', new Passes());
 
-            public function process(FieldName $parentFieldName, mixed $value): Result
-            {
-                return Result::valid($value);
-            }
-        };
-
-        $invalidProcessor = new class() implements Processor {
-            public function processes(): string
-            {
-                return '';
-            }
-
-            public function process(FieldName $parentFieldName, mixed $value): Result
-            {
-                return Result::invalid($value, new MessageSet(null, new Message('invalid result', [])));
-            }
-        };
+        $invalidProcessor = new Field('', new Fails());
 
         $uri = self::createMock(UriInterface::class);
         $uri->method('getPath')
@@ -143,8 +129,8 @@ class RequestTest extends TestCase
                     'cookie' => [],
                     'body' => '',
                 ],
-                    new MessageSet(null, new Message('invalid result', [])),
-                    new MessageSet(null, new Message('invalid result', []))
+                    new MessageSet(new FieldName('', ''), new Message('I always fail', [])),
+                    new MessageSet(new FieldName('', ''), new Message('I always fail', []))
                 ),
             ],
             'mock server request, no processors' => [
@@ -191,8 +177,8 @@ class RequestTest extends TestCase
                     'cookie' => [],
                     'body' => 'request body',
                 ],
-                    new MessageSet(null, new Message('invalid result', [])),
-                    new MessageSet(null, new Message('invalid result', []))
+                    new MessageSet(new FieldName('', ''), new Message('I always fail', [])),
+                    new MessageSet(new FieldName('', ''), new Message('I always fail', []))
                 ),
             ],
             'guzzle server request, valid processors' => [

--- a/tests/Processor/BeforeSetTest.php
+++ b/tests/Processor/BeforeSetTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Processor;
 
-use Membrane\Filter;
+use Membrane\Filter\Type\ToFloat;
 use Membrane\Processor\BeforeSet;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
-use Membrane\Validator;
+use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
  * @uses   \Membrane\Result\Result
  * @uses   \Membrane\Result\MessageSet
  * @uses   \Membrane\Result\Message
+ * @uses   \Membrane\Filter\Type\ToFloat
+ * @uses   \Membrane\Validator\Type\IsFloat
  * @uses   \Membrane\Validator\Utility\Fails
  * @uses   \Membrane\Validator\Utility\Indifferent
  * @uses   \Membrane\Validator\Utility\Passes
@@ -29,9 +31,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BeforeSetTest extends TestCase
 {
-    /**
-     * @test
-     */
+    /**  @test */
     public function processesMethodReturnsEmptyString(): void
     {
         $expected = '';
@@ -42,114 +42,58 @@ class BeforeSetTest extends TestCase
         self::assertSame($expected, $result);
     }
 
-    /**
-     * @test
-     */
-    public function noChainReturnsNoResult(): void
-    {
-        $input = ['a' => 1, 'b' => 2, 'c' => 3];
-        $expected = Result::noResult($input);
-        $field = new BeforeSet();
-
-        $result = $field->process(new Fieldname('Parent FieldName'), $input);
-
-        self::assertEquals($expected, $result);
-    }
-
     public function dataSetsForFiltersOrValidators(): array
     {
-        $incrementFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key]++;
-                }
-
-                return Result::noResult($value);
-            }
-        };
-
-        $evenFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key] *= 2;
-                }
-
-                return Result::noResult($value);
-            }
-        };
-
-        $evenValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    if ($value[$key] % 2 !== 0) {
-                        return Result::invalid($value, new MessageSet(
-                            null,
-                            new Message('not even', [])
-                        ));
-                    }
-                }
-                return Result::valid($value);
-            }
-        };
-
         return [
-            'checks it can return valid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Passes(),
+            'no chain returns noResult' => [
+                Result::noResult(1),
+                new BeforeSet(),
+                1,
             ],
-            'checks it can return invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3], new MessageSet(
-                    new FieldName('', 'parent field'),
-                    new Message('I always fail', [])
-                )),
-                new Fails(),
+            'can return valid' => [
+                Result::valid(1),
+                new BeforeSet(new Passes()),
+                1,
             ],
-            'checks it can return noresult' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Indifferent(),
+            'can return invalid' => [
+                Result::invalid(
+                    1,
+                    new MessageSet(new FieldName('', 'parent field'), new Message('I always fail', []))
+                ),
+                new BeforeSet(new Fails()),
+                1,
+            ],
+            'can return noResult' => [
+                Result::noResult(1),
+                new BeforeSet(new Indifferent()),
+                1,
             ],
             'checks it keeps track of previous results' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::valid(['a' => 1, 'b' => 2, 'c' => 3]),
-                new Passes(),
-                new Indifferent(),
-                new Indifferent(),
+                Result::valid(1),
+                new BeforeSet(new Passes(), new Indifferent(), new Indifferent()),
+                1,
+
             ],
             'checks it can make changes to value' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 2, 'b' => 3, 'c' => 4]),
-                $incrementFilter,
+                Result::noResult(5.0),
+                new BeforeSet(new ToFloat()),
+                '5',
             ],
-            'checks that changes made to value persist' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::noResult(['a' => 3, 'b' => 4, 'c' => 5]),
-                $incrementFilter,
-                $incrementFilter,
-            ],
-            'checks that chain runs in correct order' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 1, 'b' => 2, 'c' => 3], new MessageSet(
-                    new FieldName('', 'parent field'),
-                    new Message('not even', [])
-                )),
-                $evenValidator,
-                $evenFilter,
+            'checks that changes made to value persist and chain runs in correct order' => [
+                Result::valid(5.0),
+                new BeforeSet(new ToFloat(), new IsFloat()),
+                '5',
             ],
             'checks that chain stops as soon as result is invalid' => [
-                ['a' => 1, 'b' => 2, 'c' => 3],
-                Result::invalid(['a' => 2, 'b' => 3, 'c' => 4], new MessageSet(
-                    new FieldName('', 'parent field'),
-                    new Message('not even', [])
-                )),
-                $incrementFilter,
-                $evenValidator,
-                $incrementFilter,
+                Result::invalid(
+                    '5',
+                    new MessageSet(
+                        new FieldName('', 'parent field'),
+                        new Message('IsFloat expects float value, %s passed instead', ['string'])
+                    )
+                ),
+                new BeforeSet(new IsFloat(), new ToFloat()),
+                '5',
             ],
         ];
     }
@@ -158,15 +102,11 @@ class BeforeSetTest extends TestCase
      * @test
      * @dataProvider dataSetsForFiltersOrValidators
      */
-    public function processesCallsFilterOrValidatorMethods(
-        mixed $input,
-        Result $expected,
-        Filter|Validator ...$chain
-    ): void {
-        $beforeSet = new BeforeSet(...$chain);
+    public function processesCallsFilterOrValidateMethods(Result $expected, BeforeSet $sut, mixed $input): void
+    {
+        $actual = $sut->process(new FieldName('parent field'), $input);
 
-        $output = $beforeSet->process(new FieldName('parent field'), $input);
-
-        self::assertEquals($expected, $output);
+        self::assertEquals($expected, $actual);
+        self::assertSame($expected->value, $actual->value);
     }
 }

--- a/tests/Processor/CollectionTest.php
+++ b/tests/Processor/CollectionTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Processor;
 
 use Membrane\Exception\InvalidProcessorArguments;
-use Membrane\Filter;
+use Membrane\Filter\Shape\Truncate;
+use Membrane\Filter\Type\ToFloat;
 use Membrane\Processor;
 use Membrane\Processor\AfterSet;
 use Membrane\Processor\BeforeSet;
@@ -15,12 +16,18 @@ use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
-use Membrane\Validator;
+use Membrane\Validator\Collection\Count;
+use Membrane\Validator\Type\IsFloat;
+use Membrane\Validator\Utility\Fails;
+use Membrane\Validator\Utility\Indifferent;
+use Membrane\Validator\Utility\Passes;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Membrane\Processor\Collection
  * @covers \Membrane\Exception\InvalidProcessorArguments
+ * @uses   \Membrane\Filter\Shape\Truncate
+ * @uses   \Membrane\Filter\Type\ToFloat
  * @uses   \Membrane\Processor\BeforeSet
  * @uses   \Membrane\Processor\Field
  * @uses   \Membrane\Processor\AfterSet
@@ -28,6 +35,11 @@ use PHPUnit\Framework\TestCase;
  * @uses   \Membrane\Result\Result
  * @uses   \Membrane\Result\MessageSet
  * @uses   \Membrane\Result\Message
+ * @uses   \Membrane\Validator\Collection\Count
+ * @uses   \Membrane\Validator\Type\IsFloat
+ * @uses   \Membrane\Validator\Utility\Passes
+ * @uses   \Membrane\Validator\Utility\Indifferent
+ * @uses   \Membrane\Validator\Utility\Fails
  */
 class CollectionTest extends TestCase
 {
@@ -59,9 +71,7 @@ class CollectionTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function onlyAcceptsOneField(): void
     {
         $field = new Field('field to process');
@@ -70,9 +80,7 @@ class CollectionTest extends TestCase
         new Collection('field to process', $field, $field);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function processesTest(): void
     {
         $fieldName = 'field to process';
@@ -83,9 +91,7 @@ class CollectionTest extends TestCase
         self::assertEquals($fieldName, $output);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function processMethodWithNoChainReturnsNoResult(): void
     {
         $value = [];
@@ -99,107 +105,66 @@ class CollectionTest extends TestCase
 
     public function dataSetsOfFields(): array
     {
-        $incrementFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                return Result::noResult(++$value);
-            }
-        };
-
-        $evenFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                return Result::noResult($value * 2);
-            }
-        };
-
-        $evenArrayFilter = new class implements Filter {
-            public function filter(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    $value[$key] *= 2;
-                }
-                return Result::noResult($value);
-            }
-        };
-
-        $evenValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                if ($value % 2 !== 0) {
-                    return Result::invalid(
-                        $value,
-                        new MessageSet(
-                            null,
-                            new Message('not even', [])
-                        )
-                    );
-                }
-                return Result::valid($value);
-            }
-        };
-
-        $evenArrayValidator = new class implements Validator {
-            public function validate(mixed $value): Result
-            {
-                foreach (array_keys($value) as $key) {
-                    if ($value[$key] % 2 !== 0) {
-                        return Result::invalid(
-                            $value,
-                            new MessageSet(
-                                null,
-                                new Message('not even', [])
-                            )
-                        );
-                    }
-                }
-                return Result::valid($value);
-            }
-        };
-
         return [
-            'Field process method is called for every item in array' => [
+            'No chain returns noResult' => [
                 [1, 2, 3],
-                Result::noResult([2, 3, 4]),
-                new Field('a', $incrementFilter),
+                Result::noResult([1, 2, 3]),
             ],
-            'Field processed values persist' => [
+            'Return valid result' => [
                 [1, 2, 3],
-                Result::noResult([3, 4, 5]),
-                new Field('b', $incrementFilter, $incrementFilter),
+                Result::valid([1, 2, 3]),
+                new Field('a', new Passes()),
             ],
-            'Field processed can return valid results' => [
+            'Return noResult' => [
                 [1, 2, 3],
-                Result::valid([2, 4, 6]),
-                new Field('b', $evenFilter, $evenValidator),
+                Result::noResult([1, 2, 3]),
+                new Field('b', new Indifferent()),
             ],
-            'Field processed can return invalid results' => [
+            'Return invalid result' => [
                 [1, 2, 3],
                 Result::invalid(
                     [1, 2, 3],
                     new MessageSet(
-                        new FieldName('a', 'parent field', 'field to process', '0'),
-                        new Message('not even', [])
+                        new FieldName('c', 'parent field', 'field to process', '0'),
+                        new Message('I always fail', [])
                     ),
                     new MessageSet(
-                        new FieldName('a', 'parent field', 'field to process', '2'),
-                        new Message('not even', [])
+                        new FieldName('c', 'parent field', 'field to process', '1'),
+                        new Message('I always fail', [])
+                    ),
+                    new MessageSet(
+                        new FieldName('c', 'parent field', 'field to process', '2'),
+                        new Message('I always fail', [])
                     )
                 ),
-
-                new Field('a', $evenValidator),
+                new Field('c', new Fails()),
+            ],
+            'Field processes every item in array' => [
+                [1, 2, 3],
+                Result::noResult([1.0, 2.0, 3.0]),
+                new Field('d', new ToFloat()),
+            ],
+            'Field processed values persist' => [
+                [1, 2, 3],
+                Result::valid([1.0, 2.0, 3.0]),
+                new Field('e', new ToFloat(), new IsFloat()),
             ],
             'BeforeSet processes before Field' => [
-                [1, 2, 3],
-                Result::valid([2, 4, 6]),
-                new BeforeSet($evenArrayFilter),
-                new Field('c', $evenValidator),
+                [1.0, 2.0, 3.0],
+                Result::noResult([]),
+                new BeforeSet(new Truncate(0)),
+                new Field('f', new IsFloat()),
             ],
             'BeforeSet processes before AfterSet' => [
                 [1, 2, 3],
-                Result::valid([2, 4, 6]),
-                new BeforeSet($evenArrayFilter),
-                new AfterSet($evenArrayValidator),
+                Result::invalid([1, 2],
+                    new MessageSet(
+                        new FieldName('', 'parent field', 'field to process'),
+                        new Message('Array is expected have a minimum of %d values', [3])
+                    )
+                ),
+                new BeforeSet(new Truncate(2)),
+                new AfterSet(new Count(3)),
             ],
             'AfterSet does not process if BeforeSet returns invalid' => [
                 [1, 2, 3],
@@ -207,34 +172,24 @@ class CollectionTest extends TestCase
                     [1, 2, 3],
                     new MessageSet(
                         new FieldName('', 'parent field', 'field to process'),
-                        new Message('not even', [])
+                        new Message('Array is expected have a minimum of %d values', [4])
                     )
                 ),
-                new BeforeSet($evenArrayValidator),
-                new AfterSet($evenArrayFilter),
+                new BeforeSet(new Count(4)),
+                new AfterSet(new Truncate(2)),
             ],
             'AfterSet processes after Field' => [
-                [1, 2, 3],
-                Result::invalid(
-                    [2, 3, 4],
-                    new MessageSet(
-                        new FieldName('', 'parent field', 'field to process'),
-                        new Message('not even', [])
-                    )
-                ),
-                new Field('a', $incrementFilter),
-                new AfterSet($evenArrayValidator),
+                [1.0, 2.0, 3.0],
+                Result::valid([]),
+                new Field('i', new IsFloat()),
+                new AfterSet(new Truncate(0)),
             ],
             'BeforeSet then Field then AfterSet' => [
                 [1, 2, 3],
-                Result::invalid([3, 5, 7],
-                    new MessageSet(
-                        new FieldName('', 'parent field', 'field to process'),
-                        new Message('not even', [])
-                    )),
-                new BeforeSet($evenArrayFilter),
-                new Field('b', $incrementFilter),
-                new AfterSet($evenArrayValidator),
+                Result::valid([]),
+                new BeforeSet(new Truncate(0)),
+                new Field('j', new IsFloat()),
+                new AfterSet(new Count(0, 0)),
             ],
         ];
     }
@@ -245,10 +200,11 @@ class CollectionTest extends TestCase
      */
     public function processTest(array $input, Result $expected, Processor ...$chain): void
     {
-        $fieldset = new Collection('field to process', ...$chain);
+        $sut = new Collection('field to process', ...$chain);
 
-        $result = $fieldset->process(new FieldName('parent field'), $input);
+        $actual = $sut->process(new FieldName('parent field'), $input);
 
-        self::assertEquals($expected, $result);
+        self::assertEquals($expected, $actual);
+        self::assertSame($expected->value, $actual->value);
     }
 }


### PR DESCRIPTION
Anonymous classes implementing filter and validator interfaces in processor tests have been replaced with existing classes

Problem
When adding new methods to the Validator and Filter interfaces, the Processor tests would explode because their anonymous classes needed to implement the new methods.

Solution
This PR replaces the anonymous classes so that tests do not need refactoring for every change to Validator|Filter interfaces unless it breaks existing behaviour.

Merge before https://github.com/membrane-php/membrane-core/pull/82