### PR TITLE
Upgrade to PHPUnit ^10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "psr/http-message": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^10.0",
     "phpstan/phpstan": "^1.8",
     "squizlabs/php_codesniffer": "^3.7",
     "guzzlehttp/psr7": "^2.4"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,27 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         convertDeprecationsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/src/OpenAPI/Processor/Request.php
+++ b/src/OpenAPI/Processor/Request.php
@@ -30,7 +30,7 @@ class Request implements Processor
         }
 
         return "Parse PSR-7 request:\n\t" .
-            implode(".\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->processors)) . '.';
+            implode("\n\t", array_map(fn($p) => preg_replace("#\n#m", "\n\t", (string)$p), $this->processors));
     }
 
     public function __toPHP(): string

--- a/src/Validator/Utility/AllOf.php
+++ b/src/Validator/Utility/AllOf.php
@@ -20,12 +20,13 @@ class AllOf implements Validator
 
     public function __toString(): string
     {
-        if ($this->chain === []) {
+        $conditions = array_filter($this->chain, fn($p) => (string)$p !== '');
+        if ($conditions === []) {
             return '';
         }
 
         return "must satisfy all of the following:\n\t" .
-            implode("\n\t", array_map(fn($p) => '- ' . (string)$p . '.', $this->chain));
+            implode("\n\t", array_map(fn($p) => '- ' . (string)$p . '.', $conditions));
     }
 
     public function __toPHP(): string

--- a/src/Validator/Utility/AnyOf.php
+++ b/src/Validator/Utility/AnyOf.php
@@ -20,12 +20,13 @@ class AnyOf implements Validator
 
     public function __toString(): string
     {
-        if ($this->chain === []) {
+        $conditions = array_filter($this->chain, fn($p) => (string)$p !== '');
+        if ($conditions === []) {
             return '';
         }
 
         return "must satisfy at least one of the following:\n\t" .
-            implode("\n\t", array_map(fn($p) => '- ' . (string)$p . '.', $this->chain));
+            implode("\n\t", array_map(fn($p) => '- ' . (string)$p . '.', $conditions));
     }
 
     public function __toPHP(): string

--- a/tests/Attribute/BuilderTest.php
+++ b/tests/Attribute/BuilderTest.php
@@ -6,9 +6,14 @@ namespace Attribute;
 
 use Membrane\Attribute\Builder;
 use Membrane\Attribute\ClassWithAttributes;
+use Membrane\Attribute\FilterOrValidator;
+use Membrane\Attribute\OverrideProcessorType;
+use Membrane\Attribute\SetFilterOrValidator;
+use Membrane\Attribute\Subtype;
 use Membrane\Builder\Specification;
 use Membrane\Exception\CannotProcessProperty;
 use Membrane\Filter\CreateObject\WithNamedArguments;
+use Membrane\Filter\Type\ToString;
 use Membrane\Fixtures\Attribute\ArraySumFilter;
 use Membrane\Fixtures\Attribute\ClassThatOverridesProcessorType;
 use Membrane\Fixtures\Attribute\ClassWithClassArrayPropertyIsIntValidator;
@@ -44,44 +49,49 @@ use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use Membrane\Validator\Collection\Count;
 use Membrane\Validator\FieldSet\RequiredFields;
+use Membrane\Validator\String\Length;
+use Membrane\Validator\String\Regex;
 use Membrane\Validator\Type\IsInt;
 use Membrane\Validator\Type\IsList;
+use Membrane\Validator\Type\IsString;
+use Membrane\Validator\Utility\AllOf;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers   \Membrane\Attribute\Builder
- * @covers   \Membrane\Exception\CannotProcessProperty
- * @uses     \Membrane\Attribute\ClassWithAttributes
- * @uses     \Membrane\Attribute\FilterOrValidator
- * @uses     \Membrane\Attribute\SetFilterOrValidator
- * @uses     \Membrane\Attribute\OverrideProcessorType
- * @uses     \Membrane\Attribute\Subtype
- * @uses     \Membrane\Result\Result
- * @uses     \Membrane\Result\MessageSet
- * @uses     \Membrane\Result\Message
- * @uses     \Membrane\Result\FieldName
- * @uses     \Membrane\Processor\Collection
- * @uses     \Membrane\Processor\FieldSet
- * @uses     \Membrane\Processor\Field
- * @uses     \Membrane\Processor\BeforeSet
- * @uses     \Membrane\Processor\AfterSet
- * @uses     \Membrane\Validator\FieldSet\RequiredFields
- * @uses     \Membrane\Validator\Type\IsList
- * @uses     \Membrane\Validator\Type\IsInt
- * @uses     \Membrane\Validator\Type\IsString
- * @uses     \Membrane\Filter\Type\ToString
- * @uses     \Membrane\Validator\String\Length
- * @uses     \Membrane\Validator\String\Regex
- * @uses     \Membrane\Validator\Utility\AllOf
- * @uses     \Membrane\Validator\Collection\Count
- * @uses     \Membrane\Filter\CreateObject\WithNamedArguments
- */
+#[CoversClass(Builder::class)]
+#[CoversClass(CannotProcessProperty::class)]
+#[UsesClass(ClassWithAttributes::class)]
+#[UsesClass(FilterOrValidator::class)]
+#[UsesClass(SetFilterOrValidator::class)]
+#[UsesClass(OverrideProcessorType::class)]
+#[UsesClass(Subtype::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Collection::class)]
+#[UsesClass(FieldSet::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(AfterSet::class)]
+#[UsesClass(RequiredFields::class)]
+#[UsesClass(IsList::class)]
+#[UsesClass(IsInt::class)]
+#[UsesClass(IsString::class)]
+#[UsesClass(ToString::class)]
+#[UsesClass(Length::class)]
+#[UsesClass(Regex::class)]
+#[UsesClass(AllOf::class)]
+#[UsesClass(Count::class)]
+#[UsesClass(WithNamedArguments::class)]
 class BuilderTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function supportsReturnsFalseIfSpecificationIsNotClassWithAttributes(): void
     {
         $specification = new class implements Specification {
@@ -93,9 +103,7 @@ class BuilderTest extends TestCase
         self::assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function supportsReturnsTrueIfSpecificationIsClassWithAttributes(): void
     {
         $class = new class {
@@ -108,9 +116,7 @@ class BuilderTest extends TestCase
         self::assertTrue($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noTypeHintThrowsException(): void
     {
         $specification = new ClassWithAttributes(ClassWithNoTypeHint::class);
@@ -122,9 +128,7 @@ class BuilderTest extends TestCase
         $builder->build($specification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noSubTypeHintThrowsException(): void
     {
         $specification = new ClassWithAttributes(ClassWithNoSubTypeHint::class);
@@ -136,9 +140,7 @@ class BuilderTest extends TestCase
         $builder->build($specification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function compoundPropertyThrowsException(): void
     {
         $specification = new ClassWithAttributes(ClassWithCompoundPropertyType::class);
@@ -152,9 +154,7 @@ class BuilderTest extends TestCase
         $builder->build($specification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nestedCollectionThrowsException(): void
     {
         $specification = new ClassWithAttributes(ClassWithNestedCollection::class);
@@ -260,10 +260,8 @@ class BuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetOfClassesToBuild
-     */
+    #[DataProvider('dataSetOfClassesToBuild')]
+    #[Test]
     public function BuildingProcessorsTest(Specification $specification, FieldSet $expected): void
     {
         $builder = new Builder();
@@ -345,10 +343,8 @@ class BuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetOfInputsAndOutputs
-     */
+    #[DataProvider('dataSetOfInputsAndOutputs')]
+    #[Test]
     public function InputsAndOutputsTest(Specification $specification, mixed $input, mixed $expected): void
     {
         $builder = new Builder();
@@ -524,10 +520,8 @@ class BuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithDocExamples
-     */
+    #[DataProvider('dataSetsWithDocExamples')]
+    #[Test]
     public function docExamplesTest(Specification $specification, array $input, Result $expected): void
     {
         $builder = new Builder();

--- a/tests/Attribute/BuilderTest.php
+++ b/tests/Attribute/BuilderTest.php
@@ -169,7 +169,7 @@ class BuilderTest extends TestCase
         $builder->build($specification);
     }
 
-    public function dataSetOfClassesToBuild(): array
+    public static function dataSetOfClassesToBuild(): array
     {
         return [
             EmptyClass::class => [
@@ -273,7 +273,7 @@ class BuilderTest extends TestCase
         self::assertEquals($expected, $output);
     }
 
-    public function dataSetOfInputsAndOutputs(): array
+    public static function dataSetOfInputsAndOutputs(): array
     {
         return [
             EmptyClass::class => [
@@ -359,7 +359,7 @@ class BuilderTest extends TestCase
         self::assertEquals($expected, $output);
     }
 
-    public function dataSetsWithDocExamples(): array
+    public static function dataSetsWithDocExamples(): array
     {
         return [
             'Blog Post: A' => [

--- a/tests/Attribute/ClassWithAttributesTest.php
+++ b/tests/Attribute/ClassWithAttributesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Attribute;
 
 use Membrane\Attribute\ClassWithAttributes;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,9 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ClassWithAttributesTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function passingNonExistentClassNameToFromClassThrowsException(): void
     {
         self::expectException('Exception');

--- a/tests/Filter/CreateObject/FromArrayTest.php
+++ b/tests/Filter/CreateObject/FromArrayTest.php
@@ -8,17 +8,18 @@ use Membrane\Filter\CreateObject\FromArray;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\CreateObject\FromArray
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(FromArray::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class FromArrayTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'calls \a\b::fromArray';
@@ -29,7 +30,7 @@ class FromArrayTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new FromArray('Arbitrary\Class');
@@ -39,9 +40,7 @@ class FromArrayTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noFromArrayMethodReturnsInvalid(): void
     {
         $input = ['a' => 1, 'b' => 2];
@@ -64,9 +63,7 @@ class FromArrayTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function incorrectFilterInputReturnsInvalid(): void
     {
         $input = 'this is not an array';
@@ -93,9 +90,7 @@ class FromArrayTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function correctFilterInputReturnsResult(): void
     {
         $input = ['a', 'b', 'c'];

--- a/tests/Filter/CreateObject/WithNamedArgumentsTest.php
+++ b/tests/Filter/CreateObject/WithNamedArgumentsTest.php
@@ -8,17 +8,19 @@ use Membrane\Filter\CreateObject\WithNamedArguments;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\CreateObject\WithNamedArguments
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(WithNamedArguments::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class WithNamedArgumentsTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'construct an instance of "\a\b" from named arguments contained in self';
@@ -29,7 +31,7 @@ class WithNamedArgumentsTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new WithNamedArguments('Arbitrary\Class');
@@ -61,10 +63,8 @@ class WithNamedArgumentsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function createsNewInstanceOfClassWithNamedArguments(object $class, array $input): void
     {
         $withNamedArgs = new WithNamedArguments(get_class($class));
@@ -102,10 +102,8 @@ class WithNamedArgumentsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function invalidParameterTest(object $class, array $input, string $expectedMessage): void
     {
         $withNamedArgs = new WithNamedArguments(get_class($class));

--- a/tests/Filter/CreateObject/WithNamedArgumentsTest.php
+++ b/tests/Filter/CreateObject/WithNamedArgumentsTest.php
@@ -39,7 +39,7 @@ class WithNamedArgumentsTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsThatPass(): array
+    public static function dataSetsThatPass(): array
     {
         $classWithNamedArguments = new class (a: 'default', b: 'arguments') {
             public function __construct(public string $a, public string $b)
@@ -75,7 +75,7 @@ class WithNamedArgumentsTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         $classWithNamedArguments = new class (a: 'default', b: 'arguments') {
             public function __construct(public string $a, public string $b)

--- a/tests/Filter/Shape/CollectTest.php
+++ b/tests/Filter/Shape/CollectTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CollectTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no fields' => [
@@ -49,7 +49,7 @@ class CollectTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no fields' => [new Collect('collection')],
@@ -69,7 +69,7 @@ class CollectTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [
@@ -99,7 +99,7 @@ class CollectTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithCorrectTypes(): array
+    public static function dataSetsWithCorrectTypes(): array
     {
         return [
             'collecting all items in array' => [

--- a/tests/Filter/Shape/CollectTest.php
+++ b/tests/Filter/Shape/CollectTest.php
@@ -8,14 +8,16 @@ use Membrane\Filter\Shape\Collect;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Shape\Collect
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Collect::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class CollectTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -36,10 +38,8 @@ class CollectTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(array $fields, string $expected): void
     {
         $sut = new Collect('new collection', ...$fields);
@@ -58,10 +58,8 @@ class CollectTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Collect $sut): void
     {
         $actual = $sut->__toPHP();
@@ -85,10 +83,8 @@ class CollectTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectFilterInputReturnsInvalid(mixed $input, string $expectedMessage, array $expectedVars): void
     {
         $collect = new Collect('new field', 'a', 'b');
@@ -120,10 +116,8 @@ class CollectTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithCorrectTypes
-     */
+    #[DataProvider('dataSetsWithCorrectTypes')]
+    #[Test]
     public function correctFilterInputReturnsResult(array $input, array $fieldsToCollect, array $expectedValue): void
     {
         $collect = new Collect('new field', ...$fieldsToCollect);

--- a/tests/Filter/Shape/DeleteTest.php
+++ b/tests/Filter/Shape/DeleteTest.php
@@ -8,14 +8,16 @@ use Membrane\Filter\Shape\Delete;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Shape\Delete
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Delete::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class DeleteTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -36,10 +38,8 @@ class DeleteTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(array $fields, string $expected): void
     {
         $sut = new Delete(...$fields);
@@ -58,10 +58,8 @@ class DeleteTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Delete $sut): void
     {
         $actual = $sut->__toPHP();
@@ -82,10 +80,8 @@ class DeleteTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectInputs
-     */
+    #[DataProvider('dataSetsWithIncorrectInputs')]
+    #[Test]
     public function incorrectInputsReturnInvalid(mixed $input, Message $expectedMessage): void
     {
         $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
@@ -117,10 +113,8 @@ class DeleteTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToFilter
-     */
+    #[DataProvider('dataSetsToFilter')]
+    #[Test]
     public function listsAreTruncatedToMatchMaxLength(array $input, array $fieldNames, array $expectedValue): void
     {
         $expected = Result::noResult($expectedValue);

--- a/tests/Filter/Shape/DeleteTest.php
+++ b/tests/Filter/Shape/DeleteTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class DeleteTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no fields' => [
@@ -49,7 +49,7 @@ class DeleteTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no fields' => [new Delete(),],
@@ -69,7 +69,7 @@ class DeleteTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectInputs(): array
+    public static function dataSetsWithIncorrectInputs(): array
     {
         $notArrayMessage = 'Delete filter requires arrays, %s given';
         $listMessage = 'Delete filter requires arrays, for lists use Truncate';
@@ -96,7 +96,7 @@ class DeleteTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsToFilter(): array
+    public static function dataSetsToFilter(): array
     {
         return [
             [

--- a/tests/Filter/Shape/NestTest.php
+++ b/tests/Filter/Shape/NestTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class NestTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no fields' => [
@@ -49,7 +49,7 @@ class NestTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no fields' => [new Nest('new field'),],
@@ -69,7 +69,7 @@ class NestTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [
@@ -99,7 +99,7 @@ class NestTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithCorrectTypes(): array
+    public static function dataSetsWithCorrectTypes(): array
     {
         return [
             'nesting all items in array' => [

--- a/tests/Filter/Shape/NestTest.php
+++ b/tests/Filter/Shape/NestTest.php
@@ -8,14 +8,16 @@ use Membrane\Filter\Shape\Nest;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Shape\Nest
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Nest::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class NestTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -36,10 +38,8 @@ class NestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(array $fields, string $expected): void
     {
         $sut = new Nest('new field set', ...$fields);
@@ -58,10 +58,8 @@ class NestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Nest $sut): void
     {
         $actual = $sut->__toPHP();
@@ -85,10 +83,8 @@ class NestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectFilterInputReturnsInvalid(mixed $input, string $expectedMessage, array $expectedVars): void
     {
         $nest = new Nest('new field', 'a', 'b');
@@ -120,10 +116,8 @@ class NestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithCorrectTypes
-     */
+    #[DataProvider('dataSetsWithCorrectTypes')]
+    #[Test]
     public function correctFilterInputReturnsResult(array $input, array $fieldsToCollect, array $expectedValue): void
     {
         $nest = new Nest('new field', ...$fieldsToCollect);

--- a/tests/Filter/Shape/PluckTest.php
+++ b/tests/Filter/Shape/PluckTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PluckTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no fields' => [
@@ -49,7 +49,7 @@ class PluckTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no fields' => [new Pluck('field set')],
@@ -69,7 +69,7 @@ class PluckTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectInputs(): array
+    public static function dataSetsWithIncorrectInputs(): array
     {
         $notArrayMessage = 'Pluck filter requires arrays, %s given';
         $listMessage = 'Pluck filter requires arrays with key-value pairs';
@@ -124,7 +124,7 @@ class PluckTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatPass(): array
+    public static function dataSetsThatPass(): array
     {
         return [
             [

--- a/tests/Filter/Shape/PluckTest.php
+++ b/tests/Filter/Shape/PluckTest.php
@@ -8,14 +8,16 @@ use Membrane\Filter\Shape\Pluck;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Shape\Pluck
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Pluck::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class PluckTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -36,10 +38,8 @@ class PluckTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(array $fields, string $expected): void
     {
         $sut = new Pluck('existing field set', ...$fields);
@@ -58,10 +58,8 @@ class PluckTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Pluck $sut): void
     {
         $actual = $sut->__toPHP();
@@ -82,10 +80,8 @@ class PluckTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectInputs
-     */
+    #[DataProvider('dataSetsWithIncorrectInputs')]
+    #[Test]
     public function incorrectInputsReturnInvalid(mixed $input, Message $expectedMessage): void
     {
         $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
@@ -96,9 +92,7 @@ class PluckTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nonExistentFieldSetIsIgnored(): void
     {
         $input = ['not-from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4];
@@ -110,9 +104,7 @@ class PluckTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nonExistentFieldNamesAreIgnored(): void
     {
         $input = ['from' => ['a' => 1, 'b' => 2, 'c' => 3], 'd' => 4];
@@ -151,10 +143,8 @@ class PluckTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function correctInputsSuccessfullyPluckValue($input, $expectedValue, $fieldSet, ...$fieldNames): void
     {
         $expected = Result::noResult($expectedValue);

--- a/tests/Filter/Shape/RenameTest.php
+++ b/tests/Filter/Shape/RenameTest.php
@@ -50,7 +50,7 @@ class RenameTest extends TestCase
         new Rename('a', 'a');
     }
 
-    public function dataSetsWithIncorrectInputs(): array
+    public static function dataSetsWithIncorrectInputs(): array
     {
         $notArrayMessage = 'Rename filter requires arrays, %s given';
         $listMessage = 'Rename filter requires arrays with key-value pairs';
@@ -91,7 +91,7 @@ class RenameTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsToFilter(): array
+    public static function dataSetsToFilter(): array
     {
         return [
             [

--- a/tests/Filter/Shape/RenameTest.php
+++ b/tests/Filter/Shape/RenameTest.php
@@ -8,17 +8,19 @@ use Membrane\Filter\Shape\Rename;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Shape\Rename
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Rename::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class RenameTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'rename "a" to "b"';
@@ -29,7 +31,7 @@ class RenameTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new Rename('a', 'b');
@@ -39,9 +41,7 @@ class RenameTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function oldAndNewCannotBeEqual(): void
     {
         self::expectException('RuntimeException');
@@ -63,10 +63,8 @@ class RenameTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectInputs
-     */
+    #[DataProvider('dataSetsWithIncorrectInputs')]
+    #[Test]
     public function incorrectInputsReturnInvalid(mixed $input, Message $expectedMessage): void
     {
         $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
@@ -77,9 +75,7 @@ class RenameTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function nonExistentKeysAreIgnored(): void
     {
         $input = ['a' => 1, 'b' => 2];
@@ -109,10 +105,8 @@ class RenameTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToFilter
-     */
+    #[DataProvider('dataSetsToFilter')]
+    #[Test]
     public function ifOldKeyExistsThenItIsRenamed(array $input, mixed $old, mixed $new, array $expectedValue): void
     {
         $expected = Result::noResult($expectedValue);

--- a/tests/Filter/Shape/TruncateTest.php
+++ b/tests/Filter/Shape/TruncateTest.php
@@ -51,7 +51,7 @@ class TruncateTest extends TestCase
         $truncate = new Truncate(-1);
     }
 
-    public function dataSetsWithIncorrectInputs(): array
+    public static function dataSetsWithIncorrectInputs(): array
     {
         $notArrayMessage = 'Truncate filter requires lists, %s given';
         $arrayMessage = 'Truncate filter requires lists, for arrays use Delete';
@@ -92,7 +92,7 @@ class TruncateTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsToFilter(): array
+    public static function dataSetsToFilter(): array
     {
         return [
             [

--- a/tests/Filter/Shape/TruncateTest.php
+++ b/tests/Filter/Shape/TruncateTest.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Filter\Shape;
 
-use Exception;
 use Membrane\Filter\Shape\Truncate;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Shape\Truncate
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Truncate::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class TruncateTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'truncate self to 5 fields or less';
@@ -30,7 +31,7 @@ class TruncateTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new Truncate(5);
@@ -40,15 +41,12 @@ class TruncateTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /**
-     * @test
-     * @throws Exception
-     */
+    #[Test]
     public function negativeMaxLengthThrowsError()
     {
         self::expectExceptionMessage('Truncate filter cannot take negative max lengths');
 
-        $truncate = new Truncate(-1);
+        new Truncate(-1);
     }
 
     public static function dataSetsWithIncorrectInputs(): array
@@ -64,10 +62,8 @@ class TruncateTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectInputs
-     */
+    #[DataProvider('dataSetsWithIncorrectInputs')]
+    #[Test]
     public function incorrectInputsReturnInvalid(mixed $input, Message $expectedMessage): void
     {
         $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
@@ -78,9 +74,7 @@ class TruncateTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function returnInputIfAlreadyBelowMaxLength(): void
     {
         $input = ['a', 'list'];
@@ -108,10 +102,8 @@ class TruncateTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToFilter
-     */
+    #[DataProvider('dataSetsToFilter')]
+    #[Test]
     public function listsAreTruncatedToMatchMaxLength(array $input, int $maxLength, array $expectedValue): void
     {
         $expected = Result::noResult($expectedValue);

--- a/tests/Filter/String/JsonDecodeTest.php
+++ b/tests/Filter/String/JsonDecodeTest.php
@@ -39,7 +39,7 @@ class JsonDecodeTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsToFilter(): array
+    public static function dataSetsToFilter(): array
     {
         return [
             'value is not a string' => [

--- a/tests/Filter/String/JsonDecodeTest.php
+++ b/tests/Filter/String/JsonDecodeTest.php
@@ -8,17 +8,19 @@ use Membrane\Filter\String\JsonDecode;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\String\JsonDecode
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(JsonDecode::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
 class JsonDecodeTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert from json to a PHP value';
@@ -29,7 +31,7 @@ class JsonDecodeTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new JsonDecode();
@@ -77,10 +79,8 @@ class JsonDecodeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToFilter
-     */
+    #[DataProvider('dataSetsToFilter')]
+    #[Test]
     public function filterTest(mixed $value, Result $expected): void
     {
         $sut = new JsonDecode();

--- a/tests/Filter/Type/ToBoolTest.php
+++ b/tests/Filter/Type/ToBoolTest.php
@@ -39,7 +39,7 @@ class ToBoolTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithAcceptableInputs(): array
+    public static function dataSetsWithAcceptableInputs(): array
     {
         return [
             [1, true],
@@ -72,7 +72,7 @@ class ToBoolTest extends TestCase
         self::assertEquals($expected->result, $result->result);
     }
 
-    public function dataSetsWithUnacceptableInputs(): array
+    public static function dataSetsWithUnacceptableInputs(): array
     {
         $unacceptableMessage = 'ToBool filter only accepts scalar values, %s given';
         $failureMessage = 'ToBool filter failed to convert value to boolean';

--- a/tests/Filter/Type/ToBoolTest.php
+++ b/tests/Filter/Type/ToBoolTest.php
@@ -8,17 +8,19 @@ use Membrane\Filter\Type\ToBool;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Type\ToBool
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(ToBool::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class ToBoolTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert to a boolean';
@@ -29,7 +31,7 @@ class ToBoolTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new ToBool();
@@ -57,10 +59,8 @@ class ToBoolTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithAcceptableInputs
-     */
+    #[DataProvider('dataSetsWithAcceptableInputs')]
+    #[Test]
     public function acceptableTypesReturnBooleanValues($input, $expectedValue): void
     {
         $toBool = new ToBool();
@@ -111,10 +111,8 @@ class ToBoolTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithUnacceptableInputs
-     */
+    #[DataProvider('dataSetsWithUnacceptableInputs')]
+    #[Test]
     public function unacceptableTypesReturnInvalid($input, $expectedMessage): void
     {
         $toBool = new ToBool();

--- a/tests/Filter/Type/ToDateTimeTest.php
+++ b/tests/Filter/Type/ToDateTimeTest.php
@@ -10,17 +10,19 @@ use Membrane\Filter\Type\ToDateTime;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Type\ToDateTime
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(ToDateTime::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class ToDateTimeTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert to a DateTime';
@@ -39,10 +41,8 @@ class ToDateTimeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(ToDateTime $sut): void
     {
         $actual = $sut->__toPHP();
@@ -61,10 +61,8 @@ class ToDateTimeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $toDateTime = new ToDateTime('');
@@ -90,10 +88,8 @@ class ToDateTimeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function stringsThatMatchFormatReturnImmutableDateTimes(string $format, string $input): void
     {
         $toDateTime = new ToDateTime($format);
@@ -105,10 +101,8 @@ class ToDateTimeTest extends TestCase
         self::assertTrue($result->value instanceof DateTimeImmutable);
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function stringsThatMatchFormatReturnDateTimesIfImmutableSetToFalse(string $format, string $input,): void
     {
         $toDateTime = new ToDateTime($format, false);
@@ -170,10 +164,8 @@ class ToDateTimeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function stringsThatDoNotMatchFormatReturnInvalid(string $format, string $input, array $expectedVars): void
     {
         $toDateTime = new ToDateTime($format);

--- a/tests/Filter/Type/ToDateTimeTest.php
+++ b/tests/Filter/Type/ToDateTimeTest.php
@@ -31,7 +31,7 @@ class ToDateTimeTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'immutable' => [new ToDateTime('Y-m-d', true)],
@@ -50,7 +50,7 @@ class ToDateTimeTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [123, 'integer'],
@@ -81,7 +81,7 @@ class ToDateTimeTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatPass(): array
+    public static function dataSetsThatPass(): array
     {
         return [
             ['', ''],
@@ -120,7 +120,7 @@ class ToDateTimeTest extends TestCase
         self::assertTrue($result->value instanceof DateTime);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         // @TODO once min requirement is PHP 8.2: remove version_compare statements
         return [

--- a/tests/Filter/Type/ToFloatTest.php
+++ b/tests/Filter/Type/ToFloatTest.php
@@ -8,17 +8,19 @@ use Membrane\Filter\Type\ToFloat;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Type\ToFloat
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(ToFloat::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class ToFloatTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert to a float';
@@ -29,7 +31,7 @@ class ToFloatTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new ToFloat();
@@ -50,10 +52,8 @@ class ToFloatTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithAcceptableInputs
-     */
+    #[DataProvider('dataSetsWithAcceptableInputs')]
+    #[Test]
     public function acceptableTypesReturnFloatValues($input, $expectedValue): void
     {
         $toFloat = new ToFloat();
@@ -91,10 +91,8 @@ class ToFloatTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithUnacceptableInputs
-     */
+    #[DataProvider('dataSetsWithUnacceptableInputs')]
+    #[Test]
     public function unacceptableTypesReturnInvalid($input, $expectedMessage): void
     {
         $toFloat = new ToFloat();

--- a/tests/Filter/Type/ToFloatTest.php
+++ b/tests/Filter/Type/ToFloatTest.php
@@ -39,7 +39,7 @@ class ToFloatTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithAcceptableInputs(): array
+    public static function dataSetsWithAcceptableInputs(): array
     {
         return [
             [1, 1.0],
@@ -65,7 +65,7 @@ class ToFloatTest extends TestCase
         self::assertEquals($expected->result, $result->result);
     }
 
-    public function dataSetsWithUnacceptableInputs(): array
+    public static function dataSetsWithUnacceptableInputs(): array
     {
         $message = 'ToFloat filter only accepts null or scalar values, %s given';
         $class = new class () {

--- a/tests/Filter/Type/ToIntTest.php
+++ b/tests/Filter/Type/ToIntTest.php
@@ -8,17 +8,19 @@ use Membrane\Filter\Type\ToInt;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Type\ToInt
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(ToInt::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class ToIntTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert to an integer';
@@ -29,7 +31,7 @@ class ToIntTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new ToInt();
@@ -50,10 +52,8 @@ class ToIntTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithAcceptableInputs
-     */
+    #[DataProvider('dataSetsWithAcceptableInputs')]
+    #[Test]
     public function acceptableTypesReturnIntegerValues($input, $expectedValue): void
     {
         $toInt = new ToInt();
@@ -91,10 +91,8 @@ class ToIntTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithUnacceptableInputs
-     */
+    #[DataProvider('dataSetsWithUnacceptableInputs')]
+    #[Test]
     public function unacceptableTypesReturnInvalid($input, $expectedMessage): void
     {
         $toInt = new ToInt();

--- a/tests/Filter/Type/ToIntTest.php
+++ b/tests/Filter/Type/ToIntTest.php
@@ -39,7 +39,7 @@ class ToIntTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithAcceptableInputs(): array
+    public static function dataSetsWithAcceptableInputs(): array
     {
         return [
             [1, 1],
@@ -65,7 +65,7 @@ class ToIntTest extends TestCase
         self::assertEquals($expected->result, $result->result);
     }
 
-    public function dataSetsWithUnacceptableInputs(): array
+    public static function dataSetsWithUnacceptableInputs(): array
     {
         $message = 'ToInt filter only accepts null or scalar values, %s given';
         $class = new class () {

--- a/tests/Filter/Type/ToListTest.php
+++ b/tests/Filter/Type/ToListTest.php
@@ -8,17 +8,19 @@ use Membrane\Filter\Type\ToList;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Type\ToList
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(ToList::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class ToListTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert to a list';
@@ -29,7 +31,7 @@ class ToListTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new ToList();
@@ -48,10 +50,8 @@ class ToListTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithAcceptableInputs
-     */
+    #[DataProvider('dataSetsWithAcceptableInputs')]
+    #[Test]
     public function acceptableTypesReturnListValues($input, $expectedValue): void
     {
         $toList = new ToList();
@@ -97,10 +97,8 @@ class ToListTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithUnacceptableInputs
-     */
+    #[DataProvider('dataSetsWithUnacceptableInputs')]
+    #[Test]
     public function unacceptableTypesReturnInvalid($input, $expectedMessage): void
     {
         $toList = new ToList();

--- a/tests/Filter/Type/ToListTest.php
+++ b/tests/Filter/Type/ToListTest.php
@@ -39,7 +39,7 @@ class ToListTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithAcceptableInputs(): array
+    public static function dataSetsWithAcceptableInputs(): array
     {
         return [
             [[], []],
@@ -63,7 +63,7 @@ class ToListTest extends TestCase
         self::assertEquals($expected->result, $result->result);
     }
 
-    public function dataSetsWithUnacceptableInputs(): array
+    public static function dataSetsWithUnacceptableInputs(): array
     {
         $message = 'ToList filter only accepts arrays, %s given';
         $class = new class () {

--- a/tests/Filter/Type/ToNumberTest.php
+++ b/tests/Filter/Type/ToNumberTest.php
@@ -39,7 +39,7 @@ class ToNumberTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsToFilter(): array
+    public static function dataSetsToFilter(): array
     {
         $class = new class {
         };

--- a/tests/Filter/Type/ToNumberTest.php
+++ b/tests/Filter/Type/ToNumberTest.php
@@ -8,17 +8,19 @@ use Membrane\Filter\Type\ToNumber;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Type\ToNumber
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(ToNumber::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
 class ToNumberTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert to a number';
@@ -29,7 +31,7 @@ class ToNumberTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new ToNumber();
@@ -97,10 +99,8 @@ class ToNumberTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToFilter
-     */
+    #[DataProvider('dataSetsToFilter')]
+    #[Test]
     public function validateTest(mixed $value, Result $expected): void
     {
         $sut = new ToNumber();

--- a/tests/Filter/Type/ToStringTest.php
+++ b/tests/Filter/Type/ToStringTest.php
@@ -8,17 +8,19 @@ use Membrane\Filter\Type\ToString;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Filter\Type\ToString
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(ToString::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class ToStringTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert to a string';
@@ -29,7 +31,7 @@ class ToStringTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new ToString();
@@ -57,10 +59,8 @@ class ToStringTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithAcceptableInputs
-     */
+    #[DataProvider('dataSetsWithAcceptableInputs')]
+    #[Test]
     public function acceptableInputsReturnStrings($input, $expectedValue)
     {
         $toString = new ToString();
@@ -94,10 +94,8 @@ class ToStringTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithUnacceptableInputs
-     */
+    #[DataProvider('dataSetsWithUnacceptableInputs')]
+    #[Test]
     public function unacceptableTypesReturnInvalid($input, $expectedMessage): void
     {
         $toString = new ToString();

--- a/tests/Filter/Type/ToStringTest.php
+++ b/tests/Filter/Type/ToStringTest.php
@@ -39,7 +39,7 @@ class ToStringTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithAcceptableInputs(): array
+    public static function dataSetsWithAcceptableInputs(): array
     {
         $classWithMethod = new class () {
             public function __toString(): string
@@ -72,7 +72,7 @@ class ToStringTest extends TestCase
         self::assertEquals($expected->result, $result->result);
     }
 
-    public function dataSetsWithUnacceptableInputs(): array
+    public static function dataSetsWithUnacceptableInputs(): array
     {
         $message = 'ToString filter only accepts objects, null or scalar values, %s given';
         $classWithoutMethod = new class () {

--- a/tests/OpenAPI/Builder/ArraysTest.php
+++ b/tests/OpenAPI/Builder/ArraysTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace OpenAPI\Builder;
 
 use cebe\openapi\spec\Schema;
+use Membrane\OpenAPI\Builder\APIBuilder;
 use Membrane\OpenAPI\Builder\Arrays;
+use Membrane\OpenAPI\Builder\Numeric;
 use Membrane\OpenAPI\Processor\AnyOf;
 use Membrane\OpenAPI\Specification;
 use Membrane\Processor;
@@ -18,27 +20,27 @@ use Membrane\Validator\Collection\Unique;
 use Membrane\Validator\Type\IsInt;
 use Membrane\Validator\Type\IsList;
 use Membrane\Validator\Type\IsNull;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Builder\Arrays
- * @covers \Membrane\OpenAPI\Builder\APIBuilder
- * @uses   \Membrane\OpenAPI\Builder\Numeric
- * @uses   \Membrane\OpenAPI\Processor\AnyOf
- * @uses   \Membrane\OpenAPI\Specification\APISchema
- * @uses   \Membrane\OpenAPI\Specification\Numeric
- * @uses   \Membrane\Processor\BeforeSet
- * @uses   \Membrane\Processor\Collection
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Validator\Collection\Contained
- * @uses   \Membrane\Validator\Collection\Count
- * @uses   \Membrane\Validator\Collection\Unique
- */
+#[CoversClass(Arrays::class)]
+#[CoversClass(APIBuilder::class)]
+#[UsesClass(Numeric::class)]
+#[UsesClass(AnyOf::class)]
+#[UsesClass(Specification\APISchema::class)]
+#[UsesClass(Specification\Numeric::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(Collection::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(Contained::class)]
+#[UsesClass(Count::class)]
+#[UsesClass(Unique::class)]
 class ArraysTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function supportsArraysSpecification(): void
     {
         $specification = self::createStub(Specification\Arrays::class);
@@ -47,9 +49,7 @@ class ArraysTest extends TestCase
         self::assertTrue($sut->supports($specification));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotSupportNonArraysSpecification(): void
     {
         $specification = self::createStub(Specification\APISpec::class);
@@ -117,10 +117,8 @@ class ArraysTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider specificationsToBuild
-     */
+    #[DataProvider('specificationsToBuild')]
+    #[Test]
     public function buildTest(Specification\Arrays $specification, Processor $expected): void
     {
         $sut = new Arrays();

--- a/tests/OpenAPI/Builder/ArraysTest.php
+++ b/tests/OpenAPI/Builder/ArraysTest.php
@@ -36,30 +36,29 @@ use PHPUnit\Framework\TestCase;
  */
 class ArraysTest extends TestCase
 {
-    public function specificationsToSupport(): array
+    /**
+     * @test
+     */
+    public function supportsArraysSpecification(): void
     {
-        return [
-            [
-                new class() implements \Membrane\Builder\Specification {
-                },
-                false,
-            ],
-            [self::createStub(Specification\Arrays::class), true],
-        ];
+        $specification = self::createStub(Specification\Arrays::class);
+        $sut = new Arrays();
+
+        self::assertTrue($sut->supports($specification));
     }
 
     /**
      * @test
-     * @dataProvider specificationsToSupport
      */
-    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    public function doesNotSupportNonArraysSpecification(): void
     {
+        $specification = self::createStub(Specification\APISpec::class);
         $sut = new Arrays();
 
-        self::assertSame($expected, $sut->supports($specification));
+        self::assertFalse($sut->supports($specification));
     }
 
-    public function specificationsToBuild(): array
+    public static function specificationsToBuild(): array
     {
         return [
             'minimum input' => [

--- a/tests/OpenAPI/Builder/NumericTest.php
+++ b/tests/OpenAPI/Builder/NumericTest.php
@@ -8,6 +8,7 @@ use cebe\openapi\spec\Schema;
 use Membrane\Filter\Type\ToFloat;
 use Membrane\Filter\Type\ToInt;
 use Membrane\Filter\Type\ToNumber;
+use Membrane\OpenAPI\Builder\APIBuilder;
 use Membrane\OpenAPI\Builder\Numeric;
 use Membrane\OpenAPI\Processor\AnyOf;
 use Membrane\OpenAPI\Specification;
@@ -21,23 +22,23 @@ use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Type\IsInt;
 use Membrane\Validator\Type\IsNull;
 use Membrane\Validator\Type\IsNumber;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Builder\Numeric
- * @covers \Membrane\OpenAPI\Builder\APIBuilder
- * @uses   \Membrane\OpenAPI\Processor\AnyOf
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Validator\Collection\Contained
- * @uses   \Membrane\Validator\Numeric\Maximum
- * @uses   \Membrane\Validator\Numeric\Minimum
- * @uses   \Membrane\Validator\Numeric\MultipleOf
- */
+#[CoversClass(Numeric::class)]
+#[CoversClass(APIBuilder::class)]
+#[UsesClass(AnyOf::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(Contained::class)]
+#[UsesClass(Maximum::class)]
+#[UsesClass(Minimum::class)]
+#[UsesClass(MultipleOf::class)]
 class NumericTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function supportsNumericSpecification(): void
     {
         $specification = self::createStub(Specification\Numeric::class);
@@ -46,9 +47,7 @@ class NumericTest extends TestCase
         self::assertTrue($sut->supports($specification));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotSupportNonNumericSpecification(): void
     {
         $specification = self::createStub(Specification\APISpec::class);
@@ -119,10 +118,8 @@ class NumericTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider specificationsToBuild
-     */
+    #[DataProvider('specificationsToBuild')]
+    #[Test]
     public function buildTest(Specification\Numeric $specification, Processor $expected): void
     {
         $sut = new Numeric();

--- a/tests/OpenAPI/Builder/NumericTest.php
+++ b/tests/OpenAPI/Builder/NumericTest.php
@@ -35,30 +35,29 @@ use PHPUnit\Framework\TestCase;
  */
 class NumericTest extends TestCase
 {
-    public function specificationsToSupport(): array
+    /**
+     * @test
+     */
+    public function supportsNumericSpecification(): void
     {
-        return [
-            [
-                new class() implements \Membrane\Builder\Specification {
-                },
-                false,
-            ],
-            [self::createStub(Specification\Numeric::class), true],
-        ];
+        $specification = self::createStub(Specification\Numeric::class);
+        $sut = new Numeric();
+
+        self::assertTrue($sut->supports($specification));
     }
 
     /**
      * @test
-     * @dataProvider specificationsToSupport
      */
-    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    public function doesNotSupportNonNumericSpecification(): void
     {
+        $specification = self::createStub(Specification\APISpec::class);
         $sut = new Numeric();
 
-        self::assertSame($expected, $sut->supports($specification));
+        self::assertFalse($sut->supports($specification));
     }
 
-    public function specificationsToBuild(): array
+    public static function specificationsToBuild(): array
     {
         return [
             'non-strict integer input' => [

--- a/tests/OpenAPI/Builder/ObjectsTest.php
+++ b/tests/OpenAPI/Builder/ObjectsTest.php
@@ -41,30 +41,29 @@ use PHPUnit\Framework\TestCase;
  */
 class ObjectsTest extends TestCase
 {
-    public function specificationsToSupport(): array
+    /**
+     * @test
+     */
+    public function supportsArraysSpecification(): void
     {
-        return [
-            [
-                new class() implements \Membrane\Builder\Specification {
-                },
-                false,
-            ],
-            [self::createStub(Specification\Objects::class), true],
-        ];
+        $specification = self::createStub(Specification\Objects::class);
+        $sut = new Objects();
+
+        self::assertTrue($sut->supports($specification));
     }
 
     /**
      * @test
-     * @dataProvider specificationsToSupport
      */
-    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    public function doesNotSupportSpecificationsThatAreNotArrays(): void
     {
+        $specification = self::createStub(Specification\APISpec::class);
         $sut = new Objects();
 
-        self::assertSame($expected, $sut->supports($specification));
+        self::assertFalse($sut->supports($specification));
     }
 
-    public function specificationsToBuild(): array
+    public static function specificationsToBuild(): array
     {
         return [
             'minimum input' => [

--- a/tests/OpenAPI/Builder/ObjectsTest.php
+++ b/tests/OpenAPI/Builder/ObjectsTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace OpenAPI\Builder;
 
 use cebe\openapi\spec\Schema;
+use Membrane\OpenAPI\Builder\APIBuilder;
+use Membrane\OpenAPI\Builder\Numeric;
 use Membrane\OpenAPI\Builder\Objects;
+use Membrane\OpenAPI\Builder\Strings;
 use Membrane\OpenAPI\Processor\AnyOf;
 use Membrane\OpenAPI\Specification;
 use Membrane\Processor;
@@ -20,30 +23,30 @@ use Membrane\Validator\Type\IsArray;
 use Membrane\Validator\Type\IsInt;
 use Membrane\Validator\Type\IsNull;
 use Membrane\Validator\Type\IsString;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Builder\Objects
- * @covers \Membrane\OpenAPI\Builder\APIBuilder
- * @uses   \Membrane\OpenAPI\Builder\Numeric
- * @uses   \Membrane\OpenAPI\Builder\Strings
- * @uses   \Membrane\OpenAPI\Processor\AnyOf
- * @uses   \Membrane\OpenAPI\Specification\APISchema
- * @uses   \Membrane\OpenAPI\Specification\Numeric
- * @uses   \Membrane\OpenAPI\Specification\Strings
- * @uses   \Membrane\Processor\BeforeSet
- * @uses   \Membrane\Processor\DefaultProcessor
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Processor\FieldSet
- * @uses   \Membrane\Validator\Collection\Contained
- * @uses   \Membrane\Validator\FieldSet\FixedFields
- * @uses   \Membrane\Validator\FieldSet\RequiredFields
- */
+#[CoversClass(Objects::class)]
+#[CoversClass(APIBuilder::class)]
+#[UsesClass(Numeric::class)]
+#[UsesClass(Strings::class)]
+#[UsesClass(AnyOf::class)]
+#[UsesClass(Specification\APISchema::class)]
+#[UsesClass(Specification\Numeric::class)]
+#[UsesClass(Specification\Strings::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(DefaultProcessor::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldSet::class)]
+#[UsesClass(Contained::class)]
+#[UsesClass(FixedFields::class)]
+#[UsesClass(RequiredFields::class)]
 class ObjectsTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function supportsArraysSpecification(): void
     {
         $specification = self::createStub(Specification\Objects::class);
@@ -52,9 +55,7 @@ class ObjectsTest extends TestCase
         self::assertTrue($sut->supports($specification));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotSupportSpecificationsThatAreNotArrays(): void
     {
         $specification = self::createStub(Specification\APISpec::class);
@@ -119,10 +120,8 @@ class ObjectsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider specificationsToBuild
-     */
+    #[DataProvider('specificationsToBuild')]
+    #[Test]
     public function buildTest(Specification\Objects $specification, Processor $expected): void
     {
         $sut = new Objects();

--- a/tests/OpenAPI/Builder/RequestBuilderTest.php
+++ b/tests/OpenAPI/Builder/RequestBuilderTest.php
@@ -8,13 +8,19 @@ use Exception;
 use GuzzleHttp\Psr7\ServerRequest;
 use Membrane\Builder\Specification;
 use Membrane\Filter\Type\ToInt;
+use Membrane\OpenAPI\Builder\APIBuilder;
+use Membrane\OpenAPI\Builder\Arrays;
+use Membrane\OpenAPI\Builder\Numeric;
 use Membrane\OpenAPI\Builder\RequestBuilder;
+use Membrane\OpenAPI\Builder\Strings;
 use Membrane\OpenAPI\Filter\HTTPParameters;
 use Membrane\OpenAPI\Filter\PathMatcher;
 use Membrane\OpenAPI\Method;
 use Membrane\OpenAPI\PathMatcher as PathMatcherClass;
 use Membrane\OpenAPI\Processor\Json;
 use Membrane\OpenAPI\Processor\Request as RequestProcessor;
+use Membrane\OpenAPI\Reader\OpenAPIFileReader;
+use Membrane\OpenAPI\Specification\APISchema;
 use Membrane\OpenAPI\Specification\APISpec;
 use Membrane\OpenAPI\Specification\Request;
 use Membrane\Processor;
@@ -27,53 +33,56 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\FieldSet\RequiredFields;
+use Membrane\Validator\Numeric\Maximum;
 use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Type\IsInt;
 use Membrane\Validator\Type\IsList;
 use Membrane\Validator\Type\IsString;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
-/**
- * @covers    \Membrane\OpenAPI\Builder\RequestBuilder
- * @covers    \Membrane\OpenAPI\Builder\APIBuilder
- * @uses      \Membrane\OpenAPI\Builder\Arrays
- * @uses      \Membrane\OpenAPI\Builder\Numeric
- * @uses      \Membrane\OpenAPI\Builder\Strings
- * @uses      \Membrane\OpenAPI\Filter\HTTPParameters
- * @uses      \Membrane\OpenAPI\Filter\PathMatcher
- * @uses      \Membrane\OpenAPI\PathMatcher
- * @uses      \Membrane\OpenAPI\Processor\Json
- * @uses      \Membrane\OpenAPI\Processor\Request
- * @uses      \Membrane\OpenAPI\Reader\OpenAPIFileReader
- * @uses      \Membrane\OpenAPI\Specification\APISchema
- * @uses      \Membrane\OpenAPI\Specification\APISpec
- * @uses      \Membrane\OpenAPI\Specification\Arrays
- * @uses      \Membrane\OpenAPI\Specification\Numeric
- * @uses      \Membrane\OpenAPI\Specification\Strings
- * @uses      \Membrane\OpenAPI\Specification\Request
- * @uses      \Membrane\Filter\Type\ToInt
- * @uses      \Membrane\Processor\BeforeSet
- * @uses      \Membrane\Processor\Collection
- * @uses      \Membrane\Processor\Field
- * @uses      \Membrane\Processor\FieldSet
- * @uses      \Membrane\Result\FieldName
- * @uses      \Membrane\Result\Message
- * @uses      \Membrane\Result\MessageSet
- * @uses      \Membrane\Result\Result
- * @uses      \Membrane\Validator\FieldSet\RequiredFields
- * @uses      \Membrane\Validator\Numeric\Maximum
- * @uses      \Membrane\Validator\Type\IsInt
- * @uses      \Membrane\Validator\Type\IsList
- * @uses      \Membrane\Validator\Type\IsString
- * @uses      \Membrane\Validator\Utility\Passes
- */
+#[CoversClass(RequestBuilder::class)]
+#[CoversClass(APIBuilder::class)]
+#[UsesClass(Arrays::class)]
+#[UsesClass(Numeric::class)]
+#[UsesClass(Strings::class)]
+#[UsesClass(HTTPParameters::class)]
+#[UsesClass(PathMatcher::class)]
+#[UsesClass(PathMatcherClass::class)]
+#[UsesClass(Json::class)]
+#[UsesClass(RequestProcessor::class)]
+#[UsesClass(OpenAPIFileReader::class)]
+#[UsesClass(APISchema::class)]
+#[UsesClass(APISpec::class)]
+#[UsesClass(\Membrane\OpenAPI\Specification\Arrays::class)]
+#[UsesClass(\Membrane\OpenAPI\Specification\Numeric::class)]
+#[UsesClass(\Membrane\OpenAPI\Specification\Strings::class)]
+#[UsesClass(Request::class)]
+#[UsesClass(ToInt::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(Collection::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldSet::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(RequiredFields::class)]
+#[UsesClass(Maximum::class)]
+#[UsesClass(IsInt::class)]
+#[UsesClass(IsList::class)]
+#[UsesClass(IsString::class)]
+#[UsesClass(Passes::class)]
 class RequestBuilderTest extends TestCase
 {
     public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
 
-    /** @test */
+    #[Test]
     public function throwsExceptionIfParameterHasContentThatIsNotJson(): void
     {
         $specification = new Request(
@@ -90,7 +99,7 @@ class RequestBuilderTest extends TestCase
         $sut->build($specification);
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionIfParameterHasNoSchemaNorContent(): void
     {
         $specification = new Request(self::DIR . 'noReferences.json', '/requestpathexceptions', Method::GET);
@@ -103,9 +112,7 @@ class RequestBuilderTest extends TestCase
         $sut->build($specification);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function supportsNumericSpecification(): void
     {
         $specification = self::createStub(Request::class);
@@ -114,9 +121,7 @@ class RequestBuilderTest extends TestCase
         self::assertTrue($sut->supports($specification));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotSupportNonNumericSpecification(): void
     {
         $specification = self::createStub(APISpec::class);
@@ -450,10 +455,8 @@ class RequestBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForBuild
-     */
+    #[DataProvider('dataSetsForBuild')]
+    #[Test]
     public function buildTest(Specification $spec, Processor $expected): void
     {
         $sut = new RequestBuilder();
@@ -541,10 +544,8 @@ class RequestBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForDocExamples
-     */
+    #[DataProvider('dataSetsForDocExamples')]
+    #[Test]
     public function docsTest(
         Request $specification,
         array|ServerRequestInterface $serverRequest,

--- a/tests/OpenAPI/Builder/RequestBuilderTest.php
+++ b/tests/OpenAPI/Builder/RequestBuilderTest.php
@@ -15,8 +15,8 @@ use Membrane\OpenAPI\Method;
 use Membrane\OpenAPI\PathMatcher as PathMatcherClass;
 use Membrane\OpenAPI\Processor\Json;
 use Membrane\OpenAPI\Processor\Request as RequestProcessor;
+use Membrane\OpenAPI\Specification\APISpec;
 use Membrane\OpenAPI\Specification\Request;
-use Membrane\OpenAPI\Specification\Response;
 use Membrane\Processor;
 use Membrane\Processor\BeforeSet;
 use Membrane\Processor\Collection;
@@ -103,39 +103,29 @@ class RequestBuilderTest extends TestCase
         $sut->build($specification);
     }
 
-    public function dataSetsforSupports(): array
+    /**
+     * @test
+     */
+    public function supportsNumericSpecification(): void
     {
-        return [
-            [
-                new class() implements Specification {
-                },
-                false,
-            ],
-            [
-                self::createStub(Request::class),
-                true,
-            ],
-            [
-                self::createStub(Response::class),
-                false,
-            ],
-        ];
+        $specification = self::createStub(Request::class);
+        $sut = new RequestBuilder();
+
+        self::assertTrue($sut->supports($specification));
     }
 
     /**
      * @test
-     * @dataProvider dataSetsforSupports
      */
-    public function supportsTest(Specification $spec, bool $expected): void
+    public function doesNotSupportNonNumericSpecification(): void
     {
+        $specification = self::createStub(APISpec::class);
         $sut = new RequestBuilder();
 
-        $supported = $sut->supports($spec);
-
-        self::assertSame($expected, $supported);
+        self::assertFalse($sut->supports($specification));
     }
 
-    public function dataSetsForBuild(): array
+    public static function dataSetsForBuild(): array
     {
         return [
             'no path params, no operation params, no requestBody' => [
@@ -474,7 +464,7 @@ class RequestBuilderTest extends TestCase
     }
 
 
-    public function dataSetsForDocExamples(): array
+    public static function dataSetsForDocExamples(): array
     {
         $api = self::DIR . '/docs/petstore.yaml';
         $expanded = self::DIR . '/docs/petstore-expanded.json';

--- a/tests/OpenAPI/Builder/ResponseBuilderTest.php
+++ b/tests/OpenAPI/Builder/ResponseBuilderTest.php
@@ -11,7 +11,7 @@ use Membrane\OpenAPI\Method;
 use Membrane\OpenAPI\Processor\AllOf;
 use Membrane\OpenAPI\Processor\AnyOf;
 use Membrane\OpenAPI\Processor\OneOf;
-use Membrane\OpenAPI\Specification\Request;
+use Membrane\OpenAPI\Specification\APISpec;
 use Membrane\OpenAPI\Specification\Response;
 use Membrane\Processor;
 use Membrane\Processor\BeforeSet;
@@ -102,39 +102,29 @@ class ResponseBuilderTest extends TestCase
         $sut->build($response);
     }
 
-    public function dataSetsforSupports(): array
+    /**
+     * @test
+     */
+    public function supportsNumericSpecification(): void
     {
-        return [
-            [
-                new class() implements Specification {
-                },
-                false,
-            ],
-            [
-                self::createStub(Request::class),
-                false,
-            ],
-            [
-                self::createStub(Response::class),
-                true,
-            ],
-        ];
+        $specification = self::createStub(Response::class);
+        $sut = new ResponseBuilder();
+
+        self::assertTrue($sut->supports($specification));
     }
 
     /**
      * @test
-     * @dataProvider dataSetsforSupports
      */
-    public function supportsTest(Specification $spec, bool $expected): void
+    public function doesNotSupportNonNumericSpecification(): void
     {
+        $specification = self::createStub(APISpec::class);
         $sut = new ResponseBuilder();
 
-        $supported = $sut->supports($spec);
-
-        self::assertSame($expected, $supported);
+        self::assertFalse($sut->supports($specification));
     }
 
-    public function dataSetsforBuilds(): array
+    public static function dataSetsforBuilds(): array
     {
         return [
             'no properties' => [
@@ -867,7 +857,7 @@ class ResponseBuilderTest extends TestCase
         self::assertEquals($expected, $processor);
     }
 
-    public function dataSetsForDocExamples(): array
+    public static function dataSetsForDocExamples(): array
     {
         $petStore1 = new Response(
             self::DIR . 'docs/petstore.yaml',

--- a/tests/OpenAPI/Builder/ResponseBuilderTest.php
+++ b/tests/OpenAPI/Builder/ResponseBuilderTest.php
@@ -6,13 +6,22 @@ namespace OpenAPI\Builder;
 
 use Exception;
 use Membrane\Builder\Specification;
+use Membrane\OpenAPI\Builder\APIBuilder;
 use Membrane\OpenAPI\Builder\ResponseBuilder;
 use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\PathMatcher;
 use Membrane\OpenAPI\Processor\AllOf;
 use Membrane\OpenAPI\Processor\AnyOf;
 use Membrane\OpenAPI\Processor\OneOf;
+use Membrane\OpenAPI\Reader\OpenAPIFileReader;
+use Membrane\OpenAPI\Specification\APISchema;
 use Membrane\OpenAPI\Specification\APISpec;
+use Membrane\OpenAPI\Specification\Arrays;
+use Membrane\OpenAPI\Specification\Numeric;
+use Membrane\OpenAPI\Specification\Objects;
 use Membrane\OpenAPI\Specification\Response;
+use Membrane\OpenAPI\Specification\Strings;
+use Membrane\OpenAPI\Specification\TrueFalse;
 use Membrane\Processor;
 use Membrane\Processor\BeforeSet;
 use Membrane\Processor\Collection;
@@ -41,57 +50,59 @@ use Membrane\Validator\Type\IsNull;
 use Membrane\Validator\Type\IsNumber;
 use Membrane\Validator\Type\IsString;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers   \Membrane\OpenAPI\Builder\ResponseBuilder
- * @covers   \Membrane\OpenAPI\Builder\APIBuilder
- * @uses     \Membrane\OpenAPI\Builder\Arrays
- * @uses     \Membrane\OpenAPI\Builder\TrueFalse
- * @uses     \Membrane\OpenAPI\Builder\Numeric
- * @uses     \Membrane\OpenAPI\Builder\Objects
- * @uses     \Membrane\OpenAPI\Builder\Strings
- * @uses     \Membrane\OpenAPI\PathMatcher
- * @uses     \Membrane\OpenAPI\Processor\AllOf
- * @uses     \Membrane\OpenAPI\Processor\AnyOf
- * @uses     \Membrane\OpenAPI\Processor\OneOf
- * @uses     \Membrane\OpenAPI\Reader\OpenAPIFileReader
- * @uses     \Membrane\OpenAPI\Specification\APISchema
- * @uses     \Membrane\OpenAPI\Specification\APISpec
- * @uses     \Membrane\OpenAPI\Specification\Arrays
- * @uses     \Membrane\OpenAPI\Specification\TrueFalse
- * @uses     \Membrane\OpenAPI\Specification\Numeric
- * @uses     \Membrane\OpenAPI\Specification\Objects
- * @uses     \Membrane\OpenAPI\Specification\Strings
- * @uses     \Membrane\OpenAPI\Specification\Response
- * @uses     \Membrane\Processor\BeforeSet
- * @uses     \Membrane\Processor\Collection
- * @uses     \Membrane\Processor\Field
- * @uses     \Membrane\Processor\FieldSet
- * @uses     \Membrane\Result\FieldName
- * @uses     \Membrane\Result\Message
- * @uses     \Membrane\Result\MessageSet
- * @uses     \Membrane\Result\Result
- * @uses     \Membrane\Validator\Collection\Contained
- * @uses     \Membrane\Validator\Collection\Count
- * @uses     \Membrane\Validator\Collection\Unique
- * @uses     \Membrane\Validator\FieldSet\RequiredFields
- * @uses     \Membrane\Validator\Numeric\Maximum
- * @uses     \Membrane\Validator\Numeric\Minimum
- * @uses     \Membrane\Validator\Numeric\MultipleOf
- * @uses     \Membrane\Validator\String\DateString
- * @uses     \Membrane\Validator\String\Length
- * @uses     \Membrane\Validator\String\Regex
- * @uses     \Membrane\Validator\Type\IsArray
- * @uses     \Membrane\Validator\Type\IsInt
- * @uses     \Membrane\Validator\Type\IsList
- * @uses     \Membrane\Validator\Type\IsString
- */
+#[CoversClass(ResponseBuilder::class)]
+#[CoversClass(APIBuilder::class)]
+#[UsesClass(\Membrane\OpenAPI\Builder\Arrays::class)]
+#[UsesClass(\Membrane\OpenAPI\Builder\TrueFalse::class)]
+#[UsesClass(\Membrane\OpenAPI\Builder\Numeric::class)]
+#[UsesClass(\Membrane\OpenAPI\Builder\Objects::class)]
+#[UsesClass(\Membrane\OpenAPI\Builder\Strings::class)]
+#[UsesClass(PathMatcher::class)]
+#[UsesClass(AllOf::class)]
+#[UsesClass(AnyOf::class)]
+#[UsesClass(OneOf::class)]
+#[UsesClass(OpenAPIFileReader::class)]
+#[UsesClass(APISchema::class)]
+#[UsesClass(APISpec::class)]
+#[UsesClass(Arrays::class)]
+#[UsesClass(TrueFalse::class)]
+#[UsesClass(Numeric::class)]
+#[UsesClass(Objects::class)]
+#[UsesClass(Strings::class)]
+#[UsesClass(Response::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(Collection::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldSet::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(Contained::class)]
+#[UsesClass(Count::class)]
+#[UsesClass(Unique::class)]
+#[UsesClass(RequiredFields::class)]
+#[UsesClass(Maximum::class)]
+#[UsesClass(Minimum::class)]
+#[UsesClass(MultipleOf::class)]
+#[UsesClass(DateString::class)]
+#[UsesClass(Length::class)]
+#[UsesClass(Regex::class)]
+#[UsesClass(IsArray::class)]
+#[UsesClass(IsInt::class)]
+#[UsesClass(IsList::class)]
+#[UsesClass(IsString::class)]
 class ResponseBuilderTest extends TestCase
 {
     public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
 
-    /** @test */
+    #[Test]
     public function throwsExceptionIfNotIsFound(): void
     {
         $sut = new ResponseBuilder();
@@ -102,9 +113,7 @@ class ResponseBuilderTest extends TestCase
         $sut->build($response);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function supportsNumericSpecification(): void
     {
         $specification = self::createStub(Response::class);
@@ -113,9 +122,7 @@ class ResponseBuilderTest extends TestCase
         self::assertTrue($sut->supports($specification));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotSupportNonNumericSpecification(): void
     {
         $specification = self::createStub(APISpec::class);
@@ -844,10 +851,8 @@ class ResponseBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsforBuilds
-     */
+    #[DataProvider('dataSetsforBuilds')]
+    #[Test]
     public function buildsTest(Specification $spec, Processor $expected): void
     {
         $sut = new ResponseBuilder();
@@ -919,10 +924,8 @@ class ResponseBuilderTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForDocExamples
-     */
+    #[DataProvider('dataSetsForDocExamples')]
+    #[Test]
     public function docsTest(Specification $spec, array $data, Result $expected): void
     {
         $sut = new ResponseBuilder();

--- a/tests/OpenAPI/Builder/StringsTest.php
+++ b/tests/OpenAPI/Builder/StringsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAPI\Builder;
 
 use cebe\openapi\spec\Schema;
+use Membrane\OpenAPI\Builder\APIBuilder;
 use Membrane\OpenAPI\Builder\Strings;
 use Membrane\OpenAPI\Processor\AnyOf;
 use Membrane\OpenAPI\Specification;
@@ -16,24 +17,24 @@ use Membrane\Validator\String\Length;
 use Membrane\Validator\String\Regex;
 use Membrane\Validator\Type\IsNull;
 use Membrane\Validator\Type\IsString;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Builder\Strings
- * @covers \Membrane\OpenAPI\Builder\APIBuilder
- * @uses   \Membrane\OpenAPI\Processor\AnyOf
- * @uses   \Membrane\OpenAPI\Specification\Strings
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Validator\Collection\Contained
- * @uses   \Membrane\Validator\String\DateString
- * @uses   \Membrane\Validator\String\Length
- * @uses   \Membrane\Validator\String\Regex
- */
+#[CoversClass(Strings::class)]
+#[CoversClass(APIBuilder::class)]
+#[UsesClass(AnyOf::class)]
+#[UsesClass(Specification\Strings::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(Contained::class)]
+#[UsesClass(DateString::class)]
+#[UsesClass(Length::class)]
+#[UsesClass(Regex::class)]
 class StringsTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function supportsNumericSpecification(): void
     {
         $specification = self::createStub(Specification\Strings::class);
@@ -42,9 +43,7 @@ class StringsTest extends TestCase
         self::assertTrue($sut->supports($specification));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotSupportNonNumericSpecification(): void
     {
         $specification = self::createStub(Specification\APISpec::class);
@@ -99,10 +98,8 @@ class StringsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider specificationsToBuild
-     */
+    #[DataProvider('specificationsToBuild')]
+    #[Test]
     public function buildTest(Specification\Strings $specification, Processor $expected): void
     {
         $sut = new Strings();

--- a/tests/OpenAPI/Builder/StringsTest.php
+++ b/tests/OpenAPI/Builder/StringsTest.php
@@ -31,30 +31,29 @@ use PHPUnit\Framework\TestCase;
  */
 class StringsTest extends TestCase
 {
-    public function specificationsToSupport(): array
+    /**
+     * @test
+     */
+    public function supportsNumericSpecification(): void
     {
-        return [
-            [
-                new class() implements \Membrane\Builder\Specification {
-                },
-                false,
-            ],
-            [self::createStub(Specification\Strings::class), true],
-        ];
+        $specification = self::createStub(Specification\Strings::class);
+        $sut = new Strings();
+
+        self::assertTrue($sut->supports($specification));
     }
 
     /**
      * @test
-     * @dataProvider specificationsToSupport
      */
-    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    public function doesNotSupportNonNumericSpecification(): void
     {
+        $specification = self::createStub(Specification\APISpec::class);
         $sut = new Strings();
 
-        self::assertSame($expected, $sut->supports($specification));
+        self::assertFalse($sut->supports($specification));
     }
 
-    public function specificationsToBuild(): array
+    public static function specificationsToBuild(): array
     {
         return [
             'minimum input' => [

--- a/tests/OpenAPI/Builder/TrueFalseTest.php
+++ b/tests/OpenAPI/Builder/TrueFalseTest.php
@@ -27,31 +27,29 @@ use PHPUnit\Framework\TestCase;
  */
 class TrueFalseTest extends TestCase
 {
-
-    public function specificationsToSupport(): array
+    /**
+     * @test
+     */
+    public function supportsNumericSpecification(): void
     {
-        return [
-            [
-                new class() implements \Membrane\Builder\Specification {
-                },
-                false,
-            ],
-            [self::createStub(Specification\TrueFalse::class), true],
-        ];
+        $specification = self::createStub(Specification\TrueFalse::class);
+        $sut = new TrueFalse();
+
+        self::assertTrue($sut->supports($specification));
     }
 
     /**
      * @test
-     * @dataProvider specificationsToSupport
      */
-    public function supportsTest(\Membrane\Builder\Specification $specification, bool $expected): void
+    public function doesNotSupportNonNumericSpecification(): void
     {
+        $specification = self::createStub(Specification\APISpec::class);
         $sut = new TrueFalse();
 
-        self::assertSame($expected, $sut->supports($specification));
+        self::assertFalse($sut->supports($specification));
     }
 
-    public function specificationsToBuild(): array
+    public static function specificationsToBuild(): array
     {
         return [
             'non-strict input' => [

--- a/tests/OpenAPI/Builder/TrueFalseTest.php
+++ b/tests/OpenAPI/Builder/TrueFalseTest.php
@@ -7,6 +7,7 @@ namespace OpenAPI\Builder;
 
 use cebe\openapi\spec\Schema;
 use Membrane\Filter\Type\ToBool;
+use Membrane\OpenAPI\Builder\APIBuilder;
 use Membrane\OpenAPI\Builder\TrueFalse;
 use Membrane\OpenAPI\Processor\AnyOf;
 use Membrane\OpenAPI\Specification;
@@ -15,21 +16,21 @@ use Membrane\Processor\Field;
 use Membrane\Validator\Collection\Contained;
 use Membrane\Validator\Type\IsBool;
 use Membrane\Validator\Type\IsNull;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Builder\TrueFalse
- * @covers \Membrane\OpenAPI\Builder\APIBuilder
- * @uses   \Membrane\OpenAPI\Processor\AnyOf
- * @uses   \Membrane\OpenAPI\Specification\TrueFalse
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Validator\Collection\Contained
- */
+#[CoversClass(TrueFalse::class)]
+#[CoversClass(APIBuilder::class)]
+#[UsesClass(AnyOf::class)]
+#[UsesClass(Specification\TrueFalse::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(Contained::class)]
 class TrueFalseTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function supportsNumericSpecification(): void
     {
         $specification = self::createStub(Specification\TrueFalse::class);
@@ -38,9 +39,7 @@ class TrueFalseTest extends TestCase
         self::assertTrue($sut->supports($specification));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function doesNotSupportNonNumericSpecification(): void
     {
         $specification = self::createStub(Specification\APISpec::class);
@@ -82,10 +81,8 @@ class TrueFalseTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider specificationsToBuild
-     */
+    #[DataProvider('specificationsToBuild')]
+    #[Test]
     public function buildTest(Specification\TrueFalse $specification, Processor $expected): void
     {
         $sut = new TrueFalse();

--- a/tests/OpenAPI/Filter/HTTPParametersTest.php
+++ b/tests/OpenAPI/Filter/HTTPParametersTest.php
@@ -39,7 +39,7 @@ class HTTPParametersTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsToFilter(): array
+    public static function dataSetsToFilter(): array
     {
         return [
             [

--- a/tests/OpenAPI/Filter/HTTPParametersTest.php
+++ b/tests/OpenAPI/Filter/HTTPParametersTest.php
@@ -8,17 +8,19 @@ use Membrane\OpenAPI\Filter\HTTPParameters;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Filter\HTTPParameters
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(HTTPParameters::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
 class HTTPParametersTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert query string to a field set of query parameters';
@@ -29,7 +31,7 @@ class HTTPParametersTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new HTTPParameters();
@@ -61,10 +63,8 @@ class HTTPParametersTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToFilter
-     */
+    #[DataProvider('dataSetsToFilter')]
+    #[Test]
     public function filterTest(mixed $input, Result $expected): void
     {
         $sut = new HTTPParameters();

--- a/tests/OpenAPI/Filter/PathMatcherTest.php
+++ b/tests/OpenAPI/Filter/PathMatcherTest.php
@@ -4,24 +4,26 @@ declare(strict_types=1);
 
 namespace OpenAPI\Filter;
 
+use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
 use Membrane\OpenAPI\Filter\PathMatcher;
 use Membrane\OpenAPI\PathMatcher as PathMatcherHelper;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Filter\PathMatcher
- * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- * @uses   \Membrane\OpenAPI\PathMatcher
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(PathMatcher::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
+#[UsesClass(PathMatcherHelper::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
 class PathMatcherTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'convert url to a field set of path parameters';
@@ -32,7 +34,7 @@ class PathMatcherTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $pathMatcherHelper = new PathMatcherHelper('/api', '/pets');
@@ -44,7 +46,7 @@ class PathMatcherTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function invalidResultForNonStringValues(): void
     {
         $expected = Result::invalid(
@@ -58,7 +60,7 @@ class PathMatcherTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function invalidResultForMismatchedPath(): void
     {
         $expected = Result::invalid(
@@ -74,7 +76,7 @@ class PathMatcherTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function filterTest(): void
     {
         $expected = Result::noResult(['filtered value']);

--- a/tests/OpenAPI/PathMatcherTest.php
+++ b/tests/OpenAPI/PathMatcherTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PathMatcherTest extends TestCase
 {
-    public function dataSetsWithImbalancedBraces(): array
+    public static function dataSetsWithImbalancedBraces(): array
     {
         return [
             ['/pets/{id{name}}'],
@@ -33,7 +33,7 @@ class PathMatcherTest extends TestCase
         new PathMatcher('', $apiPath);
     }
 
-    public function dataSetsToMatch(): array
+    public static function dataSetsToMatch(): array
     {
         return [
             'path is identical, server missing, server path missing' => [
@@ -134,7 +134,7 @@ class PathMatcherTest extends TestCase
         $sut->getPathParams('/hats/23');
     }
 
-    public function dataSetsToGetPathParams(): array
+    public static function dataSetsToGetPathParams(): array
     {
         return [
             [

--- a/tests/OpenAPI/PathMatcherTest.php
+++ b/tests/OpenAPI/PathMatcherTest.php
@@ -6,12 +6,13 @@ namespace OpenAPI;
 
 use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
 use Membrane\OpenAPI\PathMatcher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers   \Membrane\OpenAPI\PathMatcher
- * @covers   \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- */
+#[CoversClass(PathMatcher::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
 class PathMatcherTest extends TestCase
 {
     public static function dataSetsWithImbalancedBraces(): array
@@ -22,10 +23,8 @@ class PathMatcherTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithImbalancedBraces
-     */
+    #[DataProvider('dataSetsWithImbalancedBraces')]
+    #[Test]
     public function throwsExceptionsForImbalancedBracesInAPIPaths(string $apiPath): void
     {
         self::expectExceptionObject(CannotProcessOpenAPI::invalidPath($apiPath));
@@ -111,10 +110,8 @@ class PathMatcherTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToMatch
-     */
+    #[DataProvider('dataSetsToMatch')]
+    #[Test]
     public function matchesTest(string $serverUrl, string $apiPath, string $requestPath, bool $expected): void
     {
         $sut = new PathMatcher($serverUrl, $apiPath);
@@ -124,7 +121,7 @@ class PathMatcherTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionGettingParamsForNonMatchingPaths(): void
     {
         $sut = new PathMatcher('https://www.server.com', '/pets/{id}');
@@ -160,10 +157,8 @@ class PathMatcherTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToGetPathParams
-     */
+    #[DataProvider('dataSetsToGetPathParams')]
+    #[Test]
     public function getPathParamsTest(string $apiUrl, string $requestUrl, array $expected): void
     {
         $sut = new PathMatcher('https://www.server.com', $apiUrl);

--- a/tests/OpenAPI/Processor/AllOfTest.php
+++ b/tests/OpenAPI/Processor/AllOfTest.php
@@ -21,26 +21,28 @@ use Membrane\Validator\Type\IsString;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Processor\AllOf
- * @covers \Membrane\Exception\InvalidProcessorArguments
- * @uses   \Membrane\Processor\BeforeSet
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Processor\FieldSet
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Validator\FieldSet\RequiredFields
- * @uses   \Membrane\Validator\Type\IsArray
- * @uses   \Membrane\Validator\Type\IsInt
- * @uses   \Membrane\Validator\Type\IsString
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- */
+#[CoversClass(AllOf::class)]
+#[CoversClass(InvalidProcessorArguments::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldSet::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(RequiredFields::class)]
+#[UsesClass(IsArray::class)]
+#[UsesClass(IsInt::class)]
+#[UsesClass(IsString::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
 class AllOfTest extends TestCase
 {
     public static function dataSetsToConvertToPHPString(): array
@@ -53,10 +55,8 @@ class AllOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(AllOf $sut): void
     {
         $actual = $sut->__toPHP();
@@ -64,7 +64,7 @@ class AllOfTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = <<<END
@@ -84,7 +84,7 @@ class AllOfTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionIfLessThanTwoProcessors(): void
     {
         self::expectExceptionObject(InvalidProcessorArguments::redundantProcessor(AllOf::class));
@@ -92,7 +92,7 @@ class AllOfTest extends TestCase
         new AllOf('');
     }
 
-    /** @test */
+    #[Test]
     public function processesTest(): void
     {
         $processes = 'test';
@@ -236,10 +236,8 @@ class AllOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToProcess
-     */
+    #[DataProvider('dataSetsToProcess')]
+    #[Test]
     public function processTest(
         string $processes,
         array $processors,

--- a/tests/OpenAPI/Processor/AllOfTest.php
+++ b/tests/OpenAPI/Processor/AllOfTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AllOfTest extends TestCase
 {
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             '2 validators' => [new AllOf('a', new Field('b'), new Field('c'))],
@@ -74,7 +74,7 @@ class AllOfTest extends TestCase
             \t"id":
             \t\t- condition.
             END;
-        $processor = self::createMock(Processor::class);
+        $processor = $this->createMock(Processor::class);
         $processor->method('__toString')
             ->willReturn("\"id\":\n\t- condition");
         $sut = new AllOf('id', $processor, $processor);
@@ -101,7 +101,7 @@ class AllOfTest extends TestCase
         self::assertEquals($processes, $sut->processes());
     }
 
-    public function dataSetsToProcess(): array
+    public static function dataSetsToProcess(): array
     {
         return [
             'two valid results' => [

--- a/tests/OpenAPI/Processor/AnyOfTest.php
+++ b/tests/OpenAPI/Processor/AnyOfTest.php
@@ -21,26 +21,28 @@ use Membrane\Validator\Type\IsString;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Processor\AnyOf
- * @covers \Membrane\Exception\InvalidProcessorArguments
- * @uses   \Membrane\Processor\BeforeSet
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Processor\FieldSet
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Validator\FieldSet\RequiredFields
- * @uses   \Membrane\Validator\Type\IsArray
- * @uses   \Membrane\Validator\Type\IsInt
- * @uses   \Membrane\Validator\Type\IsString
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- */
+#[CoversClass(AnyOf::class)]
+#[CoversClass(InvalidProcessorArguments::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldSet::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(RequiredFields::class)]
+#[UsesClass(IsArray::class)]
+#[UsesClass(IsInt::class)]
+#[UsesClass(IsString::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
 class AnyOfTest extends TestCase
 {
     public static function dataSetsToConvertToPHPString(): array
@@ -53,10 +55,8 @@ class AnyOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(AnyOf $sut): void
     {
         $actual = $sut->__toPHP();
@@ -64,7 +64,7 @@ class AnyOfTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = <<<END
@@ -84,7 +84,7 @@ class AnyOfTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionIfLessThanTwoProcessors(): void
     {
         self::expectExceptionObject(InvalidProcessorArguments::redundantProcessor(AnyOf::class));
@@ -92,7 +92,7 @@ class AnyOfTest extends TestCase
         new AnyOf('');
     }
 
-    /** @test */
+    #[Test]
     public function processesTest(): void
     {
         $processes = 'test';
@@ -238,10 +238,8 @@ class AnyOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToProcess
-     */
+    #[DataProvider('dataSetsToProcess')]
+    #[Test]
     public function processTest(
         string $processes,
         array $processors,

--- a/tests/OpenAPI/Processor/AnyOfTest.php
+++ b/tests/OpenAPI/Processor/AnyOfTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AnyOfTest extends TestCase
 {
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             '2 validators' => [new AnyOf('a', new Field('b'), new Field('c'))],
@@ -74,7 +74,7 @@ class AnyOfTest extends TestCase
             \t"id":
             \t\t- condition.
             END;
-        $processor = self::createMock(Processor::class);
+        $processor = $this->createMock(Processor::class);
         $processor->method('__toString')
             ->willReturn("\"id\":\n\t- condition");
         $sut = new AnyOf('id', $processor, $processor);
@@ -101,7 +101,7 @@ class AnyOfTest extends TestCase
         self::assertEquals($processes, $sut->processes());
     }
 
-    public function dataSetsToProcess(): array
+    public static function dataSetsToProcess(): array
     {
         return [
             'two Fields with valid results' => [

--- a/tests/OpenAPI/Processor/JsonTest.php
+++ b/tests/OpenAPI/Processor/JsonTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenAPI\Processor;
 
+use Membrane\Filter\String\JsonDecode;
 use Membrane\OpenAPI\Processor\Json;
 use Membrane\Processor;
 use Membrane\Processor\Field;
@@ -11,24 +12,25 @@ use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Processor\Json
- * @uses   \Membrane\Filter\String\JsonDecode
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(Json::class)]
+#[UsesClass(JsonDecode::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
 class JsonTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = "\"pet\":\n\t- convert from json to a PHP value.\n\t- condition";
-        $wrapped = self::createMock(Processor\Field::class);
+        $wrapped = self::createMock(Field::class);
         $sut = new Json($wrapped);
 
         $wrapped->expects($this->once())
@@ -44,7 +46,7 @@ class JsonTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new Json(new Field('a'));
@@ -54,7 +56,7 @@ class JsonTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function processesTest(): void
     {
         $expected = 'fieldName that observer processes';
@@ -69,7 +71,7 @@ class JsonTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function processStopsEarlyIfJsonDecodeFails(): void
     {
         $expected = Result::invalid(
@@ -89,7 +91,7 @@ class JsonTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function processTest(): void
     {
         $expected = Result::valid(['id' => 5]);

--- a/tests/OpenAPI/Processor/OneOfTest.php
+++ b/tests/OpenAPI/Processor/OneOfTest.php
@@ -21,26 +21,28 @@ use Membrane\Validator\Type\IsString;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Processor\OneOf
- * @covers \Membrane\Exception\InvalidProcessorArguments
- * @uses   \Membrane\Processor\BeforeSet
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Processor\FieldSet
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Validator\FieldSet\RequiredFields
- * @uses   \Membrane\Validator\Type\IsArray
- * @uses   \Membrane\Validator\Type\IsInt
- * @uses   \Membrane\Validator\Type\IsString
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- */
+#[CoversClass(OneOf::class)]
+#[CoversClass(InvalidProcessorArguments::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldSet::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(RequiredFields::class)]
+#[UsesClass(IsArray::class)]
+#[UsesClass(IsInt::class)]
+#[UsesClass(IsString::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
 class OneOfTest extends TestCase
 {
     public static function dataSetsToConvertToPHPString(): array
@@ -53,10 +55,8 @@ class OneOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(OneOf $sut): void
     {
         $actual = $sut->__toPHP();
@@ -64,7 +64,7 @@ class OneOfTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = <<<END
@@ -84,7 +84,7 @@ class OneOfTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionIfLessThanTwoProcessors(): void
     {
         self::expectExceptionObject(InvalidProcessorArguments::redundantProcessor(OneOf::class));
@@ -92,7 +92,7 @@ class OneOfTest extends TestCase
         new OneOf('');
     }
 
-    /** @test */
+    #[Test]
     public function processesTest(): void
     {
         $processes = 'test';
@@ -225,10 +225,8 @@ class OneOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToProcess
-     */
+    #[DataProvider('dataSetsToProcess')]
+    #[Test]
     public function processTest(
         string $processes,
         array $processors,

--- a/tests/OpenAPI/Processor/OneOfTest.php
+++ b/tests/OpenAPI/Processor/OneOfTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
  */
 class OneOfTest extends TestCase
 {
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             '2 validators' => [new OneOf('a', new Field('b'), new Field('c'))],
@@ -101,7 +101,7 @@ class OneOfTest extends TestCase
         self::assertEquals($processes, $sut->processes());
     }
 
-    public function dataSetsToProcess(): array
+    public static function dataSetsToProcess(): array
     {
         return [
             'two Fields with valid results' => [

--- a/tests/OpenAPI/Processor/RequestTest.php
+++ b/tests/OpenAPI/Processor/RequestTest.php
@@ -15,18 +15,20 @@ use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Processor\Request
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Passes
- */
+#[CoversClass(Request::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Passes::class)]
 class RequestTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -49,10 +51,8 @@ class RequestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(string $expected, array $processors): void
     {
         $sut = new Request('test', '', Method::GET, $processors);
@@ -79,10 +79,8 @@ class RequestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Request $sut): void
     {
         $actual = $sut->__toPHP();
@@ -90,7 +88,7 @@ class RequestTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function processesTest(): void
     {
         $sut = new Request('test', '', Method::GET, []);
@@ -98,7 +96,7 @@ class RequestTest extends TestCase
         self::assertEquals('test', $sut->processes());
     }
 
-    /** @test */
+    #[Test]
     public function unsupportedValuesDoNotGetProcessed(): void
     {
         $expected = Result::invalid(
@@ -236,10 +234,8 @@ class RequestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToProcess
-     */
+    #[DataProvider('dataSetsToProcess')]
+    #[Test]
     public function processTest(mixed $value, array $processors, Result $expected): void
     {
         $sut = new Request('', '', Method::GET, $processors);

--- a/tests/OpenAPI/Reader/OpenAPIFileReaderTest.php
+++ b/tests/OpenAPI/Reader/OpenAPIFileReaderTest.php
@@ -19,7 +19,7 @@ class OpenAPIFileReaderTest extends TestCase
 {
     public const FIXTURES = __DIR__ . '/../../fixtures/OpenAPI/';
 
-    public function dataSetsThatThrowExceptions(): array
+    public static function dataSetsThatThrowExceptions(): array
     {
         return [
             'Non-existent file throws CannotReadOpenAPI::fileNotFound' => [

--- a/tests/OpenAPI/Reader/OpenAPIFileReaderTest.php
+++ b/tests/OpenAPI/Reader/OpenAPIFileReaderTest.php
@@ -8,13 +8,15 @@ use cebe\openapi\exceptions\UnresolvableReferenceException;
 use cebe\openapi\spec\OpenApi;
 use Membrane\OpenAPI\Exception\CannotReadOpenAPI;
 use Membrane\OpenAPI\Reader\OpenAPIFileReader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Exception\ParseException;
+use TypeError;
 
-/**
- * @covers \Membrane\OpenAPI\Reader\OpenAPIFileReader
- * @covers \Membrane\OpenAPI\Exception\CannotReadOpenAPI
- */
+#[CoversClass(OpenAPIFileReader::class)]
+#[CoversClass(CannotReadOpenAPI::class)]
 class OpenAPIFileReaderTest extends TestCase
 {
     public const FIXTURES = __DIR__ . '/../../fixtures/OpenAPI/';
@@ -35,15 +37,15 @@ class OpenAPIFileReaderTest extends TestCase
                 __FILE__,
             ],
             'Empty .json file throws CannotReadOpenAPI::cannotParse' => [
-                CannotReadOpenAPI::cannotParse('empty.json', new \TypeError()),
+                CannotReadOpenAPI::cannotParse('empty.json', new TypeError()),
                 self::FIXTURES . 'empty.json',
             ],
             'Empty .yml file throws CannotReadOpenAPI::cannotParse' => [
-                CannotReadOpenAPI::cannotParse('empty.yml', new \TypeError()),
+                CannotReadOpenAPI::cannotParse('empty.yml', new TypeError()),
                 self::FIXTURES . 'empty.yml',
             ],
             '.json file in invalid json format throws CannotReadOpenAPI::cannotParse' => [
-                CannotReadOpenAPI::cannotParse('invalid.json', new \TypeError()),
+                CannotReadOpenAPI::cannotParse('invalid.json', new TypeError()),
                 self::FIXTURES . 'invalid.json',
             ],
             '.yaml file in invalid yaml format throws CannotReadOpenAPI::cannotParse' => [
@@ -61,10 +63,8 @@ class OpenAPIFileReaderTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatThrowExceptions
-     */
+    #[DataProvider('dataSetsThatThrowExceptions')]
+    #[Test]
     public function exceptionHandlingTest(CannotReadOpenAPI $expected, string $filePath): void
     {
         self::expectExceptionObject($expected);
@@ -72,7 +72,7 @@ class OpenAPIFileReaderTest extends TestCase
         (new OpenAPIFileReader())->readFromAbsoluteFilePath($filePath);
     }
 
-    /** @test */
+    #[Test]
     public function readFromAbsoluteFilePathTest(): void
     {
         $expected = OpenApi::class;

--- a/tests/OpenAPI/Specification/APISpecTest.php
+++ b/tests/OpenAPI/Specification/APISpecTest.php
@@ -35,7 +35,7 @@ class APISpecTest extends TestCase
         };
     }
 
-    public function dataSetsThatPass(): array
+    public static function dataSetsThatPass(): array
     {
         return [
             'GET does not have any content' => [

--- a/tests/OpenAPI/Specification/APISpecTest.php
+++ b/tests/OpenAPI/Specification/APISpecTest.php
@@ -7,24 +7,30 @@ namespace OpenAPI\Specification;
 use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\PathItem;
 use cebe\openapi\spec\Response;
+use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
 use Membrane\OpenAPI\Exception\CannotProcessRequest;
+use Membrane\OpenAPI\Exception\CannotReadOpenAPI;
 use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\PathMatcher;
+use Membrane\OpenAPI\Reader\OpenAPIFileReader;
 use Membrane\OpenAPI\Specification\APISpec;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Specification\APISpec
- * @covers \Membrane\OpenAPI\Exception\CannotReadOpenAPI
- * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- * @covers \Membrane\OpenAPI\Exception\CannotProcessRequest
- * @uses   \Membrane\OpenAPI\PathMatcher
- * @uses   \Membrane\OpenAPI\Reader\OpenAPIFileReader
- */
+#[CoversClass(APISpec::class)]
+#[CoversClass(CannotReadOpenAPI::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
+#[CoversClass(CannotProcessRequest::class)]
+#[UsesClass(PathMatcher::class)]
+#[UsesClass(OpenAPIFileReader::class)]
 class APISpecTest extends TestCase
 {
     public const FIXTURES = __DIR__ . '/../../fixtures/OpenAPI/';
 
-    /** @test */
+    #[Test]
     public function throwsExceptionIfNoPathMatches(): void
     {
         $fileName = 'noReferences.json';
@@ -66,10 +72,8 @@ class APISpecTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function successfulConstructionForValidInputs(string $filePath, string $url, Method $method): void
     {
         $class = new class(self::FIXTURES . $filePath, $url, $method) extends APISpec {

--- a/tests/OpenAPI/Specification/ArraysTest.php
+++ b/tests/OpenAPI/Specification/ArraysTest.php
@@ -6,17 +6,19 @@ namespace OpenAPI\Specification;
 
 use cebe\openapi\spec\Schema;
 use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
+use Membrane\OpenAPI\Specification\APISchema;
 use Membrane\OpenAPI\Specification\Arrays;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Specification\Arrays
- * @covers \Membrane\OpenAPI\Specification\APISchema
- * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- */
+#[CoversClass(Arrays::class)]
+#[CoversClass(APISchema::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
 class ArraysTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function throwsExceptionForMissingType(): void
     {
         self::expectExceptionObject(CannotProcessOpenAPI::mismatchedType(Arrays::class, 'array', 'no type'));
@@ -24,7 +26,7 @@ class ArraysTest extends TestCase
         new Arrays('', new Schema([]));
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionForInvalidType(): void
     {
         self::expectExceptionObject(CannotProcessOpenAPI::mismatchedType(Arrays::class, 'array', 'string'));
@@ -71,10 +73,8 @@ class ArraysTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConstruct
-     */
+    #[DataProvider('dataSetsToConstruct')]
+    #[Test]
     public function constructTest(Schema $schema, array $expected): void
     {
         $sut = new Arrays('', $schema);

--- a/tests/OpenAPI/Specification/ArraysTest.php
+++ b/tests/OpenAPI/Specification/ArraysTest.php
@@ -32,7 +32,7 @@ class ArraysTest extends TestCase
         new Arrays('', new Schema(['type' => 'string']));
     }
 
-    public function dataSetsToConstruct(): array
+    public static function dataSetsToConstruct(): array
     {
         return [
             'default values' => [

--- a/tests/OpenAPI/Specification/NumericTest.php
+++ b/tests/OpenAPI/Specification/NumericTest.php
@@ -36,7 +36,7 @@ class NumericTest extends TestCase
         new Numeric('', new Schema(['type' => 'string']));
     }
 
-    public function dataSetsToConstruct(): array
+    public static function dataSetsToConstruct(): array
     {
         return [
             'default values for number' => [

--- a/tests/OpenAPI/Specification/NumericTest.php
+++ b/tests/OpenAPI/Specification/NumericTest.php
@@ -6,17 +6,19 @@ namespace OpenAPI\Specification;
 
 use cebe\openapi\spec\Schema;
 use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
+use Membrane\OpenAPI\Specification\APISchema;
 use Membrane\OpenAPI\Specification\Numeric;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Specification\Numeric
- * @covers \Membrane\OpenAPI\Specification\APISchema
- * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- */
+#[CoversClass(Numeric::class)]
+#[CoversClass(APISchema::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
 class NumericTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function throwsExceptionForMissingType(): void
     {
         self::expectExceptionObject(
@@ -26,7 +28,7 @@ class NumericTest extends TestCase
         new Numeric('', new Schema([]));
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionForInvalidType(): void
     {
         self::expectExceptionObject(
@@ -116,10 +118,8 @@ class NumericTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConstruct
-     */
+    #[DataProvider('dataSetsToConstruct')]
+    #[Test]
     public function constructTest(Schema $schema, array $expected): void
     {
         $sut = new Numeric('', $schema);

--- a/tests/OpenAPI/Specification/ObjectsTest.php
+++ b/tests/OpenAPI/Specification/ObjectsTest.php
@@ -32,7 +32,7 @@ class ObjectsTest extends TestCase
         new Objects('', new Schema(['type' => 'string']));
     }
 
-    public function dataSetsToConstruct(): array
+    public static function dataSetsToConstruct(): array
     {
         return [
             'default values' => [

--- a/tests/OpenAPI/Specification/ObjectsTest.php
+++ b/tests/OpenAPI/Specification/ObjectsTest.php
@@ -6,17 +6,19 @@ namespace OpenAPI\Specification;
 
 use cebe\openapi\spec\Schema;
 use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
+use Membrane\OpenAPI\Specification\APISchema;
 use Membrane\OpenAPI\Specification\Objects;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Specification\Objects
- * @covers \Membrane\OpenAPI\Specification\APISchema
- * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- */
+#[CoversClass(Objects::class)]
+#[CoversClass(APISchema::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
 class ObjectsTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function throwsExceptionForMissingType(): void
     {
         self::expectExceptionObject(CannotProcessOpenAPI::mismatchedType(Objects::class, 'object', 'no type'));
@@ -24,7 +26,7 @@ class ObjectsTest extends TestCase
         new Objects('', new Schema([]));
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionForIncorrectType(): void
     {
         self::expectExceptionObject(CannotProcessOpenAPI::mismatchedType(Objects::class, 'object', 'string'));
@@ -79,10 +81,8 @@ class ObjectsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConstruct
-     */
+    #[DataProvider('dataSetsToConstruct')]
+    #[Test]
     public function constructTest(Schema $schema, array $expected): void
     {
         $sut = new Objects('', $schema);

--- a/tests/OpenAPI/Specification/RequestTest.php
+++ b/tests/OpenAPI/Specification/RequestTest.php
@@ -25,7 +25,7 @@ class RequestTest extends TestCase
 {
     public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
 
-    public function dataSetsWithIncorrectMethods(): array
+    public static function dataSetsWithIncorrectMethods(): array
     {
         return [
             'no methods in path' => [
@@ -63,7 +63,7 @@ class RequestTest extends TestCase
     }
 
 
-    public function dataSetsWithValidSchemas(): array
+    public static function dataSetsWithValidSchemas(): array
     {
         return [
             [
@@ -86,7 +86,7 @@ class RequestTest extends TestCase
     }
 
 
-    public function dataSetsWithNullSchemas(): array
+    public static function dataSetsWithNullSchemas(): array
     {
         return [
             'requestBody not found' => [
@@ -127,7 +127,7 @@ class RequestTest extends TestCase
         self::assertContains('name', $names);
     }
 
-    public function dataSetsWithReferences(): array
+    public static function dataSetsWithReferences(): array
     {
         return [
             'json file with references that must be resolved' => [

--- a/tests/OpenAPI/Specification/RequestTest.php
+++ b/tests/OpenAPI/Specification/RequestTest.php
@@ -8,19 +8,25 @@ use cebe\openapi\spec\Parameter;
 use cebe\openapi\spec\Schema;
 use Exception;
 use GuzzleHttp\Psr7\ServerRequest;
+use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
 use Membrane\OpenAPI\Exception\CannotProcessRequest;
 use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\PathMatcher;
+use Membrane\OpenAPI\Reader\OpenAPIFileReader;
+use Membrane\OpenAPI\Specification\APISpec;
 use Membrane\OpenAPI\Specification\Request;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Specification\Request
- * @covers \Membrane\OpenAPI\Specification\APISpec
- * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- * @covers \Membrane\OpenAPI\Exception\CannotProcessRequest
- * @uses   \Membrane\OpenAPI\PathMatcher
- * @uses   \Membrane\OpenAPI\Reader\OpenAPIFileReader
- */
+#[CoversClass(Request::class)]
+#[CoversClass(APISpec::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
+#[CoversClass(CannotProcessRequest::class)]
+#[UsesClass(PathMatcher::class)]
+#[UsesClass(OpenAPIFileReader::class)]
 class RequestTest extends TestCase
 {
     public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
@@ -41,10 +47,8 @@ class RequestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectMethods
-     */
+    #[DataProvider('dataSetsWithIncorrectMethods')]
+    #[Test]
     public function getOperationThrowsExceptionForIncorrectMethod(string $filePath, string $url, Method $method): void
     {
         self::expectExceptionObject(CannotProcessRequest::methodNotFound($method->value));
@@ -52,9 +56,7 @@ class RequestTest extends TestCase
         new Request(self::DIR . $filePath, $url, $method);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throwsExceptionIfRequestBodyFoundButContentNotJson(): void
     {
         self::expectExceptionObject(CannotProcessRequest::unsupportedContent());
@@ -74,10 +76,8 @@ class RequestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithValidSchemas
-     */
+    #[DataProvider('dataSetsWithValidSchemas')]
+    #[Test]
     public function schemaIsSchemaObjectIfRequestBodyWithContentJson(string $url, Method $method, $filePath): void
     {
         $class = new Request(self::DIR . $filePath, $url, $method);
@@ -102,10 +102,8 @@ class RequestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithNullSchemas
-     */
+    #[DataProvider('dataSetsWithNullSchemas')]
+    #[Test]
     public function schemaIsNullIfNoRequestBodyNorContent(string $url, Method $method, $filePath): void
     {
         $class = new Request(self::DIR . $filePath, $url, $method);
@@ -113,9 +111,7 @@ class RequestTest extends TestCase
         self::assertNull($class->requestBodySchema);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mergesPathAndOperationParameters(): void
     {
         $class = new Request(self::DIR . 'noReferences.json', 'http://test.com/parampath/01', Method::GET);
@@ -143,10 +139,8 @@ class RequestTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithReferences
-     */
+    #[DataProvider('dataSetsWithReferences')]
+    #[Test]
     public function ParameterSchemaReferencesResolved(string $url, Method $method, string $filePath): void
     {
         $class = new Request(self::DIR . $filePath, $url, $method);
@@ -156,7 +150,7 @@ class RequestTest extends TestCase
         self::assertInstanceOf(Schema::class, $class->pathParameters[0]->schema);
     }
 
-    /** @test */
+    #[Test]
     public function fromPsr7ThrowsExceptionIfUnsupportedMethod(): void
     {
         self::expectExceptionObject(new Exception('not supported'));
@@ -166,7 +160,7 @@ class RequestTest extends TestCase
         Request::fromPsr7(self::DIR . 'noReferences.json', $serverRequest);
     }
 
-    /** @test */
+    #[Test]
     public function fromPsr7SuccessfulConstructionTest(): void
     {
         $expected = new Request(self::DIR . 'noReferences.json', 'http://test.com/path', Method::GET);

--- a/tests/OpenAPI/Specification/ResponseTest.php
+++ b/tests/OpenAPI/Specification/ResponseTest.php
@@ -8,24 +8,27 @@ use cebe\openapi\spec\Schema;
 use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
 use Membrane\OpenAPI\Exception\CannotProcessRequest;
 use Membrane\OpenAPI\Method;
+use Membrane\OpenAPI\PathMatcher;
+use Membrane\OpenAPI\Reader\OpenAPIFileReader;
+use Membrane\OpenAPI\Specification\APISpec;
 use Membrane\OpenAPI\Specification\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Specification\Response
- * @covers \Membrane\OpenAPI\Specification\APISpec
- * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- * @covers \Membrane\OpenAPI\Exception\CannotProcessRequest
- * @uses   \Membrane\OpenAPI\PathMatcher
- * @uses   \Membrane\OpenAPI\Reader\OpenAPIFileReader
- */
+#[CoversClass(Response::class)]
+#[CoversClass(APISpec::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
+#[CoversClass(CannotProcessRequest::class)]
+#[UsesClass(PathMatcher::class)]
+#[UsesClass(OpenAPIFileReader::class)]
 class ResponseTest extends TestCase
 {
     public const DIR = __DIR__ . '/../../fixtures/OpenAPI/';
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throwsExceptionIfApplicableResponseNotFound(): void
     {
         $httpStatus = '404';
@@ -34,9 +37,7 @@ class ResponseTest extends TestCase
         new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::GET, $httpStatus);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function throwsExceptionIfResponseContentNotJson(): void
     {
         self::expectExceptionObject(CannotProcessRequest::unsupportedContent());
@@ -44,9 +45,7 @@ class ResponseTest extends TestCase
         new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::PUT, '200');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function returnsDefaultResponseIfExactMatchNotFound(): void
     {
         $class = new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::DELETE, '404');
@@ -54,9 +53,7 @@ class ResponseTest extends TestCase
         self::assertInstanceOf(Schema::class, $class->schema);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function schemaIsSchemaObjectIfContentJson(): void
     {
         $class = new Response(self::DIR . 'noReferences.json', 'http://test.com/path', Method::DELETE, 'default');
@@ -82,10 +79,8 @@ class ResponseTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithNullSchemas
-     */
+    #[DataProvider('dataSetsWithNullSchemas')]
+    #[Test]
     public function schemaIsNullIfResponseHasNoContentOrEmpty(
         string $url,
         Method $method,
@@ -115,10 +110,8 @@ class ResponseTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithReferences
-     */
+    #[DataProvider('dataSetsWithReferences')]
+    #[Test]
     public function ResponseSchemaReferencesResolved(
         string $url,
         Method $method,

--- a/tests/OpenAPI/Specification/ResponseTest.php
+++ b/tests/OpenAPI/Specification/ResponseTest.php
@@ -64,7 +64,7 @@ class ResponseTest extends TestCase
         self::assertInstanceOf(Schema::class, $class->schema);
     }
 
-    public function dataSetsWithNullSchemas(): array
+    public static function dataSetsWithNullSchemas(): array
     {
         return [
             'response with no content' => [
@@ -97,7 +97,7 @@ class ResponseTest extends TestCase
         self::assertNull($class->schema);
     }
 
-    public function dataSetsWithReferences(): array
+    public static function dataSetsWithReferences(): array
     {
         return [
             [

--- a/tests/OpenAPI/Specification/StringsTest.php
+++ b/tests/OpenAPI/Specification/StringsTest.php
@@ -6,17 +6,19 @@ namespace OpenAPI\Specification;
 
 use cebe\openapi\spec\Schema;
 use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
+use Membrane\OpenAPI\Specification\APISchema;
 use Membrane\OpenAPI\Specification\Strings;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Specification\Strings
- * @covers \Membrane\OpenAPI\Specification\APISchema
- * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- */
+#[CoversClass(Strings::class)]
+#[CoversClass(APISchema::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
 class StringsTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function throwsExceptionForMissingType(): void
     {
         self::expectExceptionObject(CannotProcessOpenAPI::mismatchedType(Strings::class, 'string', 'no type'));
@@ -24,7 +26,7 @@ class StringsTest extends TestCase
         new Strings('', new Schema([]));
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionForIncorrectType(): void
     {
         self::expectExceptionObject(CannotProcessOpenAPI::mismatchedType(Strings::class, 'string', 'integer'));
@@ -68,10 +70,8 @@ class StringsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConstruct
-     */
+    #[DataProvider('dataSetsToConstruct')]
+    #[Test]
     public function constructTest(Schema $schema, array $expected): void
     {
         $sut = new Strings('', $schema);

--- a/tests/OpenAPI/Specification/StringsTest.php
+++ b/tests/OpenAPI/Specification/StringsTest.php
@@ -32,7 +32,7 @@ class StringsTest extends TestCase
         new Strings('', new Schema(['type' => 'integer']));
     }
 
-    public function dataSetsToConstruct(): array
+    public static function dataSetsToConstruct(): array
     {
         return [
             'default values' => [

--- a/tests/OpenAPI/Specification/TrueFalseTest.php
+++ b/tests/OpenAPI/Specification/TrueFalseTest.php
@@ -32,7 +32,7 @@ class TrueFalseTest extends TestCase
         new TrueFalse('', new Schema(['type' => 'string']));
     }
 
-    public function dataSetsToConstruct(): array
+    public static function dataSetsToConstruct(): array
     {
         return [
             'default values' => [

--- a/tests/OpenAPI/Specification/TrueFalseTest.php
+++ b/tests/OpenAPI/Specification/TrueFalseTest.php
@@ -6,17 +6,19 @@ namespace OpenAPI\Specification;
 
 use cebe\openapi\spec\Schema;
 use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
+use Membrane\OpenAPI\Specification\APISchema;
 use Membrane\OpenAPI\Specification\TrueFalse;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\OpenAPI\Specification\TrueFalse
- * @covers \Membrane\OpenAPI\Specification\APISchema
- * @covers \Membrane\OpenAPI\Exception\CannotProcessOpenAPI
- */
+#[CoversClass(TrueFalse::class)]
+#[CoversClass(APISchema::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
 class TrueFalseTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function throwsExceptionForMissingType(): void
     {
         self::expectExceptionObject(CannotProcessOpenAPI::mismatchedType(TrueFalse::class, 'boolean', 'no type'));
@@ -24,7 +26,7 @@ class TrueFalseTest extends TestCase
         new TrueFalse('', new Schema([]));
     }
 
-    /** @test */
+    #[Test]
     public function throwsExceptionForInvalidType(): void
     {
         self::expectExceptionObject(CannotProcessOpenAPI::mismatchedType(TrueFalse::class, 'boolean', 'string'));
@@ -59,10 +61,8 @@ class TrueFalseTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConstruct
-     */
+    #[DataProvider('dataSetsToConstruct')]
+    #[Test]
     public function constructTest(Schema $schema, array $expected): void
     {
         $sut = new TrueFalse('', $schema);

--- a/tests/Processor/AfterSetTest.php
+++ b/tests/Processor/AfterSetTest.php
@@ -6,6 +6,7 @@ namespace Processor;
 
 use Membrane\Filter\Type\ToFloat;
 use Membrane\Processor\AfterSet;
+use Membrane\Processor\Field;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
@@ -14,21 +15,23 @@ use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Processor\AfterSet
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Filter\Type\ToFloat
- * @uses   \Membrane\Validator\Type\IsFloat
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(AfterSet::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(ToFloat::class)]
+#[UsesClass(IsFloat::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldName::class)]
 class AfterSetTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -53,10 +56,8 @@ class AfterSetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(string $expected, AfterSet $sut): void
     {
         $actual = (string)$sut;
@@ -79,10 +80,8 @@ class AfterSetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(AfterSet $sut): void
     {
         $actual = $sut->__toPHP();
@@ -90,7 +89,7 @@ class AfterSetTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function processesMethodReturnsEmptyString(): void
     {
         $expected = '';
@@ -157,10 +156,8 @@ class AfterSetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForFiltersOrValidators
-     */
+    #[DataProvider('dataSetsForFiltersOrValidators')]
+    #[Test]
     public function processesCallsFilterOrValidateMethods(Result $expected, AfterSet $sut, mixed $input): void
     {
         $actual = $sut->process(new FieldName('parent field'), $input);

--- a/tests/Processor/AfterSetTest.php
+++ b/tests/Processor/AfterSetTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AfterSetTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'No chain returns empty string' => [
@@ -64,7 +64,7 @@ class AfterSetTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no chain' => [
@@ -101,7 +101,7 @@ class AfterSetTest extends TestCase
         self::assertSame($expected, $result);
     }
 
-    public function dataSetsForFiltersOrValidators(): array
+    public static function dataSetsForFiltersOrValidators(): array
     {
         return [
             'No chain returns noResult' => [

--- a/tests/Processor/BeforeSetTest.php
+++ b/tests/Processor/BeforeSetTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BeforeSetTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'No chain returns empty string' => [
@@ -65,7 +65,7 @@ class BeforeSetTest extends TestCase
     }
 
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no chain' => [
@@ -102,7 +102,7 @@ class BeforeSetTest extends TestCase
         self::assertSame($expected, $result);
     }
 
-    public function dataSetsForFiltersOrValidators(): array
+    public static function dataSetsForFiltersOrValidators(): array
     {
         return [
             'no chain returns noResult' => [

--- a/tests/Processor/BeforeSetTest.php
+++ b/tests/Processor/BeforeSetTest.php
@@ -6,6 +6,7 @@ namespace Processor;
 
 use Membrane\Filter\Type\ToFloat;
 use Membrane\Processor\BeforeSet;
+use Membrane\Processor\Field;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
@@ -14,21 +15,23 @@ use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Processor\BeforeSet
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Filter\Type\ToFloat
- * @uses   \Membrane\Validator\Type\IsFloat
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Result\FieldName
- */
+#[CoversClass(BeforeSet::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(ToFloat::class)]
+#[UsesClass(IsFloat::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldName::class)]
 class BeforeSetTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -53,10 +56,8 @@ class BeforeSetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(string $expected, BeforeSet $sut): void
     {
         $actual = (string)$sut;
@@ -80,10 +81,8 @@ class BeforeSetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(BeforeSet $sut): void
     {
         $actual = $sut->__toPHP();
@@ -91,7 +90,7 @@ class BeforeSetTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function processesMethodReturnsEmptyString(): void
     {
         $expected = '';
@@ -158,10 +157,8 @@ class BeforeSetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForFiltersOrValidators
-     */
+    #[DataProvider('dataSetsForFiltersOrValidators')]
+    #[Test]
     public function processesCallsFilterOrValidateMethods(Result $expected, BeforeSet $sut, mixed $input): void
     {
         $actual = $sut->process(new FieldName('parent field'), $input);

--- a/tests/Processor/CollectionTest.php
+++ b/tests/Processor/CollectionTest.php
@@ -21,26 +21,28 @@ use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Processor\Collection
- * @covers \Membrane\Exception\InvalidProcessorArguments
- * @uses   \Membrane\Filter\Shape\Truncate
- * @uses   \Membrane\Filter\Type\ToFloat
- * @uses   \Membrane\Processor\BeforeSet
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Processor\AfterSet
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Validator\Collection\Count
- * @uses   \Membrane\Validator\Type\IsFloat
- * @uses   \Membrane\Validator\Utility\Passes
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Fails
- */
+#[CoversClass(Collection::class)]
+#[CoversClass(InvalidProcessorArguments::class)]
+#[UsesClass(Truncate::class)]
+#[UsesClass(ToFloat::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(AfterSet::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(Count::class)]
+#[UsesClass(IsFloat::class)]
+#[UsesClass(Passes::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Fails::class)]
 class CollectionTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -94,10 +96,8 @@ class CollectionTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(string $expected, Collection $sut): void
     {
         $actual = (string)$sut;
@@ -134,10 +134,8 @@ class CollectionTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Collection $sut): void
     {
         $actual = $sut->__toPHP();
@@ -158,10 +156,8 @@ class CollectionTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectValues
-     */
+    #[DataProvider('dataSetsWithIncorrectValues')]
+    #[Test]
     public function onlyAcceptsArrayValues(mixed $input, Message $expectedMessage): void
     {
         $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
@@ -173,7 +169,7 @@ class CollectionTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /** @test */
+    #[Test]
     public function onlyAcceptsOneField(): void
     {
         $field = new Field('field to process');
@@ -182,7 +178,7 @@ class CollectionTest extends TestCase
         new Collection('field to process', $field, $field);
     }
 
-    /** @test */
+    #[Test]
     public function processesTest(): void
     {
         $fieldName = 'field to process';
@@ -193,7 +189,7 @@ class CollectionTest extends TestCase
         self::assertEquals($fieldName, $output);
     }
 
-    /** @test */
+    #[Test]
     public function processMethodWithNoChainReturnsNoResult(): void
     {
         $value = [];
@@ -296,10 +292,8 @@ class CollectionTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsOfFields
-     */
+    #[DataProvider('dataSetsOfFields')]
+    #[Test]
     public function processTest(array $input, Result $expected, Processor ...$chain): void
     {
         $sut = new Collection('field to process', ...$chain);

--- a/tests/Processor/CollectionTest.php
+++ b/tests/Processor/CollectionTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CollectionTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'No chain returns empty string' => [
@@ -105,7 +105,7 @@ class CollectionTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no chain' => [
@@ -145,7 +145,7 @@ class CollectionTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectValues(): array
+    public static function dataSetsWithIncorrectValues(): array
     {
         $notArrayMessage = 'Value passed to %s in Collection chain must be a list, %s passed instead';
         return [
@@ -205,7 +205,7 @@ class CollectionTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsOfFields(): array
+    public static function dataSetsOfFields(): array
     {
         return [
             'No chain returns noResult' => [

--- a/tests/Processor/DefaultProcessorTest.php
+++ b/tests/Processor/DefaultProcessorTest.php
@@ -6,6 +6,7 @@ namespace Processor;
 
 use Membrane\Filter\Type\ToFloat;
 use Membrane\Processor\DefaultProcessor;
+use Membrane\Processor\Field;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
@@ -14,21 +15,23 @@ use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Processor\DefaultProcessor
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Filter\Type\ToFloat
- * @uses   \Membrane\Validator\Type\IsFloat
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- */
+#[CoversClass(DefaultProcessor::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(ToFloat::class)]
+#[UsesClass(IsFloat::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
 class DefaultProcessorTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -53,10 +56,8 @@ class DefaultProcessorTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(string $expected, DefaultProcessor $sut): void
     {
         $actual = (string)$sut;
@@ -79,10 +80,8 @@ class DefaultProcessorTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(DefaultProcessor $sut): void
     {
         $actual = $sut->__toPHP();
@@ -90,7 +89,7 @@ class DefaultProcessorTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function processesTest(): void
     {
         $expected = '';
@@ -157,10 +156,8 @@ class DefaultProcessorTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForFiltersOrValidators
-     */
+    #[DataProvider('dataSetsForFiltersOrValidators')]
+    #[Test]
     public function processesCallsFilterOrValidateMethods(Result $expected, DefaultProcessor $sut, mixed $input): void
     {
         $actual = $sut->process(new FieldName('parent field'), $input);

--- a/tests/Processor/DefaultProcessorTest.php
+++ b/tests/Processor/DefaultProcessorTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
  */
 class DefaultProcessorTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'No chain returns empty string' => [
@@ -64,7 +64,7 @@ class DefaultProcessorTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no chain' => [
@@ -101,7 +101,7 @@ class DefaultProcessorTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsForFiltersOrValidators(): array
+    public static function dataSetsForFiltersOrValidators(): array
     {
         return [
             'no chain returns noResult' => [

--- a/tests/Processor/FieldTest.php
+++ b/tests/Processor/FieldTest.php
@@ -14,20 +14,22 @@ use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Processor\Field
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Filter\Type\ToFloat
- * @uses   \Membrane\Validator\Type\IsFloat
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Field::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(ToFloat::class)]
+#[UsesClass(IsFloat::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class FieldTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -56,10 +58,8 @@ class FieldTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(string $expected, Field $sut): void
     {
         $actual = (string)$sut;
@@ -77,10 +77,8 @@ class FieldTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Field $sut): void
     {
         $actual = $sut->__toPHP();
@@ -88,7 +86,7 @@ class FieldTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /** @test */
+    #[Test]
     public function processesMethodReturnsProcessesString(): void
     {
         $input = 'FieldName to process';
@@ -155,10 +153,8 @@ class FieldTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForFiltersOrValidators
-     */
+    #[DataProvider('dataSetsForFiltersOrValidators')]
+    #[Test]
     public function processesCallsFilterOrValidateMethods(Result $expected, Field $sut, mixed $input): void
     {
         $actual = $sut->process(new FieldName('parent field'), $input);

--- a/tests/Processor/FieldTest.php
+++ b/tests/Processor/FieldTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FieldTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'No chain returns empty string' => [
@@ -67,7 +67,7 @@ class FieldTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'empty processes string, no chain' => [new Field('')],
@@ -99,7 +99,7 @@ class FieldTest extends TestCase
         self::assertEquals($output, $input);
     }
 
-    public function dataSetsForFiltersOrValidators(): array
+    public static function dataSetsForFiltersOrValidators(): array
     {
         return [
             'No chain returns noResult' => [

--- a/tests/Processor/FieldsetTest.php
+++ b/tests/Processor/FieldsetTest.php
@@ -25,30 +25,32 @@ use Membrane\Validator\Type\IsFloat;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Processor\FieldSet
- * @covers \Membrane\Exception\InvalidProcessorArguments
- * @uses   \Membrane\Validator\Collection\Identical
- * @uses   \Membrane\Filter\Shape\Rename
- * @uses   \Membrane\Filter\Type\ToFloat
- * @uses   \Membrane\Filter\Type\ToInt
- * @uses   \Membrane\Filter\Type\ToString
- * @uses   \Membrane\Processor\AfterSet
- * @uses   \Membrane\Processor\BeforeSet
- * @uses   \Membrane\Processor\DefaultProcessor
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Processor\Field
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Validator\FieldSet\RequiredFields
- * @uses   \Membrane\Validator\Type\IsFloat
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- */
+#[CoversClass(FieldSet::class)]
+#[CoversClass(InvalidProcessorArguments::class)]
+#[UsesClass(Identical::class)]
+#[UsesClass(Rename::class)]
+#[UsesClass(ToFloat::class)]
+#[UsesClass(ToInt::class)]
+#[UsesClass(ToString::class)]
+#[UsesClass(AfterSet::class)]
+#[UsesClass(BeforeSet::class)]
+#[UsesClass(DefaultProcessor::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(Field::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(RequiredFields::class)]
+#[UsesClass(IsFloat::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
 class FieldsetTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -116,10 +118,8 @@ class FieldsetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(string $expected, FieldSet $sut): void
     {
         $actual = (string)$sut;
@@ -148,10 +148,8 @@ class FieldsetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(FieldSet $sut): void
     {
         $actual = $sut->__toPHP();
@@ -173,10 +171,8 @@ class FieldsetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectValues
-     */
+    #[DataProvider('dataSetsWithIncorrectValues')]
+    #[Test]
     public function onlyAcceptsArrayValues(mixed $input, Message $expectedMessage): void
     {
         $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
@@ -188,7 +184,7 @@ class FieldsetTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /** @test */
+    #[Test]
     public function onlyAcceptsOneBeforeSet(): void
     {
         $beforeSet = new BeforeSet();
@@ -197,7 +193,7 @@ class FieldsetTest extends TestCase
         new FieldSet('field to process', $beforeSet, $beforeSet);
     }
 
-    /** @test */
+    #[Test]
     public function onlyAcceptsOneAfterSet(): void
     {
         $afterSet = new AfterSet();
@@ -206,7 +202,7 @@ class FieldsetTest extends TestCase
         new FieldSet('field to process', $afterSet, $afterSet);
     }
 
-    /** @test */
+    #[Test]
     public function onlyAcceptsOneDefaultField(): void
     {
         $defaultField = DefaultProcessor::fromFiltersAndValidators();
@@ -215,7 +211,7 @@ class FieldsetTest extends TestCase
         new FieldSet('field to process', $defaultField, $defaultField);
     }
 
-    /** @test */
+    #[Test]
     public function processesTest(): void
     {
         $fieldName = 'field to process';
@@ -226,7 +222,7 @@ class FieldsetTest extends TestCase
         self::assertEquals($fieldName, $output);
     }
 
-    /** @test */
+    #[Test]
     public function processMethodCallsFieldProcessesMethod(): void
     {
         $input = ['a' => 1, 'b' => 2, 'c' => 3];
@@ -238,7 +234,7 @@ class FieldsetTest extends TestCase
         $fieldset->process(new FieldName('Parent field'), $input);
     }
 
-    /** @test */
+    #[Test]
     public function processCallsBeforeSetProcessOnceAndProcessesNever(): void
     {
         $input = ['a' => 1, 'b' => 2, 'c' => 3];
@@ -254,7 +250,7 @@ class FieldsetTest extends TestCase
         $fieldset->process(new FieldName('Parent field'), $input);
     }
 
-    /** @test */
+    #[Test]
     public function processCallsAfterSetProcessOnceAndProcessesNever(): void
     {
         $input = ['a' => 1, 'b' => 2, 'c' => 3];
@@ -348,10 +344,8 @@ class FieldsetTest extends TestCase
     }
 
 
-    /**
-     * @test
-     * @dataProvider dataSetsOfFields
-     */
+    #[DataProvider('dataSetsOfFields')]
+    #[Test]
     public function processTest(array $input, Result $expected, Processor ...$chain): void
     {
         $fieldset = new FieldSet('field to process', ...$chain);

--- a/tests/Processor/FieldsetTest.php
+++ b/tests/Processor/FieldsetTest.php
@@ -51,7 +51,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FieldsetTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'No chain returns empty string' => [
@@ -127,7 +127,7 @@ class FieldsetTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no chain' => [new FieldSet('a')],
@@ -159,7 +159,7 @@ class FieldsetTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectValues(): array
+    public static function dataSetsWithIncorrectValues(): array
     {
         $notArrayMessage = 'Value passed to FieldSet chain be an array, %s passed instead';
         $listMessage = 'Value passed to FieldSet chain must be an array, list passed instead';
@@ -270,7 +270,7 @@ class FieldsetTest extends TestCase
         $fieldset->process(new FieldName('Parent field'), $input);
     }
 
-    public function dataSetsOfFields(): array
+    public static function dataSetsOfFields(): array
     {
         return [
             'No chain returns noResult' => [

--- a/tests/Renderer/HumanReadableTest.php
+++ b/tests/Renderer/HumanReadableTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class HumanReadableTest extends TestCase
 {
-    public function dataSetsToRenderAsArrays(): array
+    public static function dataSetsToRenderAsArrays(): array
     {
         $msg = fn($var) => new Message('%s', [$var]);
 
@@ -102,7 +102,7 @@ class HumanReadableTest extends TestCase
     }
 
 
-    public function dataSetsToRenderAsStrings(): array
+    public static function dataSetsToRenderAsStrings(): array
     {
         $msg = fn($var) => new Message('%s', [$var]);
 

--- a/tests/Renderer/HumanReadableTest.php
+++ b/tests/Renderer/HumanReadableTest.php
@@ -9,15 +9,17 @@ use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Renderer\HumanReadable
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(HumanReadable::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class HumanReadableTest extends TestCase
 {
     public static function dataSetsToRenderAsArrays(): array
@@ -72,10 +74,8 @@ class HumanReadableTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToRenderAsArrays
-     */
+    #[DataProvider('dataSetsToRenderAsArrays')]
+    #[Test]
     public function toArrayTest(Result $result, array $expected): void
     {
         $sut = new HumanReadable($result);
@@ -85,7 +85,7 @@ class HumanReadableTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function jsonSerializeTest(): void
     {
         $result = Result::invalid(
@@ -146,10 +146,8 @@ class HumanReadableTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToRenderAsStrings
-     */
+    #[DataProvider('dataSetsToRenderAsStrings')]
+    #[Test]
     public function renderTest(Result $result, string $expected): void
     {
         $sut = new HumanReadable($result);

--- a/tests/Renderer/JsonFlatTest.php
+++ b/tests/Renderer/JsonFlatTest.php
@@ -9,15 +9,17 @@ use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Renderer\JsonFlat
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(JsonFlat::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class JsonFlatTest extends TestCase
 {
     public static function dataSetsToRenderAsArrays(): array
@@ -72,10 +74,8 @@ class JsonFlatTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToRenderAsArrays
-     */
+    #[DataProvider('dataSetsToRenderAsArrays')]
+    #[Test]
     public function toArrayTest(Result $result, array $expected): void
     {
         $sut = new JsonFlat($result);
@@ -85,7 +85,7 @@ class JsonFlatTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function JsonSerializeTest(): void
     {
         $result = Result::invalid(
@@ -101,7 +101,7 @@ class JsonFlatTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $result = Result::invalid(

--- a/tests/Renderer/JsonFlatTest.php
+++ b/tests/Renderer/JsonFlatTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonFlatTest extends TestCase
 {
-    public function dataSetsToRenderAsArrays(): array
+    public static function dataSetsToRenderAsArrays(): array
     {
         $msg = fn($var) => new Message('%s', [$var]);
 

--- a/tests/Renderer/JsonNestedTest.php
+++ b/tests/Renderer/JsonNestedTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonNestedTest extends TestCase
 {
-    public function dataSetsToRenderAsArrays(): array
+    public static function dataSetsToRenderAsArrays(): array
     {
         $msg = fn($var) => new Message('%s', [$var]);
 

--- a/tests/Renderer/JsonNestedTest.php
+++ b/tests/Renderer/JsonNestedTest.php
@@ -9,15 +9,17 @@ use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Renderer\JsonNested
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(JsonNested::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class JsonNestedTest extends TestCase
 {
     public static function dataSetsToRenderAsArrays(): array
@@ -143,10 +145,8 @@ class JsonNestedTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToRenderAsArrays
-     */
+    #[DataProvider('dataSetsToRenderAsArrays')]
+    #[Test]
     public function toArrayTest(Result $result, array $expected): void
     {
         $sut = new JsonNested($result);
@@ -156,7 +156,7 @@ class JsonNestedTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function jsonSerializeTest(): void
     {
         $result = Result::invalid(
@@ -180,7 +180,7 @@ class JsonNestedTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $result = Result::invalid(

--- a/tests/Result/FieldNameTest.php
+++ b/tests/Result/FieldNameTest.php
@@ -5,16 +5,15 @@ declare(strict_types=1);
 namespace Result;
 
 use Membrane\Result\FieldName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Result\FieldName
- */
+#[CoversClass(FieldName::class)]
 class FieldNameTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function pushTest(): void
     {
         $expected = new FieldName('new field', 'original field');
@@ -25,9 +24,7 @@ class FieldNameTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function fieldNameIsAlwaysMergableByItself(): void
     {
         $fieldName = new FieldName('test field');
@@ -79,11 +76,9 @@ class FieldNameTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithEqualStringRepresentations
-     * @dataProvider dataSetsWithDifferentStringRepresentations
-     */
+    #[DataProvider('dataSetsWithEqualStringRepresentations')]
+    #[DataProvider('dataSetsWithDifferentStringRepresentations')]
+    #[Test]
     public function mergableTest(FieldName $firstFieldName, FieldName $secondFieldName, bool $expected): void
     {
         $equals = $firstFieldName->equals($secondFieldName);
@@ -103,10 +98,8 @@ class FieldNameTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForStringRepresentation
-     */
+    #[DataProvider('dataSetsForStringRepresentation')]
+    #[Test]
     public function stringRepresentationTest(array $input, string $expected): void
     {
         $fieldName = new FieldName(...$input);

--- a/tests/Result/FieldNameTest.php
+++ b/tests/Result/FieldNameTest.php
@@ -37,7 +37,7 @@ class FieldNameTest extends TestCase
         self::assertTrue($result);
     }
 
-    public function dataSetsWithEqualStringRepresentations(): array
+    public static function dataSetsWithEqualStringRepresentations(): array
     {
         return [
             [
@@ -63,7 +63,7 @@ class FieldNameTest extends TestCase
         ];
     }
 
-    public function dataSetsWithDifferentStringRepresentations(): array
+    public static function dataSetsWithDifferentStringRepresentations(): array
     {
         return [
             [
@@ -93,7 +93,7 @@ class FieldNameTest extends TestCase
         self::assertEquals($expected, $mergable);
     }
 
-    public function dataSetsForStringRepresentation(): array
+    public static function dataSetsForStringRepresentation(): array
     {
         return [
             'empty string ignored' => [[''], ''],

--- a/tests/Result/MessageSetTest.php
+++ b/tests/Result/MessageSetTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MessageSetTest extends TestCase
 {
-    public function dataSetsThatCanMerge(): array
+    public static function dataSetsThatCanMerge(): array
     {
         $fieldName = new FieldName('field a');
         $firstMessage = new Message('message 1', ['a', 'c']);
@@ -69,7 +69,7 @@ class MessageSetTest extends TestCase
         $firstMessageSet->merge($secondMessageSet);
     }
 
-    public function dataSetsForIsEmptyTest(): array
+    public static function dataSetsForIsEmptyTest(): array
     {
         return [
             [new MessageSet(null), true],

--- a/tests/Result/MessageSetTest.php
+++ b/tests/Result/MessageSetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Result;
@@ -6,13 +7,15 @@ namespace Result;
 use Membrane\Result\FieldName;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\FieldName
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(MessageSet::class)]
+#[UsesClass(FieldName::class)]
+#[UsesClass(Message::class)]
 class MessageSetTest extends TestCase
 {
     public static function dataSetsThatCanMerge(): array
@@ -41,10 +44,8 @@ class MessageSetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatCanMerge
-     */
+    #[DataProvider('dataSetsThatCanMerge')]
+    #[Test]
     public function mergeMessageSets(MessageSet $firstInput, MessageSet $secondInput, MessageSet $expected): void
     {
         $result = $firstInput->merge($secondInput);
@@ -52,9 +53,7 @@ class MessageSetTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mergeDifferentFieldNameThrowsError(): void
     {
         $firstFieldName = new FieldName('field a');
@@ -78,10 +77,8 @@ class MessageSetTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForIsEmptyTest
-     */
+    #[DataProvider('dataSetsForIsEmptyTest')]
+    #[Test]
     public function isEmptyTest(MessageSet $messageSet, bool $expected): void
     {
         $result = $messageSet->isEmpty();

--- a/tests/Result/MessageTest.php
+++ b/tests/Result/MessageTest.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace Result;
 
 use Membrane\Result\Message;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Result\Message
- */
+#[CoversClass(Message::class)]
 class MessageTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderedMessageTest(): void
     {
         $expected = 'This message is a test';

--- a/tests/Result/ResultTest.php
+++ b/tests/Result/ResultTest.php
@@ -7,18 +7,16 @@ namespace Result;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Result\Result
- * @covers \Membrane\Result\MessageSet
- * @covers \Membrane\Result\Message
- */
+#[CoversClass(Result::class)]
+#[CoversClass(MessageSet::class)]
+#[CoversClass(Message::class)]
 class ResultTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function validConstructorReturnsValid(): void
     {
         $input = 'arbitrary value';
@@ -30,9 +28,7 @@ class ResultTest extends TestCase
         self::assertTrue($result->isValid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function invalidConstructorReturnsInvalid(): void
     {
         $inputValue = 'arbitrary value';
@@ -45,9 +41,7 @@ class ResultTest extends TestCase
         self::assertFalse($result->isValid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noResultConstructorReturnsNoResult(): void
     {
         $input = 'arbitrary value';
@@ -59,9 +53,7 @@ class ResultTest extends TestCase
         self::assertTrue($result->isValid());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mergeTwoValidsReturnsValid(): void
     {
         $firstInputValue = 'a value';
@@ -75,9 +67,7 @@ class ResultTest extends TestCase
         self::assertEquals($expected, $mergedResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mergeNoResultAndValidReturnsValid(): void
     {
         $firstInputValue = 'a value';
@@ -91,9 +81,7 @@ class ResultTest extends TestCase
         self::assertEquals($expected, $mergedResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mergeInvalidAndValidReturnsInvalid(): void
     {
         $firstInputValue = 'a value';
@@ -108,9 +96,7 @@ class ResultTest extends TestCase
         self::assertEquals($expected, $mergedResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mergeTwoInvalidsReturnsInvalid(): void
     {
         $firstInputValue = 'a value';
@@ -126,9 +112,7 @@ class ResultTest extends TestCase
         self::assertEquals($expected, $mergedResult);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mergeNoResultAndInvalidReturnsInvalid(): void
     {
         $firstValue = 'a value';

--- a/tests/Validator/Collection/ContainedTest.php
+++ b/tests/Validator/Collection/ContainedTest.php
@@ -8,14 +8,16 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Collection\Contained;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Collection\Contained
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Contained::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class ContainedTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -40,10 +42,8 @@ class ContainedTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(array $enum, string $expected): void
     {
         $sut = new Contained($enum);
@@ -62,10 +62,8 @@ class ContainedTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Contained $sut): void
     {
         $actual = $sut->__toPHP();
@@ -106,10 +104,8 @@ class ContainedTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToValidate
-     */
+    #[DataProvider('dataSetsToValidate')]
+    #[Test]
     public function validateTest(mixed $value, array $enum, Result $expected): void
     {
         $sut = new Contained($enum);

--- a/tests/Validator/Collection/ContainedTest.php
+++ b/tests/Validator/Collection/ContainedTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ContainedTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no values' => [
@@ -53,7 +53,7 @@ class ContainedTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'empty array' => [new Contained([])],
@@ -73,7 +73,7 @@ class ContainedTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsToValidate(): array
+    public static function dataSetsToValidate(): array
     {
         return [
             'value contained in array' => [

--- a/tests/Validator/Collection/CountTest.php
+++ b/tests/Validator/Collection/CountTest.php
@@ -8,14 +8,16 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Collection\Count;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Collection\Count
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Count::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class CountTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -44,10 +46,8 @@ class CountTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(int $min, ?int $max, string $expected): void
     {
         $sut = new Count($min, $max);
@@ -65,10 +65,8 @@ class CountTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Count $sut): void
     {
         $actual = $sut->__toPHP();
@@ -87,10 +85,8 @@ class CountTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $count = new Count();
@@ -107,9 +103,7 @@ class CountTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noMinAndNoMaxReturnsValid(): void
     {
         $input = ['this', 'has', 'four', 'values'];
@@ -129,10 +123,8 @@ class CountTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithLessThanMinimum
-     */
+    #[DataProvider('dataSetsWithLessThanMinimum')]
+    #[Test]
     public function arraysWithLessValuesThanMinimumReturnInvalid(array $input, int $min): void
     {
         $expectedMessage = new Message('Array is expected have a minimum of %d values', [$min]);
@@ -152,10 +144,8 @@ class CountTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithMoreThanMaximum
-     */
+    #[DataProvider('dataSetsWithMoreThanMaximum')]
+    #[Test]
     public function arraysWithMoreValuesThanMaximumReturnInvalid(array $input, int $max): void
     {
         $expectedMessage = new Message('Array is expected have a maximum of %d values', [$max]);
@@ -175,10 +165,8 @@ class CountTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithinRange
-     */
+    #[DataProvider('dataSetsWithinRange')]
+    #[Test]
     public function arraysWithinRangeReturnValid(array $input, int $min, int $max): void
     {
         $expected = Result::valid($input);

--- a/tests/Validator/Collection/CountTest.php
+++ b/tests/Validator/Collection/CountTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CountTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no minimum or maximum' => [
@@ -57,7 +57,7 @@ class CountTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'default arguments' => [new Count()],
@@ -76,7 +76,7 @@ class CountTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [123, 'integer'],
@@ -121,7 +121,7 @@ class CountTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithLessThanMinimum(): array
+    public static function dataSetsWithLessThanMinimum(): array
     {
         return [
             [[], 1],
@@ -144,7 +144,7 @@ class CountTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithMoreThanMaximum(): array
+    public static function dataSetsWithMoreThanMaximum(): array
     {
         return [
             [['two', 'values'], 1],
@@ -167,7 +167,7 @@ class CountTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithinRange(): array
+    public static function dataSetsWithinRange(): array
     {
         return [
             [['two', 'values'], 1, 3],

--- a/tests/Validator/Collection/IdenticalTest.php
+++ b/tests/Validator/Collection/IdenticalTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Collection\Identical;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Collection\Identical
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Identical::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class IdenticalTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'contains only identical values';
@@ -29,7 +31,7 @@ class IdenticalTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new Identical();
@@ -50,10 +52,8 @@ class IdenticalTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $identical = new Identical();
@@ -83,10 +83,8 @@ class IdenticalTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForValidResults
-     */
+    #[DataProvider('dataSetsForValidResults')]
+    #[Test]
     public function returnsValidIfEveryInputIsIdentical(mixed $input): void
     {
         $expected = Result::valid($input);
@@ -113,10 +111,8 @@ class IdenticalTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForInvalidResults
-     */
+    #[DataProvider('dataSetsForInvalidResults')]
+    #[Test]
     public function returnsInvalidIfAnyInputIsDifferent(mixed $input): void
     {
         $expected = Result::invalid($input, new MessageSet(null, new Message('Do not match', [])));

--- a/tests/Validator/Collection/IdenticalTest.php
+++ b/tests/Validator/Collection/IdenticalTest.php
@@ -39,7 +39,7 @@ class IdenticalTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [123, 'integer'],
@@ -70,7 +70,7 @@ class IdenticalTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsForValidResults(): array
+    public static function dataSetsForValidResults(): array
     {
         return [
             [[]],
@@ -97,7 +97,7 @@ class IdenticalTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsForInvalidResults(): array
+    public static function dataSetsForInvalidResults(): array
     {
         return [
             [[null, 1], Result::INVALID],

--- a/tests/Validator/Collection/UniqueTest.php
+++ b/tests/Validator/Collection/UniqueTest.php
@@ -39,7 +39,7 @@ class UniqueTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [123, 'integer'],
@@ -70,7 +70,7 @@ class UniqueTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsToValidate(): array
+    public static function dataSetsToValidate(): array
     {
         $invalidMessageSet = new MessageSet(null, new Message('Collection contains duplicate values', []));
         return [

--- a/tests/Validator/Collection/UniqueTest.php
+++ b/tests/Validator/Collection/UniqueTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Collection\Unique;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Collection\Unique
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Unique::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class UniqueTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'contains only unique values';
@@ -29,7 +31,7 @@ class UniqueTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new Unique();
@@ -50,10 +52,8 @@ class UniqueTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $unique = new Unique();
@@ -101,10 +101,8 @@ class UniqueTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToValidate
-     */
+    #[DataProvider('dataSetsToValidate')]
+    #[Test]
     public function validateTest(array $value, Result $expected): void
     {
         $sut = new Unique();

--- a/tests/Validator/DateTime/RangeDeltaTest.php
+++ b/tests/Validator/DateTime/RangeDeltaTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RangeDeltaTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no minimum or maximum' => [
@@ -59,7 +59,7 @@ class RangeDeltaTest extends TestCase
         self::assertStringMatchesFormat($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no minimum, no maximum' => [null, null,],
@@ -96,7 +96,7 @@ class RangeDeltaTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithDatesEarlierThanMin(): array
+    public static function dataSetsWithDatesEarlierThanMin(): array
     {
         $now = new DateTime();
 
@@ -122,7 +122,7 @@ class RangeDeltaTest extends TestCase
         self::assertEqualsWithDelta($expected, $result, 2);
     }
 
-    public function dataSetsWithDatesLaterThanMax(): array
+    public static function dataSetsWithDatesLaterThanMax(): array
     {
         $now = new DateTime();
 
@@ -148,7 +148,7 @@ class RangeDeltaTest extends TestCase
         self::assertEqualsWithDelta($expected, $result, 2);
     }
 
-    public function dataSetsWithDatesWithinRange(): array
+    public static function dataSetsWithDatesWithinRange(): array
     {
         $now = new DateTime();
 

--- a/tests/Validator/DateTime/RangeDeltaTest.php
+++ b/tests/Validator/DateTime/RangeDeltaTest.php
@@ -10,14 +10,16 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\DateTime\RangeDelta;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\DateTime\RangeDelta
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(RangeDelta::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class RangeDeltaTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -46,10 +48,8 @@ class RangeDeltaTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(?DateInterval $min, ?DateInterval $max, string $expected): void
     {
         $sut = new RangeDelta($min, $max);
@@ -69,10 +69,8 @@ class RangeDeltaTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(?DateInterval $min, ?DateInterval $max): void
     {
         $sut = new RangeDelta($min, $max);
@@ -82,9 +80,7 @@ class RangeDeltaTest extends TestCase
         self::assertEqualsWithDelta($sut, eval('return ' . $actual . ';'), 2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noMinAndMaxReturnsValid(): void
     {
         $input = new DateTime('1970-01-01 00:00:00 UTC');
@@ -106,10 +102,8 @@ class RangeDeltaTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithDatesEarlierThanMin
-     */
+    #[DataProvider('dataSetsWithDatesEarlierThanMin')]
+    #[Test]
     public function datesEarlierThanMinReturnInvalid(DateTime $input, DateInterval $min): void
     {
         $now = new DateTime();
@@ -132,10 +126,8 @@ class RangeDeltaTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithDatesLaterThanMax
-     */
+    #[DataProvider('dataSetsWithDatesLaterThanMax')]
+    #[Test]
     public function datesLaterThanMaxReturnInvalid(DateTime $input, DateInterval $max): void
     {
         $now = new DateTime();
@@ -157,10 +149,8 @@ class RangeDeltaTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithDatesWithinRange
-     */
+    #[DataProvider('dataSetsWithDatesWithinRange')]
+    #[Test]
     public function datesWithinRangeReturnValid(DateTime $input, DateInterval $min, DateInterval $max): void
     {
         $expected = Result::valid($input);

--- a/tests/Validator/DateTime/RangeTest.php
+++ b/tests/Validator/DateTime/RangeTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RangeTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no minimum or maximum' => [
@@ -58,7 +58,7 @@ class RangeTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no minimum, no maximum' => [null, null],
@@ -95,7 +95,7 @@ class RangeTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithDatesEarlierThanMin(): array
+    public static function dataSetsWithDatesEarlierThanMin(): array
     {
         return [
             [new DateTime('1960-01-01 00:00:00 UTC'), new DateTime('1970-01-01 00:00:00 UTC')],
@@ -118,7 +118,7 @@ class RangeTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithDatesLaterThanMax(): array
+    public static function dataSetsWithDatesLaterThanMax(): array
     {
         return [
             [new DateTime('1980-01-01 00:00:00 UTC'), new DateTime('1970-01-01 00:00:00 UTC')],
@@ -141,7 +141,7 @@ class RangeTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsWithDatesWithinRange(): array
+    public static function dataSetsWithDatesWithinRange(): array
     {
         return [
             [

--- a/tests/Validator/DateTime/RangeTest.php
+++ b/tests/Validator/DateTime/RangeTest.php
@@ -9,14 +9,16 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\DateTime\Range;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\DateTime\Range
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Range::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class RangeTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -45,10 +47,8 @@ class RangeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(?DateTime $min, ?DateTime $max, string $expected): void
     {
         $sut = new Range($min, $max);
@@ -68,10 +68,8 @@ class RangeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(?DateTime $min, ?DateTime $max): void
     {
         $sut = new Range($min, $max);
@@ -81,9 +79,7 @@ class RangeTest extends TestCase
         self::assertEqualsWithDelta($sut, eval('return ' . $actual . ';'), 2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noMinAndMaxReturnsValid(): void
     {
         $input = new DateTime('1970-01-01 00:00:00 UTC');
@@ -103,10 +99,8 @@ class RangeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithDatesEarlierThanMin
-     */
+    #[DataProvider('dataSetsWithDatesEarlierThanMin')]
+    #[Test]
     public function datesEarlierThanMinReturnInvalid(DateTime $input, DateTime $min): void
     {
         $expectedMessage = new Message('DateTime is expected to be after %s', [$min]);
@@ -126,10 +120,8 @@ class RangeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithDatesLaterThanMax
-     */
+    #[DataProvider('dataSetsWithDatesLaterThanMax')]
+    #[Test]
     public function datesLaterThanMaxReturnInvalid(DateTime $input, DateTime $max): void
     {
         $expectedMessage = new Message('DateTime is expected to be before %s', [$max]);
@@ -158,10 +150,8 @@ class RangeTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithDatesWithinRange
-     */
+    #[DataProvider('dataSetsWithDatesWithinRange')]
+    #[Test]
     public function datesWithinRangeReturnValid(DateTime $input, DateTime $min, DateTime $max): void
     {
         $expected = Result::valid($input);

--- a/tests/Validator/FieldSet/FixedFieldsTest.php
+++ b/tests/Validator/FieldSet/FixedFieldsTest.php
@@ -8,14 +8,16 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\FieldSet\FixedFields;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\FieldSet\FixedFields
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(FixedFields::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class FixedFieldsTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -36,10 +38,8 @@ class FixedFieldsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(array $fields, string $expected): void
     {
         $sut = new FixedFields(...$fields);
@@ -58,10 +58,8 @@ class FixedFieldsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(FixedFields $sut): void
     {
         $actual = $sut->__toPHP();
@@ -80,10 +78,8 @@ class FixedFieldsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectTypesReturnInvalidResults($input, $inputType): void
     {
         $expected = Result::invalid(
@@ -144,10 +140,8 @@ class FixedFieldsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToValidate
-     */
+    #[DataProvider('dataSetsToValidate')]
+    #[Test]
     public function validateTest(array $fields, array $input, Result $expected): void
     {
         $sut = new FixedFields(...$fields);

--- a/tests/Validator/FieldSet/FixedFieldsTest.php
+++ b/tests/Validator/FieldSet/FixedFieldsTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FixedFieldsTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no fixed fields' => [
@@ -49,7 +49,7 @@ class FixedFieldsTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no fields' => [new FixedFields()],
@@ -69,7 +69,7 @@ class FixedFieldsTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [123, 'integer'],
@@ -100,7 +100,7 @@ class FixedFieldsTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsToValidate(): array
+    public static function dataSetsToValidate(): array
     {
         return [
             'no fixed fields, no input' => [

--- a/tests/Validator/FieldSet/RequiredFieldsTest.php
+++ b/tests/Validator/FieldSet/RequiredFieldsTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RequiredFieldsTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no required fields' => [
@@ -49,7 +49,7 @@ class RequiredFieldsTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no fields' => [new RequiredFields()],
@@ -69,7 +69,7 @@ class RequiredFieldsTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [123, 'integer'],
@@ -100,7 +100,7 @@ class RequiredFieldsTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsForValidResults(): array
+    public static function dataSetsForValidResults(): array
     {
         return [
             'no required fields' => [
@@ -147,7 +147,7 @@ class RequiredFieldsTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsForInvalidResults(): array
+    public static function dataSetsForInvalidResults(): array
     {
         return [
             'one required field, none filled' => [

--- a/tests/Validator/FieldSet/RequiredFieldsTest.php
+++ b/tests/Validator/FieldSet/RequiredFieldsTest.php
@@ -8,14 +8,16 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\FieldSet\RequiredFields;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\FieldSet\RequiredFields
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(RequiredFields::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class RequiredFieldsTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -36,10 +38,8 @@ class RequiredFieldsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(array $fields, string $expected): void
     {
         $sut = new RequiredFields(...$fields);
@@ -58,10 +58,8 @@ class RequiredFieldsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(RequiredFields $sut): void
     {
         $actual = $sut->__toPHP();
@@ -80,10 +78,8 @@ class RequiredFieldsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectTypesReturnInvalidResults($input, $inputType): void
     {
         $sut = new RequiredFields();
@@ -133,10 +129,8 @@ class RequiredFieldsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForValidResults
-     */
+    #[DataProvider('dataSetsForValidResults')]
+    #[Test]
     public function ifRequiredFieldsAreFilledReturnValid(array $requiredFields, array $input): void
     {
         $expected = Result::valid($input);
@@ -176,10 +170,8 @@ class RequiredFieldsTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsForInvalidResults
-     */
+    #[DataProvider('dataSetsForInvalidResults')]
+    #[Test]
     public function ifRequiredFieldsAreNotFilledReturnInvalid(
         array $requiredFields,
         array $input,

--- a/tests/Validator/Numeric/MaximumTest.php
+++ b/tests/Validator/Numeric/MaximumTest.php
@@ -8,14 +8,16 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Numeric\Maximum;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Numeric\Maximum
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Maximum::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class MaximumTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -34,10 +36,8 @@ class MaximumTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(int $max, bool $exclusive, string $expected): void
     {
         $sut = new Maximum($max, $exclusive);
@@ -55,10 +55,8 @@ class MaximumTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Maximum $sut): void
     {
         $actual = $sut->__toPHP();
@@ -88,10 +86,8 @@ class MaximumTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsOfNonNumericValues
-     */
+    #[DataProvider('dataSetsOfNonNumericValues')]
+    #[Test]
     public function invalidForNonNumericValues(mixed $value, array $messageVars): void
     {
         $expected = Result::invalid(
@@ -189,10 +185,8 @@ class MaximumTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToValidate
-     */
+    #[DataProvider('dataSetsToValidate')]
+    #[Test]
     public function validateTest(int|float $max, bool $exclusive, int|float $value, Result $expected): void
     {
         $sut = new Maximum($max, $exclusive);

--- a/tests/Validator/Numeric/MaximumTest.php
+++ b/tests/Validator/Numeric/MaximumTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MaximumTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'inclusive max' => [
@@ -47,7 +47,7 @@ class MaximumTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'inclusive maximum' => [new Maximum(5)],
@@ -66,7 +66,7 @@ class MaximumTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsOfNonNumericValues(): array
+    public static function dataSetsOfNonNumericValues(): array
     {
         return [
             [
@@ -105,7 +105,7 @@ class MaximumTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function dataSetsToValidate(): array
+    public static function dataSetsToValidate(): array
     {
         return [
             'less than max (int, inclusive)' => [

--- a/tests/Validator/Numeric/MinimumTest.php
+++ b/tests/Validator/Numeric/MinimumTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MinimumTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'inclusive min' => [
@@ -47,7 +47,7 @@ class MinimumTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'inclusive minimum' => [new Minimum(5)],
@@ -66,7 +66,7 @@ class MinimumTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsOfNonNumericValues(): array
+    public static function dataSetsOfNonNumericValues(): array
     {
         return [
             [
@@ -105,7 +105,7 @@ class MinimumTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function dataSetsToValidate(): array
+    public static function dataSetsToValidate(): array
     {
         return [
             'greater than min (int, inclusive)' => [

--- a/tests/Validator/Numeric/MinimumTest.php
+++ b/tests/Validator/Numeric/MinimumTest.php
@@ -8,14 +8,16 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Numeric\Minimum;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Numeric\Minimum
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Minimum::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class MinimumTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -34,10 +36,8 @@ class MinimumTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(int $min, bool $exclusive, string $expected): void
     {
         $sut = new Minimum($min, $exclusive);
@@ -55,10 +55,8 @@ class MinimumTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Minimum $sut): void
     {
         $actual = $sut->__toPHP();
@@ -88,10 +86,8 @@ class MinimumTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsOfNonNumericValues
-     */
+    #[DataProvider('dataSetsOfNonNumericValues')]
+    #[Test]
     public function invalidForNonNumericValues(mixed $value, array $messageVars): void
     {
         $expected = Result::invalid(
@@ -189,10 +185,8 @@ class MinimumTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToValidate
-     */
+    #[DataProvider('dataSetsToValidate')]
+    #[Test]
     public function validateTest(int|float $min, bool $exclusive, int|float $value, Result $expected): void
     {
         $sut = new Minimum($min, $exclusive);

--- a/tests/Validator/Numeric/MultipleOfTest.php
+++ b/tests/Validator/Numeric/MultipleOfTest.php
@@ -9,17 +9,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Numeric\MultipleOf;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Numeric\MultipleOf
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(MultipleOf::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class MultipleOfTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'is a multiple of 5';
@@ -30,7 +32,7 @@ class MultipleOfTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new MultipleOf(5);
@@ -50,10 +52,8 @@ class MultipleOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatThrowExceptions
-     */
+    #[DataProvider('dataSetsThatThrowExceptions')]
+    #[Test]
     public function throwsExceptionForZeroOrNegatives(int|float $multiple): void
     {
         self::expectException(Exception::class);
@@ -142,10 +142,8 @@ class MultipleOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToValidate
-     */
+    #[DataProvider('dataSetsToValidate')]
+    #[Test]
     public function validateTest(mixed $value, float|int $multiple, $expected): void
     {
         $multipleOf = new MultipleOf($multiple);

--- a/tests/Validator/Numeric/MultipleOfTest.php
+++ b/tests/Validator/Numeric/MultipleOfTest.php
@@ -40,7 +40,7 @@ class MultipleOfTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsThatThrowExceptions(): array
+    public static function dataSetsThatThrowExceptions(): array
     {
         return [
             [0],
@@ -62,7 +62,7 @@ class MultipleOfTest extends TestCase
         new MultipleOf($multiple);
     }
 
-    public function dataSetsToValidate(): array
+    public static function dataSetsToValidate(): array
     {
         $notNumMessage = 'MultipleOf validator requires a number, %s given';
 

--- a/tests/Validator/String/DateStringTest.php
+++ b/tests/Validator/String/DateStringTest.php
@@ -39,7 +39,7 @@ class DateStringTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [123, 'integer'],
@@ -70,7 +70,7 @@ class DateStringTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatPass(): array
+    public static function dataSetsThatPass(): array
     {
         return [
             ['', ''],
@@ -93,7 +93,7 @@ class DateStringTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         return [
             ['Y-m-d', '1990 June 15'],

--- a/tests/Validator/String/DateStringTest.php
+++ b/tests/Validator/String/DateStringTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\String\DateString;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\String\DateString
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(DateString::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class DateStringTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'matches the DateTime format: "#^[a-zA-Z]+$#"';
@@ -29,7 +31,7 @@ class DateStringTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new DateString('Y-m-d');
@@ -50,10 +52,8 @@ class DateStringTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $dateString = new DateString('');
@@ -79,10 +79,8 @@ class DateStringTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function stringsThatMatchFormatReturnValid(string $format, string $input): void
     {
         $dateString = new DateString($format);
@@ -102,10 +100,8 @@ class DateStringTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function stringsThatDoNotMatchFormatReturnInvalid(string $format, string $input): void
     {
         $dateString = new DateString($format);

--- a/tests/Validator/String/LengthTest.php
+++ b/tests/Validator/String/LengthTest.php
@@ -8,14 +8,16 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\String\Length;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\String\Length
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- */
+#[CoversClass(Length::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class LengthTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
@@ -44,10 +46,8 @@ class LengthTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringTest(int $min, ?int $max, string $expected): void
     {
         $sut = new Length($min, $max);
@@ -65,10 +65,8 @@ class LengthTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(Length $sut): void
     {
         $actual = $sut->__toPHP();
@@ -87,10 +85,8 @@ class LengthTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $length = new Length();
@@ -118,10 +114,8 @@ class LengthTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function stringLengthWithinMinAndMaxReturnsValid(mixed $input, int $min, ?int $max): void
     {
         $expected = Result::valid($input);
@@ -141,10 +135,8 @@ class LengthTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function stringLengthOutsideMinOrMaxReturnsInvalid(
         mixed $input,
         int $min,

--- a/tests/Validator/String/LengthTest.php
+++ b/tests/Validator/String/LengthTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class LengthTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
         return [
             'no conditions' => [
@@ -57,7 +57,7 @@ class LengthTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'default arguments' => [new Length()],
@@ -76,7 +76,7 @@ class LengthTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [123, 'integer'],
@@ -107,7 +107,7 @@ class LengthTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatPass(): array
+    public static function dataSetsThatPass(): array
     {
         return [
             ['', 0, 0],
@@ -132,7 +132,7 @@ class LengthTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         return [
             ['', 1, 5, new Message('String is expected to be a minimum of %d characters', [1])],

--- a/tests/Validator/String/RegexTest.php
+++ b/tests/Validator/String/RegexTest.php
@@ -39,7 +39,7 @@ class RegexTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsWithIncorrectTypes(): array
+    public static function dataSetsWithIncorrectTypes(): array
     {
         return [
             [123, 'integer'],
@@ -70,7 +70,7 @@ class RegexTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatPass(): array
+    public static function dataSetsThatPass(): array
     {
         return [
             ['//', ''],
@@ -93,7 +93,7 @@ class RegexTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         return [
             ['/abc/', 'ABC'],

--- a/tests/Validator/String/RegexTest.php
+++ b/tests/Validator/String/RegexTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\String\Regex;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\String\Regex
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Regex::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class RegexTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'matches the regex: "#^[a-zA-Z]+$#"';
@@ -29,7 +31,7 @@ class RegexTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new Regex('/[abc]/i');
@@ -50,10 +52,8 @@ class RegexTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsWithIncorrectTypes
-     */
+    #[DataProvider('dataSetsWithIncorrectTypes')]
+    #[Test]
     public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
     {
         $regex = new Regex('');
@@ -79,10 +79,8 @@ class RegexTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function stringsThatMatchPatternReturnValid(string $pattern, string $input): void
     {
         $regex = new Regex($pattern);
@@ -102,10 +100,8 @@ class RegexTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function stringsThatDoNotMatchPatternReturnInvalid(string $pattern, string $input): void
     {
         $regex = new Regex($pattern);

--- a/tests/Validator/Type/IsArrayTest.php
+++ b/tests/Validator/Type/IsArrayTest.php
@@ -39,7 +39,7 @@ class IsArrayTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsThatPass(): array
+    public static function dataSetsThatPass(): array
     {
         return [
             [['a' => 'arrays have', 'b' => 'string keys']],
@@ -61,7 +61,7 @@ class IsArrayTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatAreNotArraysOrLists(): array
+    public static function dataSetsThatAreNotArraysOrLists(): array
     {
         return [
             ['true', 'string'],

--- a/tests/Validator/Type/IsArrayTest.php
+++ b/tests/Validator/Type/IsArrayTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Type\IsArray;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Type\IsArray
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(IsArray::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class IsArrayTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'is an array with string keys';
@@ -29,7 +31,7 @@ class IsArrayTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new IsArray();
@@ -47,10 +49,8 @@ class IsArrayTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function arrayReturnsValid($input): void
     {
         $isArray = new IsArray();
@@ -72,10 +72,8 @@ class IsArrayTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatAreNotArraysOrLists
-     */
+    #[DataProvider('dataSetsThatAreNotArraysOrLists')]
+    #[Test]
     public function typesThatAreNotArraysReturnInvalid($input, $expectedVar): void
     {
         $isArray = new IsArray();
@@ -90,9 +88,7 @@ class IsArrayTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function listsReturnInvalid(): void
     {
         $input = ['this', 'is', 'a', 'list'];

--- a/tests/Validator/Type/IsBoolTest.php
+++ b/tests/Validator/Type/IsBoolTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Type\IsBool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Type\IsBool
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(IsBool::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class IsBoolTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'is a boolean';
@@ -29,7 +31,7 @@ class IsBoolTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new IsBool();
@@ -39,9 +41,7 @@ class IsBoolTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function booleanReturnValid(): void
     {
         $input = false;
@@ -64,10 +64,8 @@ class IsBoolTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function typesThatAreNotBooleanReturnInvalid($input, $expectedVar): void
     {
         $isBool = new IsBool();

--- a/tests/Validator/Type/IsBoolTest.php
+++ b/tests/Validator/Type/IsBoolTest.php
@@ -53,7 +53,7 @@ class IsBoolTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         return [
             ['true', 'string'],

--- a/tests/Validator/Type/IsFloatTest.php
+++ b/tests/Validator/Type/IsFloatTest.php
@@ -53,7 +53,7 @@ class IsFloatTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         return [
             [true, 'boolean'],

--- a/tests/Validator/Type/IsFloatTest.php
+++ b/tests/Validator/Type/IsFloatTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Type\IsFloat;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Type\IsFloat
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(IsFloat::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class IsFloatTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'is a float';
@@ -29,7 +31,7 @@ class IsFloatTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new IsFloat();
@@ -39,9 +41,7 @@ class IsFloatTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function floatReturnValid(): void
     {
         $input = 1.1;
@@ -64,10 +64,8 @@ class IsFloatTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function typesThatAreNotFloatReturnInvalid($input, $expectedVar): void
     {
         $isFloat = new IsFloat();

--- a/tests/Validator/Type/IsIntTest.php
+++ b/tests/Validator/Type/IsIntTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Type\IsInt;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Type\IsInt
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(IsInt::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class IsIntTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'is an integer';
@@ -29,7 +31,7 @@ class IsIntTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new IsInt();
@@ -39,9 +41,7 @@ class IsIntTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function integerReturnValid(): void
     {
         $input = 10;
@@ -64,10 +64,8 @@ class IsIntTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function typesThatAreNotIntegerReturnInvalid($input, $expectedVar): void
     {
         $isInt = new IsInt();

--- a/tests/Validator/Type/IsIntTest.php
+++ b/tests/Validator/Type/IsIntTest.php
@@ -53,7 +53,7 @@ class IsIntTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         return [
             ['1', 'string'],

--- a/tests/Validator/Type/IsListTest.php
+++ b/tests/Validator/Type/IsListTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Type\IsList;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Type\IsList
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(IsList::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class IsListTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'is a list';
@@ -29,7 +31,7 @@ class IsListTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new IsList();
@@ -47,10 +49,8 @@ class IsListTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatPass
-     */
+    #[DataProvider('dataSetsThatPass')]
+    #[Test]
     public function listReturnsValid($input): void
     {
         $isList = new IsList();
@@ -72,10 +72,8 @@ class IsListTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatAreNotArraysOrLists
-     */
+    #[DataProvider('dataSetsThatAreNotArraysOrLists')]
+    #[Test]
     public function typesThatAreNotArraysOrListsReturnInvalid($input, $expectedVar): void
     {
         $isList = new IsList();
@@ -90,9 +88,7 @@ class IsListTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function arrayReturnsInvalid(): void
     {
         $input = ['a' => 'this is', 'b' => 'an array'];

--- a/tests/Validator/Type/IsListTest.php
+++ b/tests/Validator/Type/IsListTest.php
@@ -39,7 +39,7 @@ class IsListTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsThatPass(): array
+    public static function dataSetsThatPass(): array
     {
         return [
             [['this', 'is', 'a', 'list']],
@@ -61,7 +61,7 @@ class IsListTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatAreNotArraysOrLists(): array
+    public static function dataSetsThatAreNotArraysOrLists(): array
     {
         return [
             ['true', 'string'],

--- a/tests/Validator/Type/IsNullTest.php
+++ b/tests/Validator/Type/IsNullTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Type\IsNull;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Type\IsNull
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(IsNull::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class IsNullTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'is null';
@@ -29,7 +31,7 @@ class IsNullTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new IsNull();
@@ -39,9 +41,7 @@ class IsNullTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function validForNullValue(): void
     {
         $sut = new IsNull();
@@ -63,10 +63,8 @@ class IsNullTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function invalidForNotNullTypes($input, $expectedVar): void
     {
         $sut = new IsNull();

--- a/tests/Validator/Type/IsNullTest.php
+++ b/tests/Validator/Type/IsNullTest.php
@@ -52,7 +52,7 @@ class IsNullTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         return [
             [true, 'boolean'],

--- a/tests/Validator/Type/IsNumberTest.php
+++ b/tests/Validator/Type/IsNumberTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Type\IsNumber;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Type\IsNumber
- * @uses   \Membrane\Result\Message
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(IsNumber::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class IsNumberTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'is a number';
@@ -29,7 +31,7 @@ class IsNumberTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new IsNumber();
@@ -103,10 +105,8 @@ class IsNumberTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToValidate
-     */
+    #[DataProvider('dataSetsToValidate')]
+    #[Test]
     public function validateTest(mixed $value, Result $expected): void
     {
         $sut = new IsNumber();

--- a/tests/Validator/Type/IsNumberTest.php
+++ b/tests/Validator/Type/IsNumberTest.php
@@ -39,7 +39,7 @@ class IsNumberTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsToValidate(): array
+    public static function dataSetsToValidate(): array
     {
         $class = new class {
         };

--- a/tests/Validator/Type/IsStringTest.php
+++ b/tests/Validator/Type/IsStringTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Type\IsString;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Type\IsString
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(IsString::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class IsStringTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'is a string';
@@ -29,7 +31,7 @@ class IsStringTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new IsString();
@@ -39,9 +41,7 @@ class IsStringTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function stringsReturnValid(): void
     {
         $input = 'this is a string';
@@ -64,10 +64,8 @@ class IsStringTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsThatFail
-     */
+    #[DataProvider('dataSetsThatFail')]
+    #[Test]
     public function typesThatAreNotStringReturnInvalid($input, $expectedVar): void
     {
         $isString = new IsString();

--- a/tests/Validator/Type/IsStringTest.php
+++ b/tests/Validator/Type/IsStringTest.php
@@ -53,7 +53,7 @@ class IsStringTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function dataSetsThatFail(): array
+    public static function dataSetsThatFail(): array
     {
         return [
             [true, 'boolean'],

--- a/tests/Validator/Utility/AllOfTest.php
+++ b/tests/Validator/Utility/AllOfTest.php
@@ -7,7 +7,6 @@ namespace Validator\Utility;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
-use Membrane\Validator;
 use Membrane\Validator\Utility\AllOf;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
@@ -25,11 +24,9 @@ use PHPUnit\Framework\TestCase;
  */
 class AllOfTest extends TestCase
 {
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
-        $validator = self::createMock(Validator::class);
-        $validator->method('__toString')
-            ->willReturn('condition');
+        $validator = new Passes();
 
         return [
             'no validators' => [
@@ -37,19 +34,18 @@ class AllOfTest extends TestCase
                 '',
             ],
             'single validator' => [
-                [$validator],
+                [new Passes()],
                 <<<END
                 must satisfy all of the following:
-                \t- condition.
+                \t- will return valid.
                 END,
             ],
             'multiple validators' => [
-                [$validator, $validator, $validator],
+                [new Fails(), new Indifferent(), new Passes()],
                 <<<END
                 must satisfy all of the following:
-                \t- condition.
-                \t- condition.
-                \t- condition.
+                \t- will return invalid.
+                \t- will return valid.
                 END,
             ],
         ];
@@ -68,7 +64,7 @@ class AllOfTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no validators' => [new AllOf()],

--- a/tests/Validator/Utility/AllOfTest.php
+++ b/tests/Validator/Utility/AllOfTest.php
@@ -11,23 +11,23 @@ use Membrane\Validator\Utility\AllOf;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Utility\AllOf
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(AllOf::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class AllOfTest extends TestCase
 {
     public static function dataSetsToConvertToString(): array
     {
-        $validator = new Passes();
-
         return [
             'no validators' => [
                 [],
@@ -51,10 +51,8 @@ class AllOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringtest(array $chain, string $expected): void
     {
         $sut = new AllOf(...$chain);
@@ -73,10 +71,8 @@ class AllOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(AllOf $sut): void
     {
         $actual = $sut->__toPHP();
@@ -84,9 +80,7 @@ class AllOfTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function noValidatorsReturnsNoResults(): void
     {
         $input = 'this can be anything';
@@ -98,9 +92,7 @@ class AllOfTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function singlePassReturnsValid(): void
     {
         $input = 'this can be anything';
@@ -112,9 +104,7 @@ class AllOfTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function singleFailsReturnsInvalid(): void
     {
         $input = 'this can be anything';
@@ -127,9 +117,7 @@ class AllOfTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function twoPassesReturnsValid(): void
     {
         $input = 'this can be anything';
@@ -141,9 +129,7 @@ class AllOfTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function twoFailsReturnsInvalid(): void
     {
         $input = 'this can be anything';
@@ -156,9 +142,7 @@ class AllOfTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function failAndPassesReturnsInvalid(): void
     {
         $input = 'this can be anything';
@@ -171,9 +155,7 @@ class AllOfTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function multipleFailsAndPassesReturnsInvalid(): void
     {
         $input = 'this can be anything';

--- a/tests/Validator/Utility/AnyOfTest.php
+++ b/tests/Validator/Utility/AnyOfTest.php
@@ -7,7 +7,6 @@ namespace Validator\Utility;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
-use Membrane\Validator;
 use Membrane\Validator\Utility\AnyOf;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
@@ -25,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AnyOfTest extends TestCase
 {
-    public function dataSetsToConvertToPHPString(): array
+    public static function dataSetsToConvertToPHPString(): array
     {
         return [
             'no validators' => [new AnyOf()],
@@ -45,31 +44,26 @@ class AnyOfTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsToConvertToString(): array
+    public static function dataSetsToConvertToString(): array
     {
-        $validator = self::createMock(Validator::class);
-        $validator->method('__toString')
-            ->willReturn('condition');
-
         return [
             'no validators' => [
                 [],
                 '',
             ],
             'single validator' => [
-                [$validator],
+                [new Passes()],
                 <<<END
                 must satisfy at least one of the following:
-                \t- condition.
+                \t- will return valid.
                 END,
             ],
             'multiple validators' => [
-                [$validator, $validator, $validator],
+                [new Fails(), new Indifferent(), new Passes()],
                 <<<END
                 must satisfy at least one of the following:
-                \t- condition.
-                \t- condition.
-                \t- condition.
+                \t- will return invalid.
+                \t- will return valid.
                 END,
             ],
         ];
@@ -88,7 +82,7 @@ class AnyOfTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function dataSetsToValidate(): array
+    public static function dataSetsToValidate(): array
     {
         return [
             'no validators' => [

--- a/tests/Validator/Utility/AnyOfTest.php
+++ b/tests/Validator/Utility/AnyOfTest.php
@@ -11,17 +11,19 @@ use Membrane\Validator\Utility\AnyOf;
 use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Utility\AnyOf
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(AnyOf::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class AnyOfTest extends TestCase
 {
     public static function dataSetsToConvertToPHPString(): array
@@ -33,10 +35,8 @@ class AnyOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToPHPString
-     */
+    #[DataProvider('dataSetsToConvertToPHPString')]
+    #[Test]
     public function toPHPTest(AnyOf $sut): void
     {
         $actual = $sut->__toPHP();
@@ -69,10 +69,8 @@ class AnyOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToConvertToString
-     */
+    #[DataProvider('dataSetsToConvertToString')]
+    #[Test]
     public function toStringtest(array $chain, string $expected): void
     {
         $sut = new AnyOf(...$chain);
@@ -151,10 +149,8 @@ class AnyOfTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToValidate
-     */
+    #[DataProvider('dataSetsToValidate')]
+    #[Test]
     public function validateTest(mixed $value, array $chain, Result $expected): void
     {
         $sut = new AnyOf(...$chain);

--- a/tests/Validator/Utility/FailsTest.php
+++ b/tests/Validator/Utility/FailsTest.php
@@ -39,7 +39,7 @@ class FailsTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSets(): array
+    public static function dataSets(): array
     {
         return [[1], [1.1], ['one'], [true], [null],];
     }

--- a/tests/Validator/Utility/FailsTest.php
+++ b/tests/Validator/Utility/FailsTest.php
@@ -8,17 +8,19 @@ use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
 use Membrane\Validator\Utility\Fails;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Fails::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class FailsTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'will return invalid';
@@ -29,7 +31,7 @@ class FailsTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new Fails();
@@ -44,10 +46,8 @@ class FailsTest extends TestCase
         return [[1], [1.1], ['one'], [true], [null],];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSets
-     */
+    #[DataProvider('dataSets')]
+    #[Test]
     public function failsAlwaysReturnsInvalid(mixed $input): void
     {
         $expected = Result::invalid($input, new MessageSet(null, new Message('I always fail', [])));

--- a/tests/Validator/Utility/IndifferentTest.php
+++ b/tests/Validator/Utility/IndifferentTest.php
@@ -6,15 +6,17 @@ namespace Validator\Utility;
 
 use Membrane\Result\Result;
 use Membrane\Validator\Utility\Indifferent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(Indifferent::class)]
+#[UsesClass(Result::class)]
 class IndifferentTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = '';
@@ -25,7 +27,7 @@ class IndifferentTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new Indifferent();
@@ -40,10 +42,8 @@ class IndifferentTest extends TestCase
         return [[1], [1.1], ['one'], [false], [null],];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSets
-     */
+    #[DataProvider('dataSets')]
+    #[Test]
     public function indifferentAlwaysReturnsNoResult(mixed $input): void
     {
         $sut = new Indifferent();

--- a/tests/Validator/Utility/IndifferentTest.php
+++ b/tests/Validator/Utility/IndifferentTest.php
@@ -35,7 +35,7 @@ class IndifferentTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSets(): array
+    public static function dataSets(): array
     {
         return [[1], [1.1], ['one'], [false], [null],];
     }

--- a/tests/Validator/Utility/NotTest.php
+++ b/tests/Validator/Utility/NotTest.php
@@ -41,7 +41,7 @@ class NotTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function toPHPProvider(): array
+    public static function toPHPProvider(): array
     {
         return [
             'fails' => [new Fails()],
@@ -63,7 +63,7 @@ class NotTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSetsToValidate(): array
+    public static function dataSetsToValidate(): array
     {
         return [
             'inverted invalid results will be valid' => [

--- a/tests/Validator/Utility/NotTest.php
+++ b/tests/Validator/Utility/NotTest.php
@@ -12,20 +12,22 @@ use Membrane\Validator\Utility\Fails;
 use Membrane\Validator\Utility\Indifferent;
 use Membrane\Validator\Utility\Not;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Utility\Not
- * @uses   \Membrane\Validator\Utility\Fails
- * @uses   \Membrane\Validator\Utility\Indifferent
- * @uses   \Membrane\Validator\Utility\Passes
- * @uses   \Membrane\Result\Result
- * @uses   \Membrane\Result\MessageSet
- * @uses   \Membrane\Result\Message
- */
+#[CoversClass(Not::class)]
+#[UsesClass(Fails::class)]
+#[UsesClass(Indifferent::class)]
+#[UsesClass(Passes::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
 class NotTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'must satisfy the opposite of the following: "inverted condition"';
@@ -50,10 +52,8 @@ class NotTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider toPHPProvider
-     */
+    #[DataProvider('toPHPProvider')]
+    #[Test]
     public function toPHPTest(Validator $invertedValidator): void
     {
         $sut = new Not($invertedValidator);
@@ -87,10 +87,8 @@ class NotTest extends TestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSetsToValidate
-     */
+    #[DataProvider('dataSetsToValidate')]
+    #[Test]
     public function notInvertsInnerValidator(mixed $input, Validator $invertedValidator, Result $expected): void
     {
         $sut = new Not($invertedValidator);

--- a/tests/Validator/Utility/PassesTest.php
+++ b/tests/Validator/Utility/PassesTest.php
@@ -35,7 +35,7 @@ class PassesTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public function dataSets(): array
+    public static function dataSets(): array
     {
         return [[1], [1.1], ['one'], [false], [null],];
     }

--- a/tests/Validator/Utility/PassesTest.php
+++ b/tests/Validator/Utility/PassesTest.php
@@ -6,15 +6,17 @@ namespace Validator\Utility;
 
 use Membrane\Result\Result;
 use Membrane\Validator\Utility\Passes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Membrane\Validator\Utility\Passes
- * @uses   \Membrane\Result\Result
- */
+#[CoversClass(Passes::class)]
+#[UsesClass(Result::class)]
 class PassesTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function toStringTest(): void
     {
         $expected = 'will return valid';
@@ -25,7 +27,7 @@ class PassesTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    /** @test */
+    #[Test]
     public function toPHPTest(): void
     {
         $sut = new Passes();
@@ -40,10 +42,8 @@ class PassesTest extends TestCase
         return [[1], [1.1], ['one'], [false], [null],];
     }
 
-    /**
-     * @test
-     * @dataProvider dataSets
-     */
+    #[DataProvider('dataSets')]
+    #[Test]
     public function passesAlwaysReturnsValid(mixed $input): void
     {
         $expected = Result::valid($input);

--- a/tests/fixtures/Attribute/ClassWithPromotedPropertyAfterSet.php
+++ b/tests/fixtures/Attribute/ClassWithPromotedPropertyAfterSet.php
@@ -13,9 +13,9 @@ use Membrane\Validator\Type\IsInt;
 #[SetFilterOrValidator(new WithNamedArguments(ClassWithPromotedPropertyAfterSet::class), Placement::AFTER)]
 class ClassWithPromotedPropertyAfterSet
 {
- public function __construct(
-     #[FilterOrValidator(new IsInt())]
-     public int $promotedProperty)
- {
- }
+    public function __construct(
+        #[FilterOrValidator(new IsInt())]
+        public int $promotedProperty
+    ) {
+    }
 }


### PR DESCRIPTION
- Refactor Tests to use static DataProviders
- Replace Test annotations with attributes
- Fix small errors in several __toString methods.