### PR TITLE
Fixes for CLI command when used as composer package

### DIFF
--- a/bin/membrane
+++ b/bin/membrane
@@ -1,10 +1,21 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__ . '/../vendor/autoload.php';
+$autoloadFiles = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php'
+];
+
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        require_once $autoloadFile;
+        break;
+    }
+}
 
 use Membrane\Console\Command\CacheOpenAPIProcessors;
 use Membrane\OpenAPIRouter\Console\Commands\CacheOpenAPI;
+use Membrane\OpenAPIRouter\Console\Commands\CacheOpenAPIRoutes;
 use Symfony\Component\Console\Application;
 
 $application = new Application();
@@ -15,6 +26,10 @@ if (class_exists(CacheOpenAPIProcessors::class)) {
 
 if (class_exists(CacheOpenAPI::class)) {
     $application->add(new CacheOpenAPI());
+}
+
+if (class_exists(CacheOpenAPIRoutes::class)) {
+    $application->add(new CacheOpenAPIRoutes());
 }
 
 $application->run();


### PR DESCRIPTION
- Adds fallback paths for composer autoloader to ensure it works properly regardless of where the composer bin directory is located 

- Adds support for renamed cli command in router 0.2