### PR TITLE
Add strict mode to date string validator,

### DIFF
--- a/src/OpenAPI/Builder/Strings.php
+++ b/src/OpenAPI/Builder/Strings.php
@@ -31,11 +31,11 @@ class Strings extends APIBuilder
         }
 
         if ($specification->format === 'date') {
-            $chain[] = new DateString('Y-m-d');
+            $chain[] = new DateString('Y-m-d', true);
         }
 
         if ($specification->format === 'date-time') {
-            $chain[] = new DateString('Y-m-d\TH:i:sP');
+            $chain[] = new DateString('Y-m-d\TH:i:sP', true);
         }
 
         if ($specification->minLength > 0 || $specification->maxLength !== null) {

--- a/src/Validator/String/DateString.php
+++ b/src/Validator/String/DateString.php
@@ -12,7 +12,7 @@ use Membrane\Validator;
 
 class DateString implements Validator
 {
-    public function __construct(private readonly string $format)
+    public function __construct(private readonly string $format, private readonly bool $strict = false)
     {
     }
 
@@ -23,7 +23,7 @@ class DateString implements Validator
 
     public function __toPHP(): string
     {
-        return sprintf('new %s("%s")', self::class, $this->format);
+        return sprintf('new %s("%s", %s)', self::class, $this->format, $this->strict ? 'true' : 'false');
     }
 
     public function validate(mixed $value): Result
@@ -37,6 +37,11 @@ class DateString implements Validator
 
         if ($dateTime === false) {
             $message = new Message('String does not match the required format %s', [$this->format]);
+            return Result::invalid($value, new MessageSet(null, $message));
+        }
+
+        if ($this->strict && $value !== $dateTime->format($this->format)) {
+            $message = new Message('String does not represent a valid date in format %s', [$this->format]);
             return Result::invalid($value, new MessageSet(null, $message));
         }
 

--- a/tests/OpenAPI/Builder/OpenAPIResponseBuilderTest.php
+++ b/tests/OpenAPI/Builder/OpenAPIResponseBuilderTest.php
@@ -329,7 +329,7 @@ class OpenAPIResponseBuilderTest extends TestCase
                     '223',
                     $noReferences->paths->getPath('/responsepath')->get->responses->getResponse('223')
                 ),
-                new Field('', new IsString(), new DateString('Y-m-d')),
+                new Field('', new IsString(), new DateString('Y-m-d', true)),
             ],
             'string, date-time format' => [
                 new OpenAPIResponse(
@@ -337,7 +337,7 @@ class OpenAPIResponseBuilderTest extends TestCase
                     '224',
                     $noReferences->paths->getPath('/responsepath')->get->responses->getResponse('224')
                 ),
-                new Field('', new IsString(), new DateString(DATE_ATOM)),
+                new Field('', new IsString(), new DateString(DATE_ATOM, true)),
             ],
             'string, minLength' => [
                 new OpenAPIResponse(

--- a/tests/OpenAPI/Builder/ResponseBuilderTest.php
+++ b/tests/OpenAPI/Builder/ResponseBuilderTest.php
@@ -281,7 +281,6 @@ class ResponseBuilderTest extends TestCase
                         new Maximum(100),
                         new Minimum(0, true),
                         new MultipleOf(3)
-
                     )
                 ),
             ],
@@ -377,7 +376,7 @@ class ResponseBuilderTest extends TestCase
                     Method::GET,
                     '223'
                 ),
-                new Field('', new IsString(), new DateString('Y-m-d')),
+                new Field('', new IsString(), new DateString('Y-m-d', true)),
             ],
             'string, date-time format' => [
                 new Response(
@@ -386,7 +385,7 @@ class ResponseBuilderTest extends TestCase
                     Method::GET,
                     '224'
                 ),
-                new Field('', new IsString(), new DateString(DATE_ATOM)),
+                new Field('', new IsString(), new DateString(DATE_ATOM, true)),
             ],
             'string, minLength' => [
                 new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '225'),

--- a/tests/OpenAPI/Builder/StringsTest.php
+++ b/tests/OpenAPI/Builder/StringsTest.php
@@ -61,11 +61,11 @@ class StringsTest extends TestCase
             ],
             'date input' => [
                 new Specification\Strings('', new Schema(['type' => 'string', 'format' => 'date',])),
-                new Field('', new IsString(), new DateString('Y-m-d')),
+                new Field('', new IsString(), new DateString('Y-m-d', true)),
             ],
             'date-time input' => [
                 new Specification\Strings('', new Schema(['type' => 'string', 'format' => 'date-time',])),
-                new Field('', new IsString(), new DateString('Y-m-d\TH:i:sP')),
+                new Field('', new IsString(), new DateString('Y-m-d\TH:i:sP', true)),
             ],
             'detailed input' => [
                 new Specification\Strings(
@@ -89,7 +89,7 @@ class StringsTest extends TestCase
                         '',
                         new IsString(),
                         new Contained(['1970/01/01', null]),
-                        new DateString('Y-m-d'),
+                        new DateString('Y-m-d', true),
                         new Length(0, 100),
                         new Regex('#\#.+#u')
                     )

--- a/tests/Validator/String/DateStringTest.php
+++ b/tests/Validator/String/DateStringTest.php
@@ -11,6 +11,7 @@ use Membrane\Validator\String\DateString;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
@@ -111,5 +112,28 @@ class DateStringTest extends TestCase
         $result = $dateString->validate($input);
 
         self::assertEquals($expected, $result);
+    }
+
+    #[Test, TestDox('Tests that a date which matches the format string but is otherwise invalid fails validation')]
+    public function testInvalidDateFailsValidationInStrictMode(): void
+    {
+        $format = 'Y-m-d';
+        $value = '2022-13-05';
+
+        $expectedMessage = new Message('String does not represent a valid date in format %s', [$format]);
+        $expected = Result::invalid($value, new MessageSet(null, $expectedMessage));
+
+        $sut = new DateString($format, true);
+
+        $result = $sut->validate($value);
+        self::assertEquals($expected, $result);
+    }
+
+    #[Test, TestDox('Tests a format which cannot be used in strict mode still validates properly in non-strict mode')]
+    public function testDatesPassInNonStrictMode(): void
+    {
+        $sut = new DateString('Y-m-d|', false);
+
+        self::assertTrue($sut->validate('2022-05-13')->isValid());
     }
 }


### PR DESCRIPTION
Adds a strict mode which validates that the date string can be turned into the expected date. 

eg 2022-13-05 passes the date format Y-m-d but creates the date 2023-01-05 

Strict mode confirms that the date not only matches the format but comes out the same when formatted that way from the date time object. This check will fail if PHP's datetime object changes the date value from what was passed in order to turn it into a valid date. 

This behaviour cannot be the default as some date format strings eg Y-m-d| do not produce the same result when used in \DateTime->format() calls.