### PR TITLE
APISpec now MUST find a server match or throws an exception. (WIP)

### DIFF
--- a/src/OpenAPI/Exception/CannotProcessRequest.php
+++ b/src/OpenAPI/Exception/CannotProcessRequest.php
@@ -7,8 +7,8 @@ namespace Membrane\OpenAPI\Exception;
 use RuntimeException;
 
 /*
- * This exception occurs when the OpenAPI has been read and parsed as OpenAPI
- * but Membrane cannot process it further due to user error.
+ * This exception occurs when your OpenAPI has been read and parsed successfully
+ * but Membrane cannot process your request due to user error.
  * This may occur for one of the following reasons:
  * 1: Your request contains features currently unsupported by Membrane
  * 2: Your request does not match anything found in your OpenAPI spec.
@@ -16,9 +16,17 @@ use RuntimeException;
 
 class CannotProcessRequest extends RuntimeException
 {
-    public const PATH_NOT_FOUND = 0;
-    public const METHOD_NOT_FOUND = 1;
-    public const CONTENT_TYPE_NOT_SUPPORTED = 2;
+    public const SERVER_NOT_FOUND = 0;
+    public const PATH_NOT_FOUND = 1;
+    public const METHOD_NOT_FOUND = 2;
+    public const METHOD_NOT_SUPPORTED = 3;
+    public const CONTENT_TYPE_NOT_SUPPORTED = 4;
+
+    public static function serverNotFound(string $fileName, string $url): self
+    {
+        $message = sprintf('%s does not match any specified servers in %s', $url, $fileName);
+        return new self($message, self::SERVER_NOT_FOUND);
+    }
 
     public static function pathNotFound(string $fileName, string $url): self
     {
@@ -32,9 +40,15 @@ class CannotProcessRequest extends RuntimeException
         return new self($message, self::METHOD_NOT_FOUND);
     }
 
+    public static function unsupportedMethod(string $method): self
+    {
+        $message = sprintf('"%s" is not a supported method', $method);
+        return new self($message, self::METHOD_NOT_SUPPORTED);
+    }
+
     public static function unsupportedContent(): self
     {
-        $message = sprintf('APISpec expects application/json content');
+        $message = '"application/json" is currently the only supported content type';
         return new self($message, self::CONTENT_TYPE_NOT_SUPPORTED);
     }
 }

--- a/src/OpenAPI/Specification/Request.php
+++ b/src/OpenAPI/Specification/Request.php
@@ -9,7 +9,7 @@ use cebe\openapi\spec\Parameter;
 use cebe\openapi\spec\PathItem;
 use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
-use Exception;
+use Membrane\OpenAPI\Exception\CannotProcessRequest;
 use Membrane\OpenAPI\Method;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -35,9 +35,10 @@ class Request extends APISpec
 
     public static function fromPsr7(string $apiPath, ServerRequestInterface $request): self
     {
-        $method = Method::tryFrom(strtolower($request->getMethod())) ?? throw new Exception('not supported');
+        $method = Method::tryFrom(strtolower($request->getMethod())) ??
+            throw CannotProcessRequest::unsupportedMethod($request->getMethod());
 
-        return new self($apiPath, $request->getUri()->getPath(), $method);
+        return new self($apiPath, (string)$request->getUri(), $method);
     }
 
     /** @return Parameter[] */

--- a/tests/OpenAPI/Specification/APISpecTest.php
+++ b/tests/OpenAPI/Specification/APISpecTest.php
@@ -120,7 +120,7 @@ class APISpecTest extends TestCase
     public function throwsExceptionIfNoPathMatches(): void
     {
         $fileName = 'noReferences.json';
-        $url = 'incorrect/path';
+        $url = 'http://www.test.com/notpath';
         self::expectExceptionObject(CannotProcessRequest::pathNotFound($fileName, $url));
 
         new class(self::DIR . $fileName, $url) extends APISpec {
@@ -132,27 +132,27 @@ class APISpecTest extends TestCase
         return [
             'GET does not have any content' => [
                 'noReferences.json',
-                'http://test.com/path',
+                'http://www.test.com/path',
                 Method::GET,
             ],
             'POST has empty content' => [
                 'noReferences.json',
-                'http://test.com/path',
+                'http://www.test.com/path',
                 Method::POST,
             ],
             'DELETE has application/json content' => [
                 'noReferences.json',
-                'http://test.com/path',
+                'http://www.test.com/path',
                 Method::DELETE,
             ],
             'path that contains reference that must be resolved .json' => [
                 'references.json',
-                'http://test.com/path',
+                'http://www.test.com/path',
                 Method::GET,
             ],
             'path that contains reference that must be resolved .yaml' => [
                 'references.json',
-                'http://test.com/path',
+                'http://www.test.com/path',
                 Method::GET,
             ],
         ];

--- a/tests/OpenAPI/Specification/ResponseTest.php
+++ b/tests/OpenAPI/Specification/ResponseTest.php
@@ -30,7 +30,7 @@ class ResponseTest extends TestCase
         $httpStatus = '404';
         self::expectExceptionObject(CannotProcessOpenAPI::responseNotFound($httpStatus));
 
-        new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::GET, $httpStatus);
+        new Response(self::DIR . 'noReferences.json', 'http://www.test.com/path', Method::GET, $httpStatus);
     }
 
     /**
@@ -40,7 +40,7 @@ class ResponseTest extends TestCase
     {
         self::expectExceptionObject(CannotProcessRequest::unsupportedContent());
 
-        new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::PUT, '200');
+        new Response(self::DIR . 'noReferences.json', 'http://www.test.com/path', Method::PUT, '200');
     }
 
     /**
@@ -48,7 +48,7 @@ class ResponseTest extends TestCase
      */
     public function returnsDefaultResponseIfExactMatchNotFound(): void
     {
-        $class = new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::DELETE, '404');
+        $class = new Response(self::DIR . 'noReferences.json', 'http://www.test.com/path', Method::DELETE, '404');
 
         self::assertInstanceOf(Schema::class, $class->schema);
     }
@@ -58,7 +58,7 @@ class ResponseTest extends TestCase
      */
     public function schemaIsSchemaObjectIfContentJson(): void
     {
-        $class = new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::DELETE, 'default');
+        $class = new Response(self::DIR . 'noReferences.json', 'http://www.test.com/path', Method::DELETE, 'default');
 
         self::assertInstanceOf(Schema::class, $class->schema);
     }
@@ -67,13 +67,13 @@ class ResponseTest extends TestCase
     {
         return [
             'response with no content' => [
-                'http://test.com/path',
+                'http://www.test.com/path',
                 Method::GET,
                 '200',
                 'noReferences.json',
             ],
             'response with empty content' => [
-                'http://test.com/path',
+                'http://www.test.com/path',
                 Method::POST,
                 '200',
                 'noReferences.json',
@@ -100,13 +100,13 @@ class ResponseTest extends TestCase
     {
         return [
             [
-                'http://test.com/path',
+                'http://www.test.com/path',
                 Method::GET,
                 '200',
                 'references.json',
             ],
             [
-                'http://test.com/path',
+                'http://www.test.com/path',
                 Method::GET,
                 '200',
                 'references.yaml',

--- a/tests/fixtures/OpenAPI/references.json
+++ b/tests/fixtures/OpenAPI/references.json
@@ -6,7 +6,7 @@
   },
   "servers": [
     {
-      "url": "http://test.com"
+      "url": "http://www.test.com"
     }
   ],
   "paths": {

--- a/tests/fixtures/OpenAPI/references.yaml
+++ b/tests/fixtures/OpenAPI/references.yaml
@@ -4,7 +4,7 @@ info:
   title: Test API
   version: 1.0.0
 servers:
-  - url: http://test.com
+  - url: http://www.test.com
 paths:
   "/path":
     get:


### PR DESCRIPTION
Fixes bug where incorrect servers are accepted.

Also adds new CannotProcessRequest exception for unsupported methods. i.e. currently 'update' is not supported.