### PR TITLE
Add ToPascalCase Filter

### DIFF
--- a/src/Filter/String/ToPascalCase.php
+++ b/src/Filter/String/ToPascalCase.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\String;
+
+use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+
+class ToPascalCase implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        if (!is_string($value)) {
+            return Result::invalid(
+                $value,
+                new MessageSet(
+                    null,
+                    new Message('ToPascalCase Filter expects a string value, %s passed instead', [gettype($value)])
+                )
+            );
+        }
+
+        $whiteSpaceSeperatedValue = preg_replace('#[\s\-_]#', ' ', $value);
+
+        assert(is_string($whiteSpaceSeperatedValue));
+        $capitilisedValue = ucwords($whiteSpaceSeperatedValue);
+
+        $pascalValue = preg_replace('#\s#', '', $capitilisedValue);
+
+        return Result::noResult($pascalValue);
+    }
+
+    public function __toString(): string
+    {
+        return 'Convert camelCase, kebab-case, snake-case, or plain text with whitespaces into PascalCase';
+    }
+
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+}

--- a/tests/Filter/String/ToPascalCaseTest.php
+++ b/tests/Filter/String/ToPascalCaseTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\String;
+
+use Membrane\Filter\String\ToPascalCase;
+use Membrane\Result\{Message, MessageSet, Result};
+use PHPUnit\Framework\Attributes\{CoversClass, DataProvider, Test, TestDox, UsesClass};
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ToPascalCase::class)]
+#[UsesClass(Message::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Result::class)]
+class ToPascalCaseTest extends TestCase
+{
+    public ToPascalCase $sut;
+
+    public function setUp(): void
+    {
+        $this->sut = new ToPascalCase();
+    }
+
+    #[Test, TestDox('toString method will describe what the Filter does')]
+    public function toStringTest(): void
+    {
+        $expected = 'Convert camelCase, kebab-case, snake-case, or plain text with whitespaces into PascalCase';
+
+        self::assertSame($expected, (string)$this->sut);
+    }
+
+    #[Test, TestDox('__toPHP() will return evaluable PHP code as a string')]
+    public function toPHPTest(): void
+    {
+        $expected = new ToPascalCase();
+
+        $actual = eval('return ' . $this->sut->__toPHP() . ';');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    #[Test, TestDox('It will return an invalid Result if it filters values that are not strings')]
+    public function returnsInvalidResultForNonStringValues(): void
+    {
+        $nonStringValue = 5;
+        $expected = Result::invalid(
+            $nonStringValue,
+            new MessageSet(
+                null,
+                new Message('ToPascalCase Filter expects a string value, %s passed instead', [gettype($nonStringValue)])
+            )
+        );
+
+        self::assertEquals($expected, $this->sut->filter($nonStringValue));
+    }
+
+    public static function provideStringsToFilter(): array
+    {
+        return [
+            'camelCase to CamelCase' => [
+                'camelCase',
+                Result::noResult('CamelCase'),
+            ],
+            'kebab-case to KebabCase' => [
+                'kebab-case',
+                Result::noResult('KebabCase'),
+            ],
+            'snake_case to SnakeCase' => [
+                'snake-case',
+                Result::noResult('SnakeCase'),
+            ],
+            'snake_____case to SnakeCase' => [
+                'snake-case',
+                Result::noResult('SnakeCase'),
+            ],
+            'plain text to PlainText' => [
+                'plain text',
+                Result::noResult('PlainText'),
+            ],
+            'plain 1text to Plain1Text' => [
+                'plain 1text',
+                Result::noResult('Plain1text'),
+            ],
+            'plain 1 text to Plain1Text' => [
+                'plain 1 text',
+                Result::noResult('Plain1Text'),
+            ],
+            'sTuPiD-_-cAsE to STuPiDCAsE' => [
+                'sTuPiD-_-cAsE',
+                Result::noResult('STuPiDCAsE'),
+            ],
+        ];
+    }
+
+    #[Test, TestDox('It filters strings to PascalCase')]
+    #[DataProvider('provideStringsToFilter')]
+    public function filtersStringsToPascalCase(string $value, Result $expected): void
+    {
+        self::assertEquals($expected, $this->sut->filter($value));
+    }
+}


### PR DESCRIPTION
Ensures all words begin with capital letters, characters treated as separators are:

- whitespace
- dash
- underscore