### PR TITLE
Allow psr-http-message ^1.0 || ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": "^8.1.0",
     "cebe/php-openapi": "^1.7",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^1.0 || ^2.0",
     "psr/log": "^2.0 || ^3.0",
     "symfony/console": "^6.2",
     "membrane/openapi-router": "^0.1.0 || ^0.2.0"


### PR DESCRIPTION
2.0 was released as of April this year, the only backwards compatible change appears to be that it now requires PHP 7.2.0 or later (which is still well below our minimum requirement).