### PR TITLE
Add KeyValueSplit Filter

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -171,6 +171,60 @@ new Delete(...$fieldNames)
 |----------------|--------|
 | ...$fieldNames | string |
 
+**Example**
+
+```php
+use Membrane\Filter\Shape\Delete;
+
+$array = ['a' => 1, 'b' => 2, 'c' => 3]
+$delete = new Delete('a', 'b');
+
+$result = $delete->filter($array);
+
+echo json_encode($result->value);
+echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+```
+
+The above example will output the following
+
+```text
+["c":3]
+Result was valid
+```
+
+### Key Value Split
+
+Split a list into two, then combine to form a key-value array.
+
+```php
+new \Membrane\Filter\Shape\KeyValueSplit($keysFirst)
+```
+
+| Parameter  | Type |
+|------------|------|
+| $keysFirst | bool |
+
+**Example**
+
+```php
+use Membrane\Filter\Shape\KeyValueSplit;
+
+$list = ['a', 'one', 'b', 'two', 'c', 'three']
+$keyValueSplit = new KeyValueSplit();
+
+$result = $keyValueSplit->filter($list);
+
+echo json_encode($result->value);
+echo $result->isValid() ? 'Result was valid' : 'Result was invalid';
+```
+
+The above example will output the following
+
+```text
+["a":"one", "b":"two", "c":"three"]
+Result was valid
+```
+
 ### Nest
 
 Opposite of Pluck.

--- a/src/Filter/Shape/KeyValueSplit.php
+++ b/src/Filter/Shape/KeyValueSplit.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Shape;
+
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+
+class KeyValueSplit implements \Membrane\Filter
+{
+    public function __construct(
+        private readonly bool $keysFirst = true
+    ) {
+    }
+
+    public function filter(mixed $value): Result
+    {
+        if (!is_array($value) || !array_is_list($value)) {
+            return Result::invalid(
+                $value,
+                new MessageSet(
+                    null,
+                    new Message('KeyValueSplit Filter expects a list value, %s passed instead', [gettype($value)])
+                )
+            );
+        }
+
+        if (count($value) % 2 !== 0) {
+            return Result::invalid(
+                $value,
+                new MessageSet(
+                    null,
+                    new Message('KeyValueSplit requires a list with an even number of values', [])
+                )
+            );
+        }
+
+        $first = array_filter($value, fn($key) => $key % 2 === 0, ARRAY_FILTER_USE_KEY);
+        $second = array_filter($value, fn($key) => $key % 2 !== 0, ARRAY_FILTER_USE_KEY);
+
+        $filteredValue = $this->keysFirst ? array_combine($first, $second) : array_combine($second, $first);
+
+        return Result::valid($filteredValue);
+    }
+
+    public function __toString()
+    {
+        return 'split list into keys and values, then combine them into an array';
+    }
+
+    public function __toPHP(): string
+    {
+        return sprintf('new %s(%s)', self::class, $this->keysFirst ? 'true' : 'false');
+    }
+}

--- a/tests/Filter/Shape/KeyValueSplitTest.php
+++ b/tests/Filter/Shape/KeyValueSplitTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Filter\Shape;
+
+use Membrane\Filter\Shape\KeyValueSplit;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(KeyValueSplit::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
+class KeyValueSplitTest extends TestCase
+{
+
+    #[Test, TestDox('toString returns a plain english description of what this filter accomplishes')]
+    public function toStringTest(): void
+    {
+        $expected = 'split list into keys and values, then combine them into an array';
+        $sut = new KeyValueSplit();
+
+        self::assertSame($expected, (string)$sut);
+    }
+
+    public static function provideInstancesOfKeyValueSplit(): array
+    {
+        return [
+            'instance with $keysFirst = true' => [new KeyValueSplit(true)],
+            'instance with $keysFirst = false' => [new KeyValueSplit(false)],
+        ];
+    }
+
+    #[Test, TestDox('toPHP returns a string of PHP code that evaluates to an instance of itself')]
+    #[DataProvider('provideInstancesOfKeyValueSplit')]
+    public function toPHPReturnsEvaluablePHPStringToCreateSelf(KeyValueSplit $sut): void
+    {
+        self::assertEquals($sut, eval('return ' . $sut->__toPHP() . ';'));
+    }
+
+    public static function provideListsToFilter(): array
+    {
+        return [
+            'invalid result for values that are not lists' => [
+                true,
+                'string value',
+                Result::invalid(
+                    'string value',
+                    new MessageSet(
+                        null,
+                        new Message('KeyValueSplit Filter expects a list value, %s passed instead', ['string'])
+                    )
+                ),
+            ],
+            'invalid result for values that are arrays instead of lists' => [
+                true,
+                ['a' => 'an', 'b' => 'array'],
+                Result::invalid(
+                    ['a' => 'an', 'b' => 'array'],
+                    new MessageSet(
+                        null,
+                        new Message('KeyValueSplit Filter expects a list value, %s passed instead', ['array'])
+                    )
+                ),
+            ],
+            'invalid result for lists with an odd number of values' => [
+                true,
+                ['a', 'b', 'c'],
+                Result::invalid(
+                    ['a', 'b', 'c'],
+                    new MessageSet(
+                        null,
+                        new Message('KeyValueSplit requires a list with an even number of values', [])
+                    )
+                ),
+            ],
+            'valid result for minimal example (keys first)' => [
+                true,
+                ['a', 'one'],
+                Result::valid(['a' => 'one']),
+            ],
+            'valid result for minimal example (keys second)' => [
+                false,
+                ['a', 'one'],
+                Result::valid(['one' => 'a']),
+            ],
+            'valid result for large example (keys first)' => [
+                true,
+                ['a', 'one', 'b', 'two', 'c', 'three'],
+                Result::valid(['a' => 'one', 'b' => 'two', 'c' => 'three']),
+            ],
+            'valid result for large example (keys second)' => [
+                false,
+                ['a', 'one', 'b', 'two', 'c', 'three'],
+                Result::valid(['one' => 'a', 'two' => 'b', 'three' => 'c']),
+            ],
+
+        ];
+    }
+
+    #[Test, TestDox('filter splits the list into two, then combines them into a key-value array')]
+    #[DataProvider('provideListsToFilter')]
+    public function filterSplitsListsAndCombinesIntoArray(bool $keysFirst, mixed $value, Result $expected): void
+    {
+        $sut = new KeyValueSplit($keysFirst);
+
+        $actual = $sut->filter($value);
+
+        self::assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
Takes a list, splits it into two, then combines them to form a key-value array.
    - takes a bool arg to specify if keys are first or second. (i.e. even or odd index)

Useful for Objects given in queries.