### PR TITLE
Change PathMatcherTest to assertSame instead of assertEquals

### DIFF
--- a/tests/OpenAPI/ExtractPathParameters/PathMatcherTest.php
+++ b/tests/OpenAPI/ExtractPathParameters/PathMatcherTest.php
@@ -165,7 +165,7 @@ class PathMatcherTest extends TestCase
             [
                 '/pets/{id}/photos/{photo_id}',
                 '/pets/1/photos/5',
-                ['id' => 1, 'photo_id' => 5],
+                ['id' => '1', 'photo_id' => '5'],
             ],
         ];
     }
@@ -178,7 +178,7 @@ class PathMatcherTest extends TestCase
 
         $actual = $sut->getPathParams($requestUrl);
 
-        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
 }


### PR DESCRIPTION
assertEquals was allowing one test to pass when it shouldn't have.

Updated to require expected to be identical to actual