### PR TITLE
Improve CannotReadOpenAPI::invalidOpenAPI Exception

### DIFF
--- a/src/OpenAPI/Exception/CannotReadOpenAPI.php
+++ b/src/OpenAPI/Exception/CannotReadOpenAPI.php
@@ -40,9 +40,13 @@ class CannotReadOpenAPI extends RuntimeException
         return new self($message, self::FORMAT_NOT_SUPPORTED, $e);
     }
 
-    public static function invalidOpenAPI(string $fileName): self
+    public static function invalidOpenAPI(string $fileName, string ...$errors): self
     {
-        $message = sprintf('%s is not valid OpenAPI', $fileName);
+        $message = sprintf(
+            "%s is invalid OpenAPI due to the following:\n\t- %s",
+            $fileName,
+            implode("\n\t- ", $errors)
+        );
         return new self($message, self::INVALID_OPEN_API);
     }
 

--- a/src/OpenAPI/Reader/OpenAPIFileReader.php
+++ b/src/OpenAPI/Reader/OpenAPIFileReader.php
@@ -34,15 +34,16 @@ class OpenAPIFileReader
         $readFrom = $this->supportedFileTypes[$fileType] ?? throw CannotReadOpenAPI::fileTypeNotSupported($fileType);
 
         try {
-            $openAPI = $readFrom($absoluteFilePath);
+            $openApi = $readFrom($absoluteFilePath);
         } catch (\TypeError | TypeErrorException | ParseException $e) {
             throw CannotReadOpenAPI::cannotParse(pathinfo($absoluteFilePath, PATHINFO_BASENAME), $e);
         } catch (UnresolvableReferenceException $e) {
             throw CannotReadOpenAPI::unresolvedReference(pathinfo($absoluteFilePath, PATHINFO_BASENAME), $e);
         }
 
-        $openAPI->validate() ?: throw CannotReadOpenAPI::invalidOpenAPI(pathinfo($absoluteFilePath, PATHINFO_BASENAME));
+        assert($openApi instanceof OpenApi);
+        $openApi->validate() ?: throw CannotReadOpenAPI::invalidOpenAPI($absoluteFilePath, ...$openApi->getErrors());
 
-        return $openAPI;
+        return $openApi;
     }
 }

--- a/tests/OpenAPI/Reader/OpenAPIFileReaderTest.php
+++ b/tests/OpenAPI/Reader/OpenAPIFileReaderTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace OpenAPI\Reader;
 
 use cebe\openapi\exceptions\UnresolvableReferenceException;
+use cebe\openapi\Reader;
 use cebe\openapi\spec\OpenApi;
 use Membrane\OpenAPI\Exception\CannotReadOpenAPI;
 use Membrane\OpenAPI\Reader\OpenAPIFileReader;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Exception\ParseException;
 use TypeError;
@@ -21,7 +23,7 @@ class OpenAPIFileReaderTest extends TestCase
 {
     public const FIXTURES = __DIR__ . '/../../fixtures/OpenAPI/';
 
-    public static function dataSetsThatThrowExceptions(): array
+    public static function provideInvalidFiles(): array
     {
         return [
             'Non-existent file throws CannotReadOpenAPI::fileNotFound' => [
@@ -52,22 +54,43 @@ class OpenAPIFileReaderTest extends TestCase
                 CannotReadOpenAPI::cannotParse('invalid.yaml', new ParseException('')),
                 self::FIXTURES . 'invalid.yaml',
             ],
-            '.json file in invalid OpenAPI format throws CannotReadOpenAPI::invalidOpenAPI' => [
-                CannotReadOpenAPI::invalidOpenAPI('invalidAPI.json'),
-                self::FIXTURES . 'invalidAPI.json',
-            ],
-            '.yaml file in invalid OpenAPI format throws CannotReadOpenAPI::invalidOpenAPI' => [
-                CannotReadOpenAPI::invalidOpenAPI('invalidAPI.yaml'),
-                self::FIXTURES . 'invalidAPI.yaml',
-            ],
         ];
     }
 
-    #[DataProvider('dataSetsThatThrowExceptions')]
+    #[DataProvider('provideInvalidFiles')]
     #[Test]
     public function exceptionHandlingTest(CannotReadOpenAPI $expected, string $filePath): void
     {
         self::expectExceptionObject($expected);
+
+        (new OpenAPIFileReader())->readFromAbsoluteFilePath($filePath);
+    }
+
+    public static function provideInvalidOpenAPI(): array
+    {
+        return [
+            '.json file in invalid OpenAPI format throws CannotReadOpenAPI::invalidOpenAPI' => [
+                self::FIXTURES . 'invalidAPI.json',
+                (Reader::readFromJsonFile(self::FIXTURES . 'invalidAPI.json'))->getErrors(),
+            ],
+            '.yaml file in invalid OpenAPI format throws CannotReadOpenAPI::invalidOpenAPI' => [
+                self::FIXTURES . 'invalidAPI.yaml',
+                (Reader::readFromYamlFile(self::FIXTURES . 'invalidAPI.yaml'))->getErrors(),
+            ],
+        ];
+    }
+
+    #[Test]
+    #[TestDox('Invalid Open API Specs will throw Exceptions which contain reasons it was considered invalid')]
+    #[DataProvider('provideInvalidOpenAPI')]
+    public function throwsExceptionForInvalidOpenAPISpecs(string $filePath, array $errors): void
+    {
+        self::expectExceptionObject(
+            CannotReadOpenAPI::invalidOpenAPI(
+                $filePath,
+                ...$errors
+            )
+        );
 
         (new OpenAPIFileReader())->readFromAbsoluteFilePath($filePath);
     }


### PR DESCRIPTION
**Changes** CannotReadOpenAPI::invalidOpenAPI

## Previously:

```text
'openapi.yaml is not valid OpenAPI'
```

## Now

```text
'OpenAPI is invalid due to the following:
	- [] OpenApi is missing required property: paths
	- [/info] Info is missing required property: title'
```