### PR TITLE
Handle style (merge second)

### DIFF
--- a/src/OpenAPI/Builder/APIBuilder.php
+++ b/src/OpenAPI/Builder/APIBuilder.php
@@ -22,8 +22,12 @@ abstract class APIBuilder implements Builder
     private Objects $objectBuilder;
     private Strings $stringBuilder;
 
-    protected function fromSchema(Schema $schema, string $fieldName = '', bool $convertFromString = false): Processor
-    {
+    public function fromSchema(
+        Schema $schema,
+        string $fieldName = '',
+        bool $convertFromString = false,
+        ?string $style = null,
+    ): Processor {
         if ($schema->not !== null) {
             throw OpenAPI\Exception\CannotProcessOpenAPI::unsupportedKeyword('not');
         }
@@ -51,10 +55,10 @@ abstract class APIBuilder implements Builder
                 ->build(new OpenAPI\Specification\TrueFalse($fieldName, $schema, $convertFromString)),
 
             'array' => $this->getArrayBuilder()
-                ->build(new OpenAPI\Specification\Arrays($fieldName, $schema)),
+                ->build(new OpenAPI\Specification\Arrays($fieldName, $schema, $style)),
 
             'object' => $this->getObjectBuilder()
-                ->build(new OpenAPI\Specification\Objects($fieldName, $schema)),
+                ->build(new OpenAPI\Specification\Objects($fieldName, $schema, $style)),
 
             default => new Field('', new Utility\Passes()),
         };

--- a/src/OpenAPI/Builder/ParameterBuilder.php
+++ b/src/OpenAPI/Builder/ParameterBuilder.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Builder;
+
+use Membrane\Builder\Specification;
+use Membrane\OpenAPI\Specification\Parameter;
+use Membrane\Processor;
+
+class ParameterBuilder extends APIBuilder
+{
+    public function supports(Specification $specification): bool
+    {
+        return $specification instanceof Parameter;
+    }
+
+    public function build(Specification $specification): Processor
+    {
+        assert($specification instanceof Parameter);
+
+        return $this->fromParameter($specification);
+    }
+
+    public function fromParameter(
+        Parameter $specification,
+        bool $convertFromString = false
+    ): Processor {
+        $schemaProcessor = $this->fromSchema(
+            $specification->schema,
+            $specification->name,
+            $convertFromString,
+            $specification->style
+        );
+
+        return $schemaProcessor;
+    }
+}

--- a/src/OpenAPI/Exception/CannotProcessOpenAPI.php
+++ b/src/OpenAPI/Exception/CannotProcessOpenAPI.php
@@ -20,8 +20,9 @@ class CannotProcessOpenAPI extends RuntimeException
     public const INVALID_OPEN_API = 0;
     public const UNSUPPORTED_MEDIA_TYPES = 1;
     public const UNSUPPORTED_KEYWORD = 2;
-    public const REFERENCES_NOT_RESOLVED = 3;
-    public const MISSING_OPERATION_ID = 4;
+    public const UNSUPPORTED_STYLE = 3;
+    public const REFERENCES_NOT_RESOLVED = 4;
+    public const MISSING_OPERATION_ID = 5;
 
     public static function invalidOpenAPI(string $fileName, string ...$errors): self
     {
@@ -33,8 +34,14 @@ class CannotProcessOpenAPI extends RuntimeException
         return new self($message, self::INVALID_OPEN_API);
     }
 
-    /** @param string[] $mediaTypes */
-    public static function unsupportedMediaTypes(array $mediaTypes): self
+    public static function invalidStyleLocation(string $name, string $style, string $in): self
+    {
+        $message = sprintf('Parameter "%s" cannot have "style":"%s" with "in":"%s"', $style, $in, $name);
+        return new self($message, self::INVALID_OPEN_API);
+    }
+
+    /** @param $mediaTypes */
+    public static function unsupportedMediaTypes(string ...$mediaTypes): self
     {
         $supportedContentTypes = [
             'application/json',
@@ -53,6 +60,16 @@ class CannotProcessOpenAPI extends RuntimeException
     {
         $message = sprintf('Membrane does not currently support the keyword "%s"', $keyword);
         return new self($message, self::UNSUPPORTED_KEYWORD);
+    }
+
+    public static function unsupportedStyle(string $name, string $style): self
+    {
+        $message = sprintf(
+            'Membrane does not currently support "style":"%s" with "explode":true in parameter "%s"',
+            $style,
+            $name
+        );
+        return new self($message, self::UNSUPPORTED_STYLE);
     }
 
     public static function unresolvedReference(string $fileName, UnresolvableReferenceException $e): self

--- a/src/OpenAPI/Specification/Arrays.php
+++ b/src/OpenAPI/Specification/Arrays.php
@@ -4,24 +4,26 @@ declare(strict_types=1);
 
 namespace Membrane\OpenAPI\Specification;
 
-use cebe\openapi\spec\Reference;
-use cebe\openapi\spec\Schema;
+use cebe\openapi\spec as Cebe;
 use Membrane\OpenAPI\Exception\CannotProcessSpecification;
 
 class Arrays extends APISchema
 {
-    public readonly ?Schema $items;
+    public readonly ?Cebe\Schema $items;
     public readonly ?int $maxItems;
     public readonly int $minItems;
     public readonly bool $uniqueItems;
 
-    public function __construct(string $fieldName, Schema $schema)
-    {
+    public function __construct(
+        string $fieldName,
+        Cebe\Schema $schema,
+        public readonly ?string $style = null
+    ) {
         if ($schema->type !== 'array') {
             throw CannotProcessSpecification::mismatchedType(self::class, 'array', $schema->type);
         }
 
-        assert(!$schema->items instanceof Reference);
+        assert(!$schema->items instanceof Cebe\Reference);
         $this->items = $schema->items;
         $this->maxItems = $schema->maxItems;
         $this->minItems = $schema->minItems ?? 0;

--- a/src/OpenAPI/Specification/Objects.php
+++ b/src/OpenAPI/Specification/Objects.php
@@ -4,29 +4,31 @@ declare(strict_types=1);
 
 namespace Membrane\OpenAPI\Specification;
 
-use cebe\openapi\spec\Reference;
-use cebe\openapi\spec\Schema;
+use cebe\openapi\spec as Cebe;
 use Membrane\OpenAPI\Exception\CannotProcessSpecification;
 
 class Objects extends APISchema
 {
     // @TODO support minProperties and maxProperties
-    public readonly bool | Schema $additionalProperties;
-    /** @var Schema[] */
+    public readonly bool | Cebe\Schema $additionalProperties;
+    /** @var Cebe\Schema[] */
     public readonly array $properties;
     /** @var string[]|null */
     public readonly ?array $required;
 
-    public function __construct(string $fieldName, Schema $schema)
-    {
+    public function __construct(
+        string $fieldName,
+        Cebe\Schema $schema,
+        public readonly ?string $style = null,
+    ) {
         if ($schema->type !== 'object') {
             throw CannotProcessSpecification::mismatchedType(self::class, 'object', $schema->type);
         }
 
-        assert(!$schema->additionalProperties instanceof Reference);
+        assert(!$schema->additionalProperties instanceof Cebe\Reference);
         $this->additionalProperties = $schema->additionalProperties;
 
-        $this->properties = array_filter($schema->properties ?? [], fn($p) => $p instanceof Schema);
+        $this->properties = array_filter($schema->properties ?? [], fn($p) => $p instanceof Cebe\Schema);
 
         $this->required = $schema->required;
 

--- a/src/OpenAPI/Specification/OpenAPIRequest.php
+++ b/src/OpenAPI/Specification/OpenAPIRequest.php
@@ -52,7 +52,7 @@ class OpenAPIRequest implements Specification
             }
         }
 
-        throw CannotProcessOpenAPI::unsupportedMediaTypes(array_keys($content));
+        throw CannotProcessOpenAPI::unsupportedMediaTypes(...array_keys($content));
     }
 
     private function getOperation(Cebe\PathItem $pathItem, Method $method): Cebe\Operation

--- a/src/OpenAPI/Specification/OpenAPIResponse.php
+++ b/src/OpenAPI/Specification/OpenAPIResponse.php
@@ -29,7 +29,7 @@ class OpenAPIResponse implements Specification
 
         $schema = $content['application/json']?->schema
             ??
-            throw CannotProcessOpenAPI::unsupportedMediaTypes(array_keys($content));
+            throw CannotProcessOpenAPI::unsupportedMediaTypes(...array_keys($content));
 
         assert($schema instanceof Cebe\Schema);
         return $schema;

--- a/src/OpenAPI/Specification/Parameter.php
+++ b/src/OpenAPI/Specification/Parameter.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\OpenAPI\Specification;
+
+use cebe\openapi\spec as Cebe;
+use Membrane\Builder\Specification;
+use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
+
+class Parameter implements Specification
+{
+    public readonly string $name;
+    public readonly string $in;
+    public readonly bool $required;
+    public readonly string $style;
+    public readonly bool $explode;
+    public readonly Cebe\Schema $schema;
+
+    public function __construct(
+        Cebe\Parameter $parameter
+    ) {
+        $this->name = $parameter->name;
+        $this->in = $parameter->in;
+        $this->style = $parameter->style;
+
+        switch ($this->style) {
+            case 'matrix':
+            case 'label':
+                if ($this->in !== 'path') {
+                    throw CannotProcessOpenAPI::invalidStyleLocation($this->name, $this->style, $this->in);
+                }
+                break;
+            case 'form':
+                if (!in_array($this->in, ['query', 'cookie'])) {
+                    throw CannotProcessOpenAPI::invalidStyleLocation($this->name, $this->style, $this->in);
+                }
+                break;
+            case 'simple':
+                if (!in_array($this->in, ['path', 'header'])) {
+                    throw CannotProcessOpenAPI::invalidStyleLocation($this->name, $this->style, $this->in);
+                }
+                break;
+            case 'spaceDelimited':
+            case 'pipeDelimited':
+            case 'deepObject':
+                if ($this->in !== 'query') {
+                    throw CannotProcessOpenAPI::invalidStyleLocation($this->name, $this->style, $this->in);
+                }
+                break;
+        }
+
+        $this->explode = $parameter->explode;
+        $this->schema = $this->findSchema($parameter);
+
+        if ($this->explode === true && in_array($this->schema->type, ['array', 'object'])) {
+            throw CannotProcessOpenAPI::unsupportedStyle($this->name, $this->style);
+        }
+
+        $this->required = $parameter->required;
+    }
+
+    private function findSchema(Cebe\Parameter $parameter): Cebe\Schema
+    {
+        $schemaLocations = null;
+
+        if ($parameter->schema !== null) {
+            $schemaLocations = $parameter->schema;
+        }
+
+        if ($parameter->content !== []) {
+            $schemaLocations = $parameter->content['application/json']?->schema
+                ??
+                throw CannotProcessOpenAPI::unsupportedMediaTypes(...array_keys($parameter->content));
+        }
+
+        // Cebe library already validates that parameters MUST have either a schema or content but not both.
+        assert($schemaLocations instanceof Cebe\Schema);
+
+        return $schemaLocations;
+    }
+}

--- a/tests/Console/Command/CacheOpenAPIProcessorsTest.php
+++ b/tests/Console/Command/CacheOpenAPIProcessorsTest.php
@@ -8,6 +8,7 @@ use Membrane;
 use Membrane\Console\Command\CacheOpenAPIProcessors;
 use Membrane\Console\Template;
 use Membrane\Filter\String\AlphaNumeric;
+use Membrane\Filter\String\Explode;
 use Membrane\Filter\String\ToPascalCase;
 use Membrane\Filter\Type as TypeFilter;
 use Membrane\OpenAPI\Builder as Builder;
@@ -52,6 +53,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[UsesClass(Membrane\Result\Result::class)]
 #[UsesClass(AlphaNumeric::class)]
 #[UsesClass(ToPascalCase::class)]
+#[UsesClass(Explode::class)]
 #[UsesClass(TypeFilter\ToInt::class)]
 #[UsesClass(Specification\APISchema::class)]
 #[UsesClass(Specification\Arrays::class)]

--- a/tests/Console/Service/CacheOpenAPIProcessorsTest.php
+++ b/tests/Console/Service/CacheOpenAPIProcessorsTest.php
@@ -7,7 +7,7 @@ namespace Membrane\Tests\Console\Service;
 use Membrane;
 use Membrane\Console\Service\CacheOpenAPIProcessors;
 use Membrane\Console\Template;
-use Membrane\Filter\{String\AlphaNumeric, String\ToPascalCase, Type as TypeFilter};
+use Membrane\Filter\{String\AlphaNumeric, String\Explode, String\ToPascalCase, Type as TypeFilter};
 use Membrane\OpenAPI\Builder as Builder;
 use Membrane\OpenAPI\Builder\OpenAPIRequestBuilder;
 use Membrane\OpenAPI\ContentType;
@@ -49,6 +49,7 @@ use Psr\Log\LoggerInterface;
 #[UsesClass(Membrane\Result\Result::class)]
 #[UsesClass(AlphaNumeric::class)]
 #[UsesClass(ToPascalCase::class)]
+#[UsesClass(Explode::class)]
 #[UsesClass(TypeFilter\ToInt::class)]
 #[UsesClass(Specification\APISchema::class)]
 #[UsesClass(Specification\Arrays::class)]

--- a/tests/OpenAPI/Builder/ParameterBuilderTest.php
+++ b/tests/OpenAPI/Builder/ParameterBuilderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Builder;
+
+use cebe\openapi\Reader;
+use cebe\openapi\spec as Cebe;
+use Membrane\Builder\Specification;
+use Membrane\Filter\String\Explode;
+use Membrane\OpenAPI\Builder as OpenAPIBuilder;
+use Membrane\OpenAPI\Specification as OpenAPISpecification;
+use Membrane\Processor;
+use Membrane\Validator\Type\IsInt;
+use Membrane\Validator\Type\IsList;
+use Membrane\Validator\Type\IsString;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OpenAPIBuilder\ParameterBuilder::class)]
+#[CoversClass(OpenAPIBuilder\APIBuilder::class)]
+#[UsesClass(OpenAPIBuilder\Arrays::class)]
+#[UsesClass(OpenAPIBuilder\Numeric::class)]
+#[UsesClass(OpenAPIBuilder\Strings::class)]
+#[UsesClass(OpenAPISpecification\Parameter::class)]
+#[UsesClass(OpenAPISpecification\APISchema::class)]
+#[UsesClass(OpenAPISpecification\Arrays::class)]
+#[UsesClass(OpenAPISpecification\Numeric::class)]
+#[UsesClass(OpenAPISpecification\Strings::class)]
+#[UsesClass(Explode::class)]
+#[UsesClass(Processor\BeforeSet::class)]
+#[UsesClass(Processor\Collection::class)]
+#[UsesClass(Processor\Field::class)]
+class ParameterBuilderTest extends TestCase
+{
+    private OpenAPIBuilder\ParameterBuilder $sut;
+
+    protected function setUp(): void
+    {
+        $this->sut = new OpenAPIBuilder\ParameterBuilder();
+    }
+
+    #[Test, TestDox('It does not support any Specifications other than Parameter')]
+    public function doesNotSupportSpecificationsOtherThanParameter(): void
+    {
+        self::assertFalse($this->sut->supports(self::createStub(Specification::class)));
+    }
+
+    #[Test, TestDox('It supports the Parameter Specification')]
+    public function supportsTheParameterSpecification(): void
+    {
+        self::assertTrue($this->sut->supports(self::createStub(OpenAPISpecification\Parameter::class)));
+    }
+
+    public static function provideParameterSpecificationsToBuildFrom(): array
+    {
+        return [
+            [
+                Reader::readFromJson(
+                    json_encode([
+                        'name' => 'id',
+                        'in' => 'path',
+                        'schema' => [
+                            'type' => 'integer',
+                        ],
+                    ]),
+                    Cebe\Parameter::class
+                ),
+                new Processor\Field('id', new IsInt()),
+            ],
+            [
+                Reader::readFromJson(
+                    json_encode([
+                        'name' => 'tags',
+                        'in' => 'query',
+                        'style' => 'spaceDelimited',
+                        'explode' => false,
+                        'schema' => [
+                            'type' => 'array',
+                            'items' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                    ]),
+                    Cebe\Parameter::class
+                ),
+                new Processor\Collection(
+                    'tags',
+                    new Processor\BeforeSet(new Explode(' '), new IsList()),
+                    new Processor\Field('', new IsString())
+                ),
+            ],
+        ];
+    }
+
+    #[Test, TestDox('It Builds a Processor that can validate against the Parameter Specification')]
+    #[DataProvider('provideParameterSpecificationsToBuildFrom')]
+    public function itBuildsProcessorsForParameters(Cebe\Parameter $parameter, Processor $expectedProcessor): void
+    {
+        $actualProcessor = $this->sut->build(new OpenAPISpecification\Parameter($parameter));
+
+        self::assertEquals($expectedProcessor, $actualProcessor);
+    }
+}

--- a/tests/OpenAPI/Builder/RequestBuilderTest.php
+++ b/tests/OpenAPI/Builder/RequestBuilderTest.php
@@ -102,7 +102,7 @@ class RequestBuilderTest extends TestCase
 
         $mediaTypes = array_keys($openApi->paths->getPath('/requestpathexceptions')->post->parameters[0]->content);
 
-        self::expectExceptionObject(CannotProcessOpenAPI::unsupportedMediaTypes($mediaTypes));
+        self::expectExceptionObject(CannotProcessOpenAPI::unsupportedMediaTypes(...$mediaTypes));
 
         $sut->build($specification);
     }
@@ -544,7 +544,7 @@ class RequestBuilderTest extends TestCase
                     'http://petstore.swagger.io/api/pets',
                     Method::GET
                 ),
-                new ServerRequest('get', 'http://petstore.swagger.io/api/pets?limit=5&tags[]=cat&tags[]=tabby'),
+                new ServerRequest('get', 'http://petstore.swagger.io/api/pets?limit=5&tags=cat,tabby'),
                 Result::valid(
                     [
                         'request' => ['method' => 'get', 'operationId' => 'findPets'],

--- a/tests/OpenAPI/Specification/OpenAPIRequestTest.php
+++ b/tests/OpenAPI/Specification/OpenAPIRequestTest.php
@@ -51,7 +51,7 @@ class OpenAPIRequestTest extends TestCase
         $pathParameterExtractor = new PathParameterExtractor('/path');
 
         self::expectExceptionObject(
-            CannotProcessOpenAPI::unsupportedMediaTypes(array_keys($pathItem->put->requestBody->content))
+            CannotProcessOpenAPI::unsupportedMediaTypes(...array_keys($pathItem->put->requestBody->content))
         );
 
         new OpenAPIRequest($pathParameterExtractor, $pathItem, Method::PUT);

--- a/tests/OpenAPI/Specification/OpenAPIResponseTest.php
+++ b/tests/OpenAPI/Specification/OpenAPIResponseTest.php
@@ -28,7 +28,7 @@ class OpenAPIResponseTest extends TestCase
             ],
         ]);
 
-        self::expectExceptionObject(CannotProcessOpenAPI::unsupportedMediaTypes(array_keys($response->content)));
+        self::expectExceptionObject(CannotProcessOpenAPI::unsupportedMediaTypes(...array_keys($response->content)));
 
         new OpenAPIResponse('testOperation', '200', $response);
     }

--- a/tests/OpenAPI/Specification/ParameterTest.php
+++ b/tests/OpenAPI/Specification/ParameterTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPI\Specification;
+
+use cebe\openapi\spec as Cebe;
+use Membrane\OpenAPI\Exception\CannotProcessOpenAPI;
+use Membrane\OpenAPI\Specification\Parameter;
+use Membrane\OpenAPIReader\OpenAPIVersion;
+use Membrane\OpenAPIReader\Reader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Parameter::class)]
+#[CoversClass(CannotProcessOpenAPI::class)]
+class ParameterTest extends TestCase
+{
+    #[Test, TestDox('Exceptions will be thrown for parameters with unsupported content types')]
+    public function throwsExceptionForUnsupportedContentTypes(): void
+    {
+        $openAPIFilePath = __DIR__ . '/../../fixtures/OpenAPI/noReferences.json';
+        $openApi = (new Reader([OpenAPIVersion::Version_3_0]))->readFromAbsoluteFilePath($openAPIFilePath);
+        $parameter = $openApi->paths->getPath('/requestpathexceptions')->post->parameters[0];
+
+        self::expectExceptionObject(CannotProcessOpenAPI::unsupportedMediaTypes('application/pdf'));
+
+        new Parameter($parameter);
+    }
+
+    public static function provideParametersWithInvalidStyleLocations(): array
+    {
+        return [
+            '"style": "matrix" outside of "path"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'query',
+                    'style' => 'matrix',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                CannotProcessOpenAPI::invalidStyleLocation('id', 'matrix', 'query'),
+            ],
+            '"style": "label" outside of "path"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'query',
+                    'style' => 'label',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                CannotProcessOpenAPI::invalidStyleLocation('id', 'label', 'query'),
+            ],
+            '"style":"form" outside of "query" or "cookie"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'path',
+                    'style' => 'form',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                CannotProcessOpenAPI::invalidStyleLocation('id', 'form', 'path'),
+            ],
+            '"style":"simple" outside of "path" or "header"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'query',
+                    'style' => 'simple',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                CannotProcessOpenAPI::invalidStyleLocation('id', 'simple', 'query'),
+            ],
+            '"style":"spaceDelimited" outside of "query"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'path',
+                    'style' => 'spaceDelimited',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                CannotProcessOpenAPI::invalidStyleLocation('id', 'spaceDelimited', 'path'),
+            ],
+            '"style":"pipeDelimited" outside of "query"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'path',
+                    'style' => 'pipeDelimited',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                CannotProcessOpenAPI::invalidStyleLocation('id', 'pipeDelimited', 'path'),
+            ],
+            '"style":"deepObject" outside of "query"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'path',
+                    'style' => 'deepObject',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                CannotProcessOpenAPI::invalidStyleLocation('id', 'deepObject', 'path'),
+            ],
+        ];
+    }
+
+    #[Test, TestDox('throws CannotProcessOpenAPI if "style" is invalid based on "in" value')]
+    #[DataProvider('provideParametersWithInvalidStyleLocations')]
+    public function throwsExceptionForInvalidStyleLocations(
+        Cebe\Parameter $parameter,
+        CannotProcessOpenAPI $expected
+    ): void {
+        self::expectExceptionObject($expected);
+
+        new Parameter($parameter);
+    }
+
+    #[Test, TestDox('throws CannotProcessOpenAPI if "explode":true if the parameter is of "type": "array" or "object"')]
+    public function throwsExceptionForExplodeOnArraysAndObjects(): void
+    {
+        $parameter = new Cebe\Parameter([
+            'name' => 'tags',
+            'in' => 'query',
+            'explode' => true,
+            'schema' => new Cebe\Schema(['type' => 'array']),
+        ]);
+
+        self::expectExceptionObject(CannotProcessOpenAPI::unsupportedStyle('tags', 'form'));
+
+        new Parameter($parameter);
+    }
+
+    public static function provideValidParameters(): array
+    {
+        return [
+            '"style": "matrix" in "path"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'path',
+                    'required' => true,
+                    'style' => 'matrix',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                [
+                    'name' => 'id',
+                    'in' => 'path',
+                    'required' => true,
+                    'style' => 'matrix',
+                    'explode' => false,
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ],
+            ],
+            '"style": "label" in "path"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'path',
+                    'required' => true,
+                    'style' => 'label',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                [
+                    'name' => 'id',
+                    'in' => 'path',
+                    'required' => true,
+                    'style' => 'label',
+                    'explode' => false,
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ],
+            ],
+            '"style":"form" in "query"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'query',
+                    'required' => false,
+                    'style' => 'form',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                [
+                    'name' => 'id',
+                    'in' => 'query',
+                    'required' => false,
+                    'style' => 'form',
+                    'explode' => true,
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ],
+            ],
+            '"style":"simple" in "path"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'path',
+                    'required' => true,
+                    'style' => 'simple',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                [
+                    'name' => 'id',
+                    'in' => 'path',
+                    'required' => true,
+                    'style' => 'simple',
+                    'explode' => false,
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ],
+            ],
+            '"style":"spaceDelimited" in "query"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'query',
+                    'required' => false,
+                    'style' => 'spaceDelimited',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                [
+                    'name' => 'id',
+                    'in' => 'query',
+                    'required' => false,
+                    'style' => 'spaceDelimited',
+                    'explode' => false,
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ],
+            ],
+            '"style":"pipeDelimited" in "query"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'query',
+                    'required' => false,
+                    'style' => 'pipeDelimited',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                [
+                    'name' => 'id',
+                    'in' => 'query',
+                    'required' => false,
+                    'style' => 'pipeDelimited',
+                    'explode' => false,
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ],
+            ],
+            '"style":"deepObject" in "query"' => [
+                new Cebe\Parameter([
+                    'name' => 'id',
+                    'in' => 'query',
+                    'required' => false,
+                    'style' => 'deepObject',
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ]),
+                [
+                    'name' => 'id',
+                    'in' => 'query',
+                    'required' => false,
+                    'style' => 'deepObject',
+                    'explode' => false,
+                    'schema' => new Cebe\Schema(['type' => 'integer']),
+                ],
+            ],
+        ];
+    }
+
+    #[Test, TestDox('It will construct itself from valid Parameters')]
+    #[DataProvider('provideValidParameters')]
+    public function constructsAParameterSpecificationFromValidParameters(
+        Cebe\Parameter $parameter,
+        array $expectedProperties
+    ): void {
+        $sut = new Parameter($parameter);
+
+        foreach ($expectedProperties as $key => $value) {
+            self::assertEquals($value, $sut->$key, sprintf("'%s' doesn't match expected", $key));
+        }
+    }
+}

--- a/tests/fixtures/OpenAPI/docs/petstore-expanded.json
+++ b/tests/fixtures/OpenAPI/docs/petstore-expanded.json
@@ -32,6 +32,7 @@
             "description": "tags to filter by",
             "required": false,
             "style": "form",
+            "explode": false,
             "schema": {
               "type": "array",
               "items": {
@@ -44,6 +45,7 @@
             "in": "query",
             "description": "maximum number of results to return",
             "required": false,
+            "explode": false,
             "schema": {
               "type": "integer",
               "format": "int32"

--- a/tests/fixtures/OpenAPI/docs/petstore.yaml
+++ b/tests/fixtures/OpenAPI/docs/petstore.yaml
@@ -18,6 +18,7 @@ paths:
           in: query
           description: How many items to return at one time (max 100)
           required: false
+          explode: false
           schema:
             type: integer
             maximum: 100

--- a/tests/fixtures/OpenAPI/hatstore.json
+++ b/tests/fixtures/OpenAPI/hatstore.json
@@ -15,6 +15,7 @@
             "description": "tags to filter by",
             "required": false,
             "style": "form",
+            "explode": false,
             "schema": {
               "type": "array",
               "items": {


### PR DESCRIPTION
close #60 

Currently throws exceptions for the petstore examples (since they have default query style of form, with explode:true