### PR TITLE
Moved all OpenAPI file reading to dedicated class

### DIFF
--- a/src/OpenAPI/Reader/OpenAPIFileReader.php
+++ b/src/OpenAPI/Reader/OpenAPIFileReader.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Reader;
+
+use cebe\openapi\exceptions\TypeErrorException;
+use cebe\openapi\exceptions\UnresolvableReferenceException;
+use cebe\openapi\Reader;
+use cebe\openapi\spec\OpenApi;
+use Membrane\OpenAPI\Exception\CannotReadOpenAPI;
+use Symfony\Component\Yaml\Exception\ParseException;
+
+class OpenAPIFileReader
+{
+    /** @var \Closure[] */
+    private readonly array $supportedFileTypes;
+
+    public function __construct()
+    {
+        $this->supportedFileTypes = [
+            'json' => fn($p) => Reader::readFromJsonFile($p),
+            'yaml' => fn($p) => Reader::readFromYamlFile($p),
+            'yml' => fn($p) => Reader::readFromYamlFile($p),
+        ];
+    }
+
+    public function readFromAbsoluteFilePath(string $absoluteFilePath): OpenApi
+    {
+        file_exists($absoluteFilePath) ?: throw CannotReadOpenAPI::fileNotFound($absoluteFilePath);
+
+        $fileType = strtolower(pathinfo($absoluteFilePath, PATHINFO_EXTENSION));
+
+        $readFrom = $this->supportedFileTypes[$fileType] ?? throw CannotReadOpenAPI::fileTypeNotSupported($fileType);
+
+        try {
+            $openAPI = $readFrom($absoluteFilePath);
+        } catch (\TypeError|TypeErrorException|ParseException $e) {
+            throw CannotReadOpenAPI::cannotParse(pathinfo($absoluteFilePath, PATHINFO_BASENAME), $e);
+        } catch (UnresolvableReferenceException $e) {
+            throw CannotReadOpenAPI::unresolvedReference(pathinfo($absoluteFilePath, PATHINFO_BASENAME), $e);
+        }
+
+        $openAPI->validate() ?: throw CannotReadOpenAPI::invalidOpenAPI(pathinfo($absoluteFilePath, PATHINFO_BASENAME));
+
+        return $openAPI;
+    }
+}

--- a/src/OpenAPI/Reader/OpenAPIFileReader.php
+++ b/src/OpenAPI/Reader/OpenAPIFileReader.php
@@ -35,7 +35,7 @@ class OpenAPIFileReader
 
         try {
             $openAPI = $readFrom($absoluteFilePath);
-        } catch (\TypeError|TypeErrorException|ParseException $e) {
+        } catch (\TypeError | TypeErrorException | ParseException $e) {
             throw CannotReadOpenAPI::cannotParse(pathinfo($absoluteFilePath, PATHINFO_BASENAME), $e);
         } catch (UnresolvableReferenceException $e) {
             throw CannotReadOpenAPI::unresolvedReference(pathinfo($absoluteFilePath, PATHINFO_BASENAME), $e);

--- a/src/OpenAPI/Specification/Request.php
+++ b/src/OpenAPI/Specification/Request.php
@@ -19,9 +19,9 @@ class Request extends APISpec
     public readonly array $pathParameters;
     public readonly ?Schema $requestBodySchema;
 
-    public function __construct(string $filePath, string $url, Method $method)
+    public function __construct(string $absoluteFilePath, string $url, Method $method)
     {
-        parent::__construct($filePath, $url);
+        parent::__construct($absoluteFilePath, $url);
 
         $requestOperation = $this->getOperation($method);
 

--- a/src/OpenAPI/Specification/Response.php
+++ b/src/OpenAPI/Specification/Response.php
@@ -12,9 +12,9 @@ class Response extends APISpec
 {
     public readonly ?Schema $schema;
 
-    public function __construct(string $filePath, string $url, Method $method, string $httpStatus)
+    public function __construct(string $absoluteFilePath, string $url, Method $method, string $httpStatus)
     {
-        parent::__construct($filePath, $url);
+        parent::__construct($absoluteFilePath, $url);
 
         $response = $this->getResponse($method, $httpStatus);
 

--- a/tests/OpenAPI/Builder/RequestBuilderTest.php
+++ b/tests/OpenAPI/Builder/RequestBuilderTest.php
@@ -46,6 +46,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * @uses      \Membrane\OpenAPI\PathMatcher
  * @uses      \Membrane\OpenAPI\Processor\Json
  * @uses      \Membrane\OpenAPI\Processor\Request
+ * @uses      \Membrane\OpenAPI\Reader\OpenAPIFileReader
  * @uses      \Membrane\OpenAPI\Specification\APISchema
  * @uses      \Membrane\OpenAPI\Specification\APISpec
  * @uses      \Membrane\OpenAPI\Specification\Arrays

--- a/tests/OpenAPI/Builder/ResponseBuilderTest.php
+++ b/tests/OpenAPI/Builder/ResponseBuilderTest.php
@@ -55,6 +55,7 @@ use PHPUnit\Framework\TestCase;
  * @uses     \Membrane\OpenAPI\Processor\AllOf
  * @uses     \Membrane\OpenAPI\Processor\AnyOf
  * @uses     \Membrane\OpenAPI\Processor\OneOf
+ * @uses     \Membrane\OpenAPI\Reader\OpenAPIFileReader
  * @uses     \Membrane\OpenAPI\Specification\APISchema
  * @uses     \Membrane\OpenAPI\Specification\APISpec
  * @uses     \Membrane\OpenAPI\Specification\Arrays

--- a/tests/OpenAPI/Reader/OpenAPIFileReaderTest.php
+++ b/tests/OpenAPI/Reader/OpenAPIFileReaderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Reader;
+
+use cebe\openapi\exceptions\UnresolvableReferenceException;
+use cebe\openapi\spec\OpenApi;
+use Membrane\OpenAPI\Exception\CannotReadOpenAPI;
+use Membrane\OpenAPI\Reader\OpenAPIFileReader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Exception\ParseException;
+
+/**
+ * @covers \Membrane\OpenAPI\Reader\OpenAPIFileReader
+ * @covers \Membrane\OpenAPI\Exception\CannotReadOpenAPI
+ */
+class OpenAPIFileReaderTest extends TestCase
+{
+    public const FIXTURES = __DIR__ . '/../../fixtures/OpenAPI/';
+
+    public function dataSetsThatThrowExceptions(): array
+    {
+        return [
+            'Non-existent file throws CannotReadOpenAPI::fileNotFound' => [
+                CannotReadOpenAPI::fileNotFound('nowhere/nothing.json'),
+                'nowhere/nothing.json',
+            ],
+            'Relative file path throws CannotReadOpenAPI::unresolvedReference' => [
+                CannotReadOpenAPI::unresolvedReference('petstore.yaml', new UnresolvableReferenceException()),
+                './tests/fixtures/OpenAPI/docs/petstore.yaml',
+            ],
+            'Unsupported file type throws CannotReadOpenAPI::fileTypeNotSupported' => [
+                CannotReadOpenAPI::fileTypeNotSupported('php'),
+                __FILE__,
+            ],
+            'Empty .json file throws CannotReadOpenAPI::cannotParse' => [
+                CannotReadOpenAPI::cannotParse('empty.json', new \TypeError()),
+                self::FIXTURES . 'empty.json',
+            ],
+            'Empty .yml file throws CannotReadOpenAPI::cannotParse' => [
+                CannotReadOpenAPI::cannotParse('empty.yml', new \TypeError()),
+                self::FIXTURES . 'empty.yml',
+            ],
+            '.json file in invalid json format throws CannotReadOpenAPI::cannotParse' => [
+                CannotReadOpenAPI::cannotParse('invalid.json', new \TypeError()),
+                self::FIXTURES . 'invalid.json',
+            ],
+            '.yaml file in invalid yaml format throws CannotReadOpenAPI::cannotParse' => [
+                CannotReadOpenAPI::cannotParse('invalid.yaml', new ParseException('')),
+                self::FIXTURES . 'invalid.yaml',
+            ],
+            '.json file in invalid OpenAPI format throws CannotReadOpenAPI::invalidOpenAPI' => [
+                CannotReadOpenAPI::invalidOpenAPI('invalidAPI.json'),
+                self::FIXTURES . 'invalidAPI.json',
+            ],
+            '.yaml file in invalid OpenAPI format throws CannotReadOpenAPI::invalidOpenAPI' => [
+                CannotReadOpenAPI::invalidOpenAPI('invalidAPI.yaml'),
+                self::FIXTURES . 'invalidAPI.yaml',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider dataSetsThatThrowExceptions
+     */
+    public function exceptionHandlingTest(CannotReadOpenAPI $expected, string $filePath): void
+    {
+        self::expectExceptionObject($expected);
+
+        (new OpenAPIFileReader())->readFromAbsoluteFilePath($filePath);
+    }
+
+    /** @test */
+    public function readFromAbsoluteFilePathTest(): void
+    {
+        $expected = OpenApi::class;
+        $sut = new OpenAPIFileReader();
+
+        $actual = $sut->readFromAbsoluteFilePath(self::FIXTURES . 'simple.json');
+
+        self::assertInstanceOf($expected, $actual);
+    }
+}

--- a/tests/OpenAPI/Specification/APISpecTest.php
+++ b/tests/OpenAPI/Specification/APISpecTest.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace OpenAPI\Specification;
 
-use cebe\openapi\exceptions\UnresolvableReferenceException;
 use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\PathItem;
 use cebe\openapi\spec\Response;
 use Membrane\OpenAPI\Exception\CannotProcessRequest;
-use Membrane\OpenAPI\Exception\CannotReadOpenAPI;
 use Membrane\OpenAPI\Method;
 use Membrane\OpenAPI\Specification\APISpec;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Yaml\Exception\ParseException;
 
 /**
  * @covers \Membrane\OpenAPI\Specification\APISpec
@@ -21,100 +18,11 @@ use Symfony\Component\Yaml\Exception\ParseException;
  * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
  * @covers \Membrane\OpenAPI\Exception\CannotProcessRequest
  * @uses   \Membrane\OpenAPI\PathMatcher
+ * @uses   \Membrane\OpenAPI\Reader\OpenAPIFileReader
  */
 class APISpecTest extends TestCase
 {
-    public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
-
-    /** @test */
-    public function throwExceptionForNonExistentFilePath(): void
-    {
-        self::expectExceptionObject(CannotReadOpenAPI::fileNotFound('nowhere/nothing.json'));
-
-        new class('nowhere/nothing.json', '/testpath') extends APISpec {
-        };
-    }
-
-    /** @test */
-    public function throwExceptionForRelativeFilePath(): void
-    {
-        $fileName = 'petstore.yaml';
-        $relativeFilePath = './tests/fixtures/OpenAPI/docs/' . $fileName;
-        $previous = new UnresolvableReferenceException();
-        self::expectExceptionObject(CannotReadOpenAPI::unresolvedReference($fileName, $previous));
-
-        new class($relativeFilePath, '/path') extends APISpec {
-        };
-    }
-
-    /** @test */
-    public function throwExceptionForInvalidFileType(): void
-    {
-        $filePath = __FILE__;
-        self::expectExceptionObject(CannotReadOpenAPI::fileTypeNotSupported(pathinfo($filePath, PATHINFO_EXTENSION)));
-
-        new class($filePath, '/testpath') extends APISpec {
-        };
-    }
-
-    public function dataSetsNotFollowingOpenAPIFormat(): array
-    {
-        return [
-            'empty json' => [
-                'empty.json',
-                new \TypeError(),
-            ],
-            'empty yml' => [
-                'empty.yml',
-                new \TypeError(),
-            ],
-            'invalid json' => [
-                'invalid.json',
-                new \TypeError(),
-            ],
-            'invalid yaml' => [
-                'invalid.yaml',
-                new ParseException(''),
-            ],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider dataSetsNotFollowingOpenAPIFormat
-     */
-    public function throwExceptionForNotFollowingOpenAPIFormat(string $fileName, \Throwable $e): void
-    {
-        $filePath = self::DIR . $fileName;
-        self::expectExceptionObject(CannotReadOpenAPI::cannotParse($fileName, $e));
-
-        new class($filePath, '/path') extends APISpec {
-        };
-    }
-
-    public function dataSetsFollowingOpenAPIFormatIncorrectly(): array
-    {
-        return [
-            'invalid OpenAPI json' => [
-                'invalidAPI.json',
-            ],
-            'invalid OpenAPI yaml' => [
-                'invalidAPI.yaml',
-            ],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider dataSetsFollowingOpenAPIFormatIncorrectly
-     */
-    public function throwsExceptionForInvalidOpenAPI(string $fileName): void
-    {
-        self::expectExceptionObject(CannotReadOpenAPI::invalidOpenAPI($fileName));
-
-        new class(self::DIR . $fileName, '/path') extends APISpec {
-        };
-    }
+    public const FIXTURES = __DIR__ . '/../../fixtures/OpenAPI/';
 
     /** @test */
     public function throwsExceptionIfNoPathMatches(): void
@@ -123,7 +31,7 @@ class APISpecTest extends TestCase
         $url = 'incorrect/path';
         self::expectExceptionObject(CannotProcessRequest::pathNotFound($fileName, $url));
 
-        new class(self::DIR . $fileName, $url) extends APISpec {
+        new class(self::FIXTURES . $fileName, $url) extends APISpec {
         };
     }
 
@@ -164,12 +72,12 @@ class APISpecTest extends TestCase
      */
     public function successfulConstructionForValidInputs(string $filePath, string $url, Method $method): void
     {
-        $class = new class(self::DIR . $filePath, $url, $method) extends APISpec {
+        $class = new class(self::FIXTURES . $filePath, $url, $method) extends APISpec {
             public Operation $requestOperation;
 
-            public function __construct(string $filePath, string $url, Method $method)
+            public function __construct(string $absoluteFilePath, string $url, Method $method)
             {
-                parent::__construct($filePath, $url);
+                parent::__construct($absoluteFilePath, $url);
                 $this->requestOperation = $this->getOperation($method);
             }
         };

--- a/tests/OpenAPI/Specification/RequestTest.php
+++ b/tests/OpenAPI/Specification/RequestTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
  * @covers \Membrane\OpenAPI\Exception\CannotProcessRequest
  * @uses   \Membrane\OpenAPI\PathMatcher
+ * @uses   \Membrane\OpenAPI\Reader\OpenAPIFileReader
  */
 class RequestTest extends TestCase
 {

--- a/tests/OpenAPI/Specification/ResponseTest.php
+++ b/tests/OpenAPI/Specification/ResponseTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
  * @covers \Membrane\OpenAPI\Exception\CannotProcessRequest
  * @uses   \Membrane\OpenAPI\PathMatcher
+ * @uses   \Membrane\OpenAPI\Reader\OpenAPIFileReader
  */
 class ResponseTest extends TestCase
 {


### PR DESCRIPTION
Adds OpenAPIFileReader:

- has private property of `$supportedFileTypes`
    - may be useful if we add a `supports(): bool` method 
- has public method `readFromAbsoluteFilePath(string $absoluteFilePath): OpenApi`