### PR TITLE
Add bin to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
     "phpstan/phpstan": "^1.8",
     "squizlabs/php_codesniffer": "^3.7",
     "guzzlehttp/psr7": "^2.4"
-  }
+  },
+  "bin": [
+    "bin/membrane"
+  ]
 }


### PR DESCRIPTION
Adds "bin" to composer.json so that commands can correctly be called from vendor/bin when imported as a package.