### PR TITLE
Filters, Processors and Validators can be cast to PHP code

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -11,4 +11,6 @@ interface Filter
     public function filter(mixed $value): Result;
 
     public function __toString();
+
+    public function __toPHP(): string;
 }

--- a/src/Filter/CreateObject/FromArray.php
+++ b/src/Filter/CreateObject/FromArray.php
@@ -21,6 +21,11 @@ class FromArray implements Filter
         return sprintf('calls %s::fromArray', $this->className);
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s("%s")', self::class, $this->className);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!method_exists($this->className, 'fromArray')) {

--- a/src/Filter/CreateObject/WithNamedArguments.php
+++ b/src/Filter/CreateObject/WithNamedArguments.php
@@ -22,6 +22,11 @@ class WithNamedArguments implements Filter
         return sprintf('construct an instance of "%s" from named arguments contained in self', $this->className);
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s("%s")', self::class, $this->className);
+    }
+
     public function filter(mixed $value): Result
     {
         try {

--- a/src/Filter/Shape/Collect.php
+++ b/src/Filter/Shape/Collect.php
@@ -35,6 +35,13 @@ class Collect implements Filter
         );
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s("%s"', self::class, $this->newField) .
+            implode('', array_map(fn($p) => ', "' . $p . '"', $this->fields)) .
+            ')';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Delete.php
+++ b/src/Filter/Shape/Delete.php
@@ -28,6 +28,13 @@ class Delete implements Filter
         return sprintf('delete "' . implode('", "', $this->fieldNames) . '" from self');
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(', self::class) .
+            implode(', ', array_map(fn($p) => '"' . $p . '"', $this->fieldNames)) .
+            ')';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Nest.php
+++ b/src/Filter/Shape/Nest.php
@@ -35,6 +35,13 @@ class Nest implements Filter
         );
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s("%s"', self::class, $this->newField) .
+            implode('', array_map(fn($p) => ', "' . $p . '"', $this->fields)) .
+            ')';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Pluck.php
+++ b/src/Filter/Shape/Pluck.php
@@ -33,6 +33,13 @@ class Pluck implements Filter
         );
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s("%s"', self::class, $this->fieldSet) .
+            implode('', array_map(fn($p) => ', "' . $p . '"', $this->fieldNames)) .
+            ')';
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Rename.php
+++ b/src/Filter/Shape/Rename.php
@@ -29,6 +29,11 @@ class Rename implements Filter
         return sprintf('rename "%s" to "%s"', $this->old, $this->new);
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s("%s", "%s")', self::class, $this->old, $this->new);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Shape/Truncate.php
+++ b/src/Filter/Shape/Truncate.php
@@ -24,6 +24,11 @@ class Truncate implements Filter
         return sprintf('truncate self to %d fields or less', $this->maxLength);
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%d)', self::class, $this->maxLength);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/String/JsonDecode.php
+++ b/src/Filter/String/JsonDecode.php
@@ -16,6 +16,11 @@ class JsonDecode implements Filter
         return 'convert from json to a PHP value';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Filter/Type/ToBool.php
+++ b/src/Filter/Type/ToBool.php
@@ -16,6 +16,11 @@ class ToBool implements Filter
         return 'convert to a boolean';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_scalar($value)) {

--- a/src/Filter/Type/ToDateTime.php
+++ b/src/Filter/Type/ToDateTime.php
@@ -24,6 +24,11 @@ class ToDateTime implements Filter
         return 'convert to a DateTime';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s("%s", %s)', self::class, $this->format, $this->immutable ? 'true' : 'false');
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Filter/Type/ToFloat.php
+++ b/src/Filter/Type/ToFloat.php
@@ -17,6 +17,11 @@ class ToFloat implements Filter
     }
 
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function filter(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Filter/Type/ToInt.php
+++ b/src/Filter/Type/ToInt.php
@@ -16,6 +16,11 @@ class ToInt implements Filter
         return 'convert to an integer';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function filter(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Filter/Type/ToList.php
+++ b/src/Filter/Type/ToList.php
@@ -16,6 +16,11 @@ class ToList implements Filter
         return 'convert to a list';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Filter/Type/ToNumber.php
+++ b/src/Filter/Type/ToNumber.php
@@ -16,6 +16,11 @@ class ToNumber implements Filter
         return 'convert to a number';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_numeric($value)) {

--- a/src/Filter/Type/ToString.php
+++ b/src/Filter/Type/ToString.php
@@ -16,6 +16,11 @@ class ToString implements Filter
         return 'convert to a string';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!(is_object($value) || is_null($value) || is_scalar($value))) {

--- a/src/OpenAPI/Filter/HTTPParameters.php
+++ b/src/OpenAPI/Filter/HTTPParameters.php
@@ -16,6 +16,11 @@ class HTTPParameters implements Filter
         return 'convert query string to a field set of query parameters';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/OpenAPI/Filter/PathMatcher.php
+++ b/src/OpenAPI/Filter/PathMatcher.php
@@ -22,6 +22,17 @@ class PathMatcher implements Filter
         return 'convert url to a field set of path parameters';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf(
+            'new %s(new %s("%s", "%s"))',
+            self::class,
+            $this->pathMatcher::class,
+            $this->pathMatcher->serverUrl,
+            $this->pathMatcher->apiPath
+        );
+    }
+
     public function filter(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/OpenAPI/PathMatcher.php
+++ b/src/OpenAPI/PathMatcher.php
@@ -13,26 +13,28 @@ class PathMatcher
     private readonly array $parameters;
     private readonly string $pathUrl;
 
-    public function __construct(string $serverUrl, string $apiPath)
-    {
-        $parseUrl = parse_url($serverUrl, PHP_URL_PATH);
+    public function __construct(
+        public readonly string $serverUrl,
+        public readonly string $apiPath
+    ) {
+        $parseUrl = parse_url($this->serverUrl, PHP_URL_PATH);
         $this->pathUrl = is_string($parseUrl) ? $parseUrl : '';
 
         $parameterNames = [];
         $pregParts = [];
         $inParameter = false;
 
-        $parts = preg_split('#([{}])#', $apiPath, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('#([{}])#', $this->apiPath, -1, PREG_SPLIT_DELIM_CAPTURE);
         assert($parts !== false);
         foreach ($parts as $part) {
             switch ($part) {
                 case '{':
                     $inParameter = !$inParameter ? true :
-                    throw CannotProcessOpenAPI::invalidPath($apiPath);
+                    throw CannotProcessOpenAPI::invalidPath($this->apiPath);
                     continue 2;
                 case '}':
                     $inParameter = $inParameter ? false :
-                    throw CannotProcessOpenAPI::invalidPath($apiPath);
+                    throw CannotProcessOpenAPI::invalidPath($this->apiPath);
                     continue 2;
             }
 

--- a/src/OpenAPI/Processor/AllOf.php
+++ b/src/OpenAPI/Processor/AllOf.php
@@ -30,6 +30,16 @@ class AllOf implements Processor
             implode(".\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->processors)) . '.';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf(
+            'new %s("%s"%s)',
+            self::class,
+            $this->processes(),
+            implode('', array_map(fn($p) => ', ' . $p->__toPHP(), $this->processors))
+        );
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/OpenAPI/Processor/AnyOf.php
+++ b/src/OpenAPI/Processor/AnyOf.php
@@ -14,20 +14,30 @@ use function count;
 class AnyOf implements Processor
 {
     /** @var Processor[] */
-    public array $fieldSets;
+    public array $processors;
 
-    public function __construct(private readonly string $processes, Processor ...$fieldSets)
+    public function __construct(private readonly string $processes, Processor ...$processors)
     {
-        if (count($fieldSets) < 2) {
+        if (count($processors) < 2) {
             throw InvalidProcessorArguments::redundantProcessor(AnyOf::class);
         }
-        $this->fieldSets = $fieldSets;
+        $this->processors = $processors;
+    }
+
+    public function __toPHP(): string
+    {
+        return sprintf(
+            'new %s("%s"%s)',
+            self::class,
+            $this->processes(),
+            implode('', array_map(fn($p) => ', ' . $p->__toPHP(), $this->processors))
+        );
     }
 
     public function __toString(): string
     {
         return "Any of the following:\n\t" .
-            implode(".\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->fieldSets)) . '.';
+            implode(".\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->processors)) . '.';
     }
 
     public function processes(): string
@@ -40,7 +50,7 @@ class AnyOf implements Processor
         $results = [];
         $messageSets = [];
 
-        foreach ($this->fieldSets as $fieldSet) {
+        foreach ($this->processors as $fieldSet) {
             $itemResult = $fieldSet->process($parentFieldName, $value);
 
             if ($itemResult->result === Result::VALID) {

--- a/src/OpenAPI/Processor/Json.php
+++ b/src/OpenAPI/Processor/Json.php
@@ -28,6 +28,11 @@ class Json implements Processor
             str_replace(sprintf('"%s":', $processes), '', (string)$this->wrapped);
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%s)', self::class, $this->wrapped->__toPHP());
+    }
+
     public function processes(): string
     {
         return $this->wrapped->processes();

--- a/src/OpenAPI/Processor/Request.php
+++ b/src/OpenAPI/Processor/Request.php
@@ -30,6 +30,16 @@ class Request implements Processor
             implode(".\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->processors)) . '.';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf(
+            'new %s("%s", [%s])',
+            self::class,
+            $this->processes(),
+            implode(', ', array_map(fn($p) => $p->__toPHP(), $this->processors))
+        );
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -14,4 +14,6 @@ interface Processor
     public function process(FieldName $parentFieldName, mixed $value): Result;
 
     public function __toString();
+
+    public function __toPHP(): string;
 }

--- a/src/Processor/AfterSet.php
+++ b/src/Processor/AfterSet.php
@@ -12,11 +12,19 @@ use Membrane\Validator;
 
 class AfterSet implements Processor
 {
+    /** @var Filter[]|Validator[] */
+    private readonly array $chain;
     private readonly Field $field;
 
     public function __construct(Filter|Validator ...$chain)
     {
-        $this->field = new Field('', ...$chain);
+        $this->chain = $chain;
+        $this->field = new Field('', ...$this->chain);
+    }
+
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%s)', self::class, implode(', ', array_map(fn($p) => $p->__toPHP(), $this->chain)));
     }
 
     public function __toString(): string

--- a/src/Processor/BeforeSet.php
+++ b/src/Processor/BeforeSet.php
@@ -12,11 +12,19 @@ use Membrane\Validator;
 
 class BeforeSet implements Processor
 {
+    /** @var Filter[]|Validator[] */
+    private readonly array $chain;
     private readonly Field $field;
 
     public function __construct(Filter|Validator ...$chain)
     {
-        $this->field = new Field('', ...$chain);
+        $this->chain = $chain;
+        $this->field = new Field('', ...$this->chain);
+    }
+
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%s)', self::class, implode(', ', array_map(fn($p) => $p->__toPHP(), $this->chain)));
     }
 
     public function __toString(): string

--- a/src/Processor/Collection.php
+++ b/src/Processor/Collection.php
@@ -77,6 +77,27 @@ class Collection implements Processor
         return $conditions === [] ? '' : implode("\n", $conditions);
     }
 
+    public function __toPHP(): string
+    {
+        $processors = [];
+        if (isset($this->before)) {
+            $processors[] = $this->before->__toPHP();
+        }
+        if (isset($this->each)) {
+            $processors[] = $this->each->__toPHP();
+        }
+        if (isset($this->after)) {
+            $processors[] = $this->after->__toPHP();
+        }
+
+        return sprintf(
+            'new %s("%s"%s)',
+            self::class,
+            $this->processes(),
+            implode('', array_map(fn($p) => ', ' . $p, $processors))
+        );
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/Processor/DefaultProcessor.php
+++ b/src/Processor/DefaultProcessor.php
@@ -27,6 +27,11 @@ class DefaultProcessor implements Processor
         return (string)$this->processor;
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%s)', self::class, $this->processor->__toPHP());
+    }
+
     public function processes(): string
     {
         return $this->processor->processes();

--- a/src/Processor/Field.php
+++ b/src/Processor/Field.php
@@ -42,6 +42,16 @@ class Field implements Processor
         }
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf(
+            'new %s("%s"%s)',
+            self::class,
+            $this->processes(),
+            implode('', array_map(fn($p) => ', ' . $p->__toPHP(), $this->chain))
+        );
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/Processor/FieldSet.php
+++ b/src/Processor/FieldSet.php
@@ -88,6 +88,32 @@ class FieldSet implements Processor
         return $conditions === [] ? '' : implode("\n", $conditions);
     }
 
+    public function __toPHP(): string
+    {
+        $processors = [];
+        if (isset($this->before)) {
+            $processors[] = $this->before->__toPHP();
+        }
+        foreach ($this->chain as $field) {
+            foreach ($field as $processor) {
+                $processors[] = $processor->__toPHP();
+            }
+        }
+        if (isset($this->default)) {
+            $processors[] = $this->default->__toPHP();
+        }
+        if (isset($this->after)) {
+            $processors[] = $this->after->__toPHP();
+        }
+
+        return sprintf(
+            'new %s("%s"%s)',
+            self::class,
+            $this->processes(),
+            implode('', array_map(fn($p) => ', ' . $p, $processors))
+        );
+    }
+
     public function processes(): string
     {
         return $this->processes;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -11,4 +11,6 @@ interface Validator
     public function validate(mixed $value): Result;
 
     public function __toString(): string;
+
+    public function __toPHP(): string;
 }

--- a/src/Validator/Collection/Contained.php
+++ b/src/Validator/Collection/Contained.php
@@ -27,6 +27,11 @@ class Contained implements Validator
             implode(', ', array_map(fn($p) => json_encode($p), $this->enum));
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%s)', self::class, json_encode($this->enum));
+    }
+
     public function validate(mixed $value): Result
     {
         if (!in_array($value, $this->enum, true)) {

--- a/src/Validator/Collection/Count.php
+++ b/src/Validator/Collection/Count.php
@@ -37,6 +37,12 @@ class Count implements Validator
         return 'has ' . implode(' and ', $conditions) . ' values';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%d', self::class, $this->min) .
+            ($this->max === null ? ')' : sprintf(', %d)', $this->max));
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Collection/Identical.php
+++ b/src/Validator/Collection/Identical.php
@@ -16,6 +16,11 @@ class Identical implements Validator
         return 'contains only identical values';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Collection/Unique.php
+++ b/src/Validator/Collection/Unique.php
@@ -16,6 +16,11 @@ class Unique implements Validator
         return 'contains only unique values';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/DateTime/Range.php
+++ b/src/Validator/DateTime/Range.php
@@ -35,6 +35,18 @@ class Range implements Validator
         return 'is ' . implode(' and ', $conditions);
     }
 
+    public function __toPHP(): string
+    {
+        if ($this->min !== null) {
+            $min = sprintf('%s::createFromFormat(DATE_ATOM, "%s")', DateTime::class, $this->min->format(DATE_ATOM));
+        }
+        if ($this->max !== null) {
+            $max = sprintf('%s::createFromFormat(DATE_ATOM, "%s")', DateTime::class, $this->max->format(DATE_ATOM));
+        }
+
+        return sprintf('new %s(%s, %s)', self::class, $min ?? 'null', $max ?? 'null');
+    }
+
     public function validate(mixed $value): Result
     {
         if ($this->min !== null && $value < $this->min) {

--- a/src/Validator/DateTime/RangeDelta.php
+++ b/src/Validator/DateTime/RangeDelta.php
@@ -16,10 +16,42 @@ class RangeDelta implements Validator
     private ?DateTime $min;
     private ?DateTime $max;
 
-    public function __construct(?DateInterval $min = null, ?DateInterval $max = null)
+    public function __construct(
+        private readonly ?DateInterval $minInterval = null,
+        private readonly ?DateInterval $maxInterval = null
+    ) {
+        $this->min = $this->minInterval === null ? null : (new DateTime())->sub($this->minInterval);
+        $this->max = $this->maxInterval === null ? null : (new DateTime())->add($this->maxInterval);
+    }
+
+    public function __toPHP(): string
     {
-        $this->min = $min === null ? null : (new DateTime())->sub($min);
-        $this->max = $max === null ? null : (new DateTime())->add($max);
+        if ($this->minInterval !== null) {
+            $minInterval = sprintf(
+                'new %s("P%dY%dM%dDT%dH%dM%dS")',
+                DateInterval::class,
+                $this->minInterval->y,
+                $this->minInterval->m,
+                $this->minInterval->d,
+                $this->minInterval->h,
+                $this->minInterval->i,
+                $this->minInterval->s,
+            );
+        }
+        if ($this->maxInterval !== null) {
+            $maxInterval = sprintf(
+                'new %s("P%dY%dM%dDT%dH%dM%dS")',
+                DateInterval::class,
+                $this->maxInterval->y,
+                $this->maxInterval->m,
+                $this->maxInterval->d,
+                $this->maxInterval->h,
+                $this->maxInterval->i,
+                $this->maxInterval->s,
+            );
+        }
+
+        return sprintf('new %s(%s, %s)', self::class, $minInterval ?? 'null', $maxInterval ?? 'null');
     }
 
     public function __toString(): string

--- a/src/Validator/FieldSet/FixedFields.php
+++ b/src/Validator/FieldSet/FixedFields.php
@@ -28,6 +28,13 @@ class FixedFields implements Validator
         return 'only contains the following fields: "' . implode('", "', $this->fields) . '"';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(', self::class) .
+            implode(', ', array_map(fn($p) => '"' . $p . '"', $this->fields)) .
+            ')';
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/FieldSet/RequiredFields.php
+++ b/src/Validator/FieldSet/RequiredFields.php
@@ -28,6 +28,13 @@ class RequiredFields implements Validator
         return 'contains the following fields: "' . implode('", "', $this->fields) . '"';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(', self::class) .
+            implode(', ', array_map(fn($p) => '"' . $p . '"', $this->fields)) .
+            ')';
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Numeric/Maximum.php
+++ b/src/Validator/Numeric/Maximum.php
@@ -22,6 +22,11 @@ class Maximum implements Validator
         return 'is less than ' . ($this->exclusive ? '' : 'or equal to ') . $this->max;
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%d, %s)', self::class, $this->max, $this->exclusive ? 'true' : 'false');
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_numeric($value)) {

--- a/src/Validator/Numeric/Minimum.php
+++ b/src/Validator/Numeric/Minimum.php
@@ -22,6 +22,11 @@ class Minimum implements Validator
         return 'is greater than ' . ($this->exclusive ? '' : 'or equal to ') . $this->min;
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%d, %s)', self::class, $this->min, $this->exclusive ? 'true' : 'false');
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_numeric($value)) {

--- a/src/Validator/Numeric/MultipleOf.php
+++ b/src/Validator/Numeric/MultipleOf.php
@@ -27,6 +27,11 @@ class MultipleOf implements Validator
         return sprintf('is a multiple of %d', $this->factor);
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%d)', self::class, $this->factor);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_numeric($value)) {

--- a/src/Validator/String/DateString.php
+++ b/src/Validator/String/DateString.php
@@ -21,6 +21,11 @@ class DateString implements Validator
         return sprintf('matches the DateTime format: "%s"', $this->format);
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s("%s")', self::class, $this->format);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Validator/String/Length.php
+++ b/src/Validator/String/Length.php
@@ -34,6 +34,12 @@ class Length implements Validator
         return implode(' and ', $conditions);
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%d', self::class, $this->min) .
+            ($this->max === null ? ')' : sprintf(', %d)', $this->max));
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Validator/String/Regex.php
+++ b/src/Validator/String/Regex.php
@@ -20,6 +20,11 @@ class Regex implements Validator
         return sprintf('matches the regex: "%s"', $this->pattern);
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s("%s")', self::class, $this->pattern);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_string($value)) {

--- a/src/Validator/Type/IsArray.php
+++ b/src/Validator/Type/IsArray.php
@@ -16,6 +16,11 @@ class IsArray implements Validator
         return 'is an array with string keys';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Type/IsBool.php
+++ b/src/Validator/Type/IsBool.php
@@ -16,6 +16,11 @@ class IsBool implements Validator
         return 'is a boolean';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Validator/Type/IsFloat.php
+++ b/src/Validator/Type/IsFloat.php
@@ -16,6 +16,11 @@ class IsFloat implements Validator
         return 'is a float';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Validator/Type/IsInt.php
+++ b/src/Validator/Type/IsInt.php
@@ -16,6 +16,11 @@ class IsInt implements Validator
         return 'is an integer';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Validator/Type/IsList.php
+++ b/src/Validator/Type/IsList.php
@@ -16,6 +16,11 @@ class IsList implements Validator
         return 'is a list';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!is_array($value)) {

--- a/src/Validator/Type/IsNull.php
+++ b/src/Validator/Type/IsNull.php
@@ -16,6 +16,11 @@ class IsNull implements Validator
         return 'is null';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         if ($value !== null) {

--- a/src/Validator/Type/IsNumber.php
+++ b/src/Validator/Type/IsNumber.php
@@ -16,6 +16,11 @@ class IsNumber implements Validator
         return 'is a number';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         if (!(is_int($value) || is_float($value))) {

--- a/src/Validator/Type/IsString.php
+++ b/src/Validator/Type/IsString.php
@@ -16,6 +16,11 @@ class IsString implements Validator
         return 'is a string';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         $type = gettype($value);

--- a/src/Validator/Utility/AllOf.php
+++ b/src/Validator/Utility/AllOf.php
@@ -28,6 +28,13 @@ class AllOf implements Validator
             implode("\n\t", array_map(fn($p) => '- ' . (string)$p . '.', $this->chain));
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(', self::class) .
+            implode(', ', array_map(fn($p) => $p->__toPHP(), $this->chain)) .
+            ')';
+    }
+
     public function validate(mixed $value): Result
     {
         $resultChain = [];

--- a/src/Validator/Utility/AnyOf.php
+++ b/src/Validator/Utility/AnyOf.php
@@ -28,6 +28,13 @@ class AnyOf implements Validator
             implode("\n\t", array_map(fn($p) => '- ' . (string)$p . '.', $this->chain));
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(', self::class) .
+            implode(', ', array_map(fn($p) => $p->__toPHP(), $this->chain)) .
+            ')';
+    }
+
     public function validate(mixed $value): Result
     {
         $resultChain = [];

--- a/src/Validator/Utility/Fails.php
+++ b/src/Validator/Utility/Fails.php
@@ -16,6 +16,11 @@ class Fails implements Validator
         return 'will return invalid';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         return Result::invalid($value, new MessageSet(null, new Message('I always fail', [])));

--- a/src/Validator/Utility/Indifferent.php
+++ b/src/Validator/Utility/Indifferent.php
@@ -14,6 +14,11 @@ class Indifferent implements Validator
         return '';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         return Result::noResult($value);

--- a/src/Validator/Utility/Not.php
+++ b/src/Validator/Utility/Not.php
@@ -21,6 +21,11 @@ class Not implements Validator
         return sprintf('must satisfy the opposite of the following: "%s"', $this->invertedValidator->__toString());
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%s)', self::class, $this->invertedValidator->__toPHP());
+    }
+
     public function validate(mixed $value): Result
     {
         $result = $this->invertedValidator->validate($value);

--- a/src/Validator/Utility/Passes.php
+++ b/src/Validator/Utility/Passes.php
@@ -14,6 +14,11 @@ class Passes implements Validator
         return 'will return valid';
     }
 
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+
     public function validate(mixed $value): Result
     {
         return Result::valid($value);

--- a/tests/Filter/CreateObject/FromArrayTest.php
+++ b/tests/Filter/CreateObject/FromArrayTest.php
@@ -29,6 +29,16 @@ class FromArrayTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new FromArray('Arbitrary\Class');
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /**
      * @test
      */

--- a/tests/Filter/CreateObject/WithNamedArgumentsTest.php
+++ b/tests/Filter/CreateObject/WithNamedArgumentsTest.php
@@ -29,6 +29,16 @@ class WithNamedArgumentsTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new WithNamedArguments('Arbitrary\Class');
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsThatPass(): array
     {
         $classWithNamedArguments = new class (a: 'default', b: 'arguments') {

--- a/tests/Filter/Shape/CollectTest.php
+++ b/tests/Filter/Shape/CollectTest.php
@@ -49,6 +49,26 @@ class CollectTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no fields' => [new Collect('collection')],
+            'one field' => [new Collect('collection', 'a')],
+            'multiple fields' => [new Collect('collection', 'a', 'b', 'c')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Collect $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Filter/Shape/DeleteTest.php
+++ b/tests/Filter/Shape/DeleteTest.php
@@ -49,6 +49,26 @@ class DeleteTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no fields' => [new Delete(),],
+            'one field' => [new Delete('a'),],
+            'multiple fields' => [new Delete('a', 'b', 'c'),],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Delete $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectInputs(): array
     {
         $notArrayMessage = 'Delete filter requires arrays, %s given';

--- a/tests/Filter/Shape/NestTest.php
+++ b/tests/Filter/Shape/NestTest.php
@@ -49,6 +49,26 @@ class NestTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no fields' => [new Nest('new field'),],
+            'one field' => [new Nest('new field', 'a'),],
+            'multiple fields' => [new Nest('new field', 'a', 'b', 'c'),],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Nest $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Filter/Shape/PluckTest.php
+++ b/tests/Filter/Shape/PluckTest.php
@@ -49,6 +49,26 @@ class PluckTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no fields' => [new Pluck('field set')],
+            'one field' => [new Pluck('field set', 'a')],
+            'multiple fields' => [new Pluck('field set', 'a', 'b', 'c')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Pluck $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectInputs(): array
     {
         $notArrayMessage = 'Pluck filter requires arrays, %s given';

--- a/tests/Filter/Shape/RenameTest.php
+++ b/tests/Filter/Shape/RenameTest.php
@@ -29,6 +29,16 @@ class RenameTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new Rename('a', 'b');
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /**
      * @test
      */

--- a/tests/Filter/Shape/TruncateTest.php
+++ b/tests/Filter/Shape/TruncateTest.php
@@ -30,6 +30,16 @@ class TruncateTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new Truncate(5);
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /**
      * @test
      * @throws Exception

--- a/tests/Filter/String/JsonDecodeTest.php
+++ b/tests/Filter/String/JsonDecodeTest.php
@@ -29,6 +29,16 @@ class JsonDecodeTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new JsonDecode();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsToFilter(): array
     {
         return [

--- a/tests/Filter/Type/ToBoolTest.php
+++ b/tests/Filter/Type/ToBoolTest.php
@@ -29,6 +29,16 @@ class ToBoolTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new ToBool();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         return [

--- a/tests/Filter/Type/ToDateTimeTest.php
+++ b/tests/Filter/Type/ToDateTimeTest.php
@@ -31,6 +31,25 @@ class ToDateTimeTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'immutable' => [new ToDateTime('Y-m-d', true)],
+            'mutable' => [new ToDateTime('Y-m-d', false)],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(ToDateTime $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Filter/Type/ToFloatTest.php
+++ b/tests/Filter/Type/ToFloatTest.php
@@ -29,6 +29,16 @@ class ToFloatTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new ToFloat();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         return [

--- a/tests/Filter/Type/ToIntTest.php
+++ b/tests/Filter/Type/ToIntTest.php
@@ -29,6 +29,16 @@ class ToIntTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new ToInt();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         return [

--- a/tests/Filter/Type/ToListTest.php
+++ b/tests/Filter/Type/ToListTest.php
@@ -29,6 +29,16 @@ class ToListTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new ToList();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         return [

--- a/tests/Filter/Type/ToNumberTest.php
+++ b/tests/Filter/Type/ToNumberTest.php
@@ -29,6 +29,16 @@ class ToNumberTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new ToNumber();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsToFilter(): array
     {
         $class = new class {

--- a/tests/Filter/Type/ToStringTest.php
+++ b/tests/Filter/Type/ToStringTest.php
@@ -29,6 +29,16 @@ class ToStringTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new ToString();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithAcceptableInputs(): array
     {
         $classWithMethod = new class () {

--- a/tests/OpenAPI/Filter/HTTPParametersTest.php
+++ b/tests/OpenAPI/Filter/HTTPParametersTest.php
@@ -29,6 +29,16 @@ class HTTPParametersTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new HTTPParameters();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsToFilter(): array
     {
         return [

--- a/tests/OpenAPI/Filter/PathMatcherTest.php
+++ b/tests/OpenAPI/Filter/PathMatcherTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenAPI\Filter;
 
 use Membrane\OpenAPI\Filter\PathMatcher;
-use Membrane\OpenAPI\PathMatcher as PathMatcherClass;
+use Membrane\OpenAPI\PathMatcher as PathMatcherHelper;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
@@ -25,11 +25,23 @@ class PathMatcherTest extends TestCase
     public function toStringTest(): void
     {
         $expected = 'convert url to a field set of path parameters';
-        $sut = new PathMatcher(self::createStub(PathMatcherClass::class));
+        $sut = new PathMatcher(self::createStub(PathMatcherHelper::class));
 
         $actual = $sut->__toString();
 
         self::assertSame($expected, $actual);
+    }
+
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $pathMatcherHelper = new PathMatcherHelper('/api', '/pets');
+        $sut = new PathMatcher($pathMatcherHelper);
+
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
     /** @test */
@@ -39,7 +51,7 @@ class PathMatcherTest extends TestCase
             false,
             new MessageSet(null, new Message('PathMatcher filter expects string, %s passed', ['boolean']))
         );
-        $sut = new PathMatcher(self::createStub(\Membrane\OpenAPI\PathMatcher::class));
+        $sut = new PathMatcher(self::createStub(PathMatcherHelper::class));
 
         $actual = $sut->filter(false);
 
@@ -55,7 +67,7 @@ class PathMatcherTest extends TestCase
         );
         $apiPath = '/pets/{id}';
         $requestPath = '/hats/23';
-        $sut = new PathMatcher(new \Membrane\OpenAPI\PathMatcher('https://www.server.com', $apiPath));
+        $sut = new PathMatcher(new PathMatcherHelper('https://www.server.com', $apiPath));
 
         $actual = $sut->filter($requestPath);
 
@@ -66,7 +78,7 @@ class PathMatcherTest extends TestCase
     public function filterTest(): void
     {
         $expected = Result::noResult(['filtered value']);
-        $observer = self::createMock(\Membrane\OpenAPI\PathMatcher::class);
+        $observer = self::createMock(PathMatcherHelper::class);
         $observer->expects($this->once())
             ->method('getPathParams')
             ->with('value')

--- a/tests/OpenAPI/Processor/AllOfTest.php
+++ b/tests/OpenAPI/Processor/AllOfTest.php
@@ -43,6 +43,27 @@ use PHPUnit\Framework\TestCase;
  */
 class AllOfTest extends TestCase
 {
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            '2 validators' => [new AllOf('a', new Field('b'), new Field('c'))],
+            '3 validators' => [
+                new AllOf('a', new Field('b', new Passes()), new Field('c', new Fails()), new Field('d')),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(AllOf $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /** @test */
     public function toStringTest(): void
     {

--- a/tests/OpenAPI/Processor/AnyOfTest.php
+++ b/tests/OpenAPI/Processor/AnyOfTest.php
@@ -43,6 +43,27 @@ use PHPUnit\Framework\TestCase;
  */
 class AnyOfTest extends TestCase
 {
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            '2 validators' => [new AnyOf('a', new Field('b'), new Field('c'))],
+            '3 validators' => [
+                new AnyOf('a', new Field('b', new Passes()), new Field('c', new Fails()), new Field('d')),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(AnyOf $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /** @test */
     public function toStringTest(): void
     {

--- a/tests/OpenAPI/Processor/JsonTest.php
+++ b/tests/OpenAPI/Processor/JsonTest.php
@@ -6,6 +6,7 @@ namespace OpenAPI\Processor;
 
 use Membrane\OpenAPI\Processor\Json;
 use Membrane\Processor;
+use Membrane\Processor\Field;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
@@ -41,6 +42,16 @@ class JsonTest extends TestCase
         $actual = (string)$sut;
 
         self::assertSame($expected, $actual);
+    }
+
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new Json(new Field('a'));
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
     /** @test */

--- a/tests/OpenAPI/Processor/OneOfTest.php
+++ b/tests/OpenAPI/Processor/OneOfTest.php
@@ -43,6 +43,27 @@ use PHPUnit\Framework\TestCase;
  */
 class OneOfTest extends TestCase
 {
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            '2 validators' => [new OneOf('a', new Field('b'), new Field('c'))],
+            '3 validators' => [
+                new OneOf('a', new Field('b', new Passes()), new Field('c', new Fails()), new Field('d')),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(OneOf $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /** @test */
     public function toStringTest(): void
     {

--- a/tests/OpenAPI/Processor/RequestTest.php
+++ b/tests/OpenAPI/Processor/RequestTest.php
@@ -67,6 +67,32 @@ class RequestTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no chain' => [new Request('a', []),],
+            '1 empty Field' => [new Request('b', [new Field('')]),],
+            '1 Field' => [new Request('c', [new Field('', new Passes())]),],
+            '3 Fields' => [
+                new Request(
+                    'd',
+                    [new Field('a', new Passes()), new Field('b', new Fails()), new Field('c', new Passes())]
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Request $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /** @test */
     public function processesTest(): void
     {

--- a/tests/Processor/AfterSetTest.php
+++ b/tests/Processor/AfterSetTest.php
@@ -53,13 +53,41 @@ class AfterSetTest extends TestCase
         ];
     }
 
-    /** @test * @dataProvider dataSetsToConvertToString
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToString
      */
     public function toStringTest(string $expected, AfterSet $sut): void
     {
         $actual = (string)$sut;
 
         self::assertSame($expected, $actual);
+    }
+
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no chain' => [
+                new AfterSet(),
+            ],
+            '1 validator' => [
+                new AfterSet(new Passes()),
+            ],
+            '3 validators' => [
+                new AfterSet(new Passes(), new Fails(), new Passes()),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(AfterSet $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
     /** @test */

--- a/tests/Processor/BeforeSetTest.php
+++ b/tests/Processor/BeforeSetTest.php
@@ -64,7 +64,34 @@ class BeforeSetTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /**  @test */
+
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no chain' => [
+                new BeforeSet(),
+            ],
+            '1 validator' => [
+                new BeforeSet(new Passes()),
+            ],
+            '3 validators' => [
+                new BeforeSet(new Passes(), new Fails(), new Passes()),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(BeforeSet $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
+    /** @test */
     public function processesMethodReturnsEmptyString(): void
     {
         $expected = '';

--- a/tests/Processor/CollectionTest.php
+++ b/tests/Processor/CollectionTest.php
@@ -105,6 +105,46 @@ class CollectionTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no chain' => [
+                new Collection('a'),
+            ],
+            '1 empty Field' => [
+                new Collection('b', new Field('')),
+            ],
+            '1 Field' => [
+                new Collection('c', new Field('', new Passes())),
+            ],
+            '1 BeforeSet' => [
+                new Collection('d', new BeforeSet(new Passes())),
+            ],
+            '1 AfterSet' => [
+                new Collection('e', new AfterSet(new Passes())),
+            ],
+            '1 Field, 1 BeforeSet, 1 AfterSet, 1 DefaultProcessor' => [
+                new Collection(
+                    'f',
+                    new Field('', new Fails()),
+                    new BeforeSet(new Passes()),
+                    new AfterSet(new Fails()),
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Collection $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectValues(): array
     {
         $notArrayMessage = 'Value passed to %s in Collection chain must be a list, %s passed instead';
@@ -126,9 +166,9 @@ class CollectionTest extends TestCase
     {
         $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
         $fieldName = 'field to process';
-        $fieldset = new Collection($fieldName, new Field(''));
+        $sut = new Collection($fieldName, new Field(''));
 
-        $result = $fieldset->process(new FieldName('parent field'), $input);
+        $result = $sut->process(new FieldName('parent field'), $input);
 
         self::assertEquals($expected, $result);
     }
@@ -146,9 +186,9 @@ class CollectionTest extends TestCase
     public function processesTest(): void
     {
         $fieldName = 'field to process';
-        $fieldset = new Collection($fieldName);
+        $sut = new Collection($fieldName);
 
-        $output = $fieldset->processes();
+        $output = $sut->processes();
 
         self::assertEquals($fieldName, $output);
     }
@@ -158,9 +198,9 @@ class CollectionTest extends TestCase
     {
         $value = [];
         $expected = Result::noResult($value);
-        $fieldset = new Collection('field to process');
+        $sut = new Collection('field to process');
 
-        $result = $fieldset->process(new FieldName('Parent field'), $value);
+        $result = $sut->process(new FieldName('Parent field'), $value);
 
         self::assertEquals($expected, $result);
     }

--- a/tests/Processor/DefaultProcessorTest.php
+++ b/tests/Processor/DefaultProcessorTest.php
@@ -64,6 +64,32 @@ class DefaultProcessorTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no chain' => [
+                DefaultProcessor::fromFiltersAndValidators(),
+            ],
+            '1 validator' => [
+                DefaultProcessor::fromFiltersAndValidators(new Passes()),
+            ],
+            '3 validators' => [
+                DefaultProcessor::fromFiltersAndValidators(new Passes(), new Fails(), new Passes()),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(DefaultProcessor $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /** @test */
     public function processesTest(): void
     {

--- a/tests/Processor/FieldTest.php
+++ b/tests/Processor/FieldTest.php
@@ -67,6 +67,27 @@ class FieldTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'empty processes string, no chain' => [new Field('')],
+            'no chain' => [new Field('b')],
+            '1 validator' => [new Field('c', new Passes())],
+            '3 validators' => [new Field('d', new Passes(), new Fails(), new Passes())],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Field $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /** @test */
     public function processesMethodReturnsProcessesString(): void
     {

--- a/tests/Processor/FieldsetTest.php
+++ b/tests/Processor/FieldsetTest.php
@@ -127,6 +127,38 @@ class FieldsetTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no chain' => [new FieldSet('a')],
+            '1 empty Field' => [new FieldSet('b', new Field(''))],
+            '1 Field' => [new FieldSet('c', new Field('', new Passes()))],
+            '1 BeforeSet' => [new FieldSet('d', new BeforeSet(new Passes()))],
+            '1 AfterSet' => [new FieldSet('e', new AfterSet(new Passes()))],
+            '1 DefaultProcessor' => [new FieldSet('f', DefaultProcessor::fromFiltersAndValidators(new Passes()))],
+            '1 Field, 1 BeforeSet, 1 AfterSet, 1 DefaultProcessor' => [
+                new FieldSet(
+                    'g',
+                    new Field('', new Fails()),
+                    new BeforeSet(new Passes()),
+                    new AfterSet(new Fails()),
+                    DefaultProcessor::fromFiltersAndValidators(new Passes())
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(FieldSet $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectValues(): array
     {
         $notArrayMessage = 'Value passed to FieldSet chain be an array, %s passed instead';

--- a/tests/Validator/Collection/ContainedTest.php
+++ b/tests/Validator/Collection/ContainedTest.php
@@ -53,6 +53,26 @@ class ContainedTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'empty array' => [new Contained([])],
+            'array with 1 value' => [new Contained(['a'])],
+            'array with 3 values' => [new Contained(['a', 1, true])],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Contained $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsToValidate(): array
     {
         return [

--- a/tests/Validator/Collection/CountTest.php
+++ b/tests/Validator/Collection/CountTest.php
@@ -57,6 +57,25 @@ class CountTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'default arguments' => [new Count()],
+            'assigned arguments' => [new Count(1, 5)],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Count $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/Collection/IdenticalTest.php
+++ b/tests/Validator/Collection/IdenticalTest.php
@@ -29,6 +29,16 @@ class IdenticalTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new Identical();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/Collection/UniqueTest.php
+++ b/tests/Validator/Collection/UniqueTest.php
@@ -29,6 +29,16 @@ class UniqueTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new Unique();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/DateTime/RangeDeltaTest.php
+++ b/tests/Validator/DateTime/RangeDeltaTest.php
@@ -59,6 +59,29 @@ class RangeDeltaTest extends TestCase
         self::assertStringMatchesFormat($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no minimum, no maximum' => [null, null,],
+            'minimum, no maximum' => [new DateInterval('P1Y2M3DT4H5M6S'), null],
+            'maximum, no minimum' => [null, new DateInterval('P9Y8M7DT6H5M4S')],
+            'minimum and maximum' => [new DateInterval('P1Y2M3DT4H5M6S'), new DateInterval('P9Y8M7DT6H5M4S')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(?DateInterval $min, ?DateInterval $max): void
+    {
+        $sut = new RangeDelta($min, $max);
+
+        $actual = $sut->__toPHP();
+
+        self::assertEqualsWithDelta($sut, eval('return ' . $actual . ';'), 2);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/DateTime/RangeTest.php
+++ b/tests/Validator/DateTime/RangeTest.php
@@ -58,6 +58,29 @@ class RangeTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no minimum, no maximum' => [null, null],
+            'minimum, no maximum' => [new DateTime('2001-02-03T04:05:06'), null],
+            'maximum, no minimum' => [null, new DateTime('2009-08-07T06:05:04')],
+            'minimum and maximum' => [new DateTime('2001-02-03T04:05:06'), new DateTime('2009-08-07T06:05:04')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(?DateTime $min, ?DateTime $max): void
+    {
+        $sut = new Range($min, $max);
+
+        $actual = $sut->__toPHP();
+
+        self::assertEqualsWithDelta($sut, eval('return ' . $actual . ';'), 2);
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/FieldSet/FixedFieldsTest.php
+++ b/tests/Validator/FieldSet/FixedFieldsTest.php
@@ -49,6 +49,26 @@ class FixedFieldsTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no fields' => [new FixedFields()],
+            '1 field' => [new FixedFields('a')],
+            '3 fields' => [new FixedFields('a', 'b', 'c')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(FixedFields $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/FieldSet/RequiredFieldsTest.php
+++ b/tests/Validator/FieldSet/RequiredFieldsTest.php
@@ -49,6 +49,26 @@ class RequiredFieldsTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no fields' => [new RequiredFields()],
+            '1 field' => [new RequiredFields('a')],
+            '3 fields' => [new RequiredFields('a', 'b', 'c')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(RequiredFields $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/Numeric/MaximumTest.php
+++ b/tests/Validator/Numeric/MaximumTest.php
@@ -47,6 +47,25 @@ class MaximumTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'inclusive maximum' => [new Maximum(5)],
+            'exclusive maximum' => [new Maximum(5, true)],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Maximum $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsOfNonNumericValues(): array
     {
         return [

--- a/tests/Validator/Numeric/MinimumTest.php
+++ b/tests/Validator/Numeric/MinimumTest.php
@@ -47,6 +47,25 @@ class MinimumTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'inclusive minimum' => [new Minimum(5)],
+            'exclusive minimum' => [new Minimum(5, true)],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Minimum $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsOfNonNumericValues(): array
     {
         return [

--- a/tests/Validator/Numeric/MultipleOfTest.php
+++ b/tests/Validator/Numeric/MultipleOfTest.php
@@ -30,6 +30,16 @@ class MultipleOfTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new MultipleOf(5);
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsThatThrowExceptions(): array
     {
         return [

--- a/tests/Validator/String/DateStringTest.php
+++ b/tests/Validator/String/DateStringTest.php
@@ -29,6 +29,16 @@ class DateStringTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new DateString('Y-m-d');
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/String/LengthTest.php
+++ b/tests/Validator/String/LengthTest.php
@@ -57,6 +57,25 @@ class LengthTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'default arguments' => [new Length()],
+            'assigned arguments' => [new Length(1, 5)],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(Length $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/String/RegexTest.php
+++ b/tests/Validator/String/RegexTest.php
@@ -29,6 +29,16 @@ class RegexTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new Regex('/[abc]/i');
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsWithIncorrectTypes(): array
     {
         return [

--- a/tests/Validator/Type/IsArrayTest.php
+++ b/tests/Validator/Type/IsArrayTest.php
@@ -29,6 +29,16 @@ class IsArrayTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new IsArray();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsThatPass(): array
     {
         return [

--- a/tests/Validator/Type/IsBoolTest.php
+++ b/tests/Validator/Type/IsBoolTest.php
@@ -29,6 +29,16 @@ class IsBoolTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new IsBool();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Type/IsFloatTest.php
+++ b/tests/Validator/Type/IsFloatTest.php
@@ -29,6 +29,16 @@ class IsFloatTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new IsFloat();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Type/IsIntTest.php
+++ b/tests/Validator/Type/IsIntTest.php
@@ -29,6 +29,16 @@ class IsIntTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new IsInt();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Type/IsListTest.php
+++ b/tests/Validator/Type/IsListTest.php
@@ -29,6 +29,16 @@ class IsListTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new IsList();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsThatPass(): array
     {
         return [

--- a/tests/Validator/Type/IsNullTest.php
+++ b/tests/Validator/Type/IsNullTest.php
@@ -29,6 +29,16 @@ class IsNullTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new IsNull();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Type/IsNumberTest.php
+++ b/tests/Validator/Type/IsNumberTest.php
@@ -29,6 +29,16 @@ class IsNumberTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new IsNumber();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsToValidate(): array
     {
         $class = new class {

--- a/tests/Validator/Type/IsStringTest.php
+++ b/tests/Validator/Type/IsStringTest.php
@@ -29,6 +29,16 @@ class IsStringTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new IsString();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     /**
      * @test
      */

--- a/tests/Validator/Utility/AllOfTest.php
+++ b/tests/Validator/Utility/AllOfTest.php
@@ -10,12 +10,14 @@ use Membrane\Result\Result;
 use Membrane\Validator;
 use Membrane\Validator\Utility\AllOf;
 use Membrane\Validator\Utility\Fails;
+use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Membrane\Validator\Utility\AllOf
  * @uses   \Membrane\Validator\Utility\Fails
+ * @uses   \Membrane\Validator\Utility\Indifferent
  * @uses   \Membrane\Validator\Utility\Passes
  * @uses   \Membrane\Result\Result
  * @uses   \Membrane\Result\MessageSet
@@ -64,6 +66,26 @@ class AllOfTest extends TestCase
         $actual = $sut->__toString();
 
         self::assertSame($expected, $actual);
+    }
+
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no validators' => [new AllOf()],
+            '1 validator' => [new AllOf(new Passes())],
+            '3 validators' => [new AllOf(new Fails(), new Indifferent(), new Passes())],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(AllOf $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
     /**

--- a/tests/Validator/Utility/AnyOfTest.php
+++ b/tests/Validator/Utility/AnyOfTest.php
@@ -25,6 +25,26 @@ use PHPUnit\Framework\TestCase;
  */
 class AnyOfTest extends TestCase
 {
+    public function dataSetsToConvertToPHPString(): array
+    {
+        return [
+            'no validators' => [new AnyOf()],
+            '1 validator' => [new AnyOf(new Passes())],
+            '3 validators' => [new AnyOf(new Fails(), new Indifferent(), new Passes())],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsToConvertToPHPString
+     */
+    public function toPHPTest(AnyOf $sut): void
+    {
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsToConvertToString(): array
     {
         $validator = self::createMock(Validator::class);

--- a/tests/Validator/Utility/FailsTest.php
+++ b/tests/Validator/Utility/FailsTest.php
@@ -29,6 +29,16 @@ class FailsTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new Fails();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSets(): array
     {
         return [[1], [1.1], ['one'], [true], [null],];

--- a/tests/Validator/Utility/IndifferentTest.php
+++ b/tests/Validator/Utility/IndifferentTest.php
@@ -25,6 +25,16 @@ class IndifferentTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new Indifferent();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSets(): array
     {
         return [[1], [1.1], ['one'], [false], [null],];

--- a/tests/Validator/Utility/NotTest.php
+++ b/tests/Validator/Utility/NotTest.php
@@ -41,6 +41,28 @@ class NotTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    public function toPHPProvider(): array
+    {
+        return [
+            'fails' => [new Fails()],
+            'indifferent' => [new Indifferent()],
+            'passes' => [new Passes()],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider toPHPProvider
+     */
+    public function toPHPTest(Validator $invertedValidator): void
+    {
+        $sut = new Not($invertedValidator);
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSetsToValidate(): array
     {
         return [

--- a/tests/Validator/Utility/PassesTest.php
+++ b/tests/Validator/Utility/PassesTest.php
@@ -25,6 +25,16 @@ class PassesTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
+    /** @test */
+    public function toPHPTest(): void
+    {
+        $sut = new Passes();
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
     public function dataSets(): array
     {
         return [[1], [1.1], ['one'], [false], [null],];

--- a/tests/fixtures/Attribute/ArraySumFilter.php
+++ b/tests/fixtures/Attribute/ArraySumFilter.php
@@ -18,4 +18,9 @@ class ArraySumFilter implements Filter
     {
         return 'return a sum of all numbers in given value';
     }
+
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
 }


### PR DESCRIPTION
Work towards #80

merge https://github.com/membrane-php/membrane-core/pull/84 and https://github.com/membrane-php/membrane-core/pull/85 first

Filter, Validator interfaces now must have the `__toPHP()` method.