### PR TITLE
Remove checks now performed by reader

### DIFF
--- a/src/OpenAPI/Builder/OpenAPIRequestBuilder.php
+++ b/src/OpenAPI/Builder/OpenAPIRequestBuilder.php
@@ -91,21 +91,12 @@ class OpenAPIRequestBuilder extends APIBuilder
 
     private function findSchema(Parameter $parameter): Schema
     {
-        $schemaLocations = null;
+        // Membrane\OpenAPIReader\Reader ensures parameters have a schema xor non-empty content
+        $schema = $parameter->schema ??
+            $parameter->content['application/json']?->schema ??
+            throw CannotProcessOpenAPI::unsupportedMediaTypes(array_keys($parameter->content));
 
-        if ($parameter->schema !== null) {
-            $schemaLocations = $parameter->schema;
-        }
-
-        if ($parameter->content !== []) {
-            $schemaLocations = $parameter->content['application/json']?->schema
-                ??
-                throw CannotProcessOpenAPI::unsupportedMediaTypes(array_keys($parameter->content));
-        }
-
-        // Cebe library already validates that parameters MUST have either a schema or content but not both.
-        assert($schemaLocations instanceof Schema);
-
-        return $schemaLocations;
+        assert($schema instanceof Schema);
+        return $schema;
     }
 }

--- a/tests/fixtures/OpenAPI/noReferences.json
+++ b/tests/fixtures/OpenAPI/noReferences.json
@@ -148,20 +148,6 @@
       }
     },
     "/requestpathexceptions": {
-      "get": {
-        "operationId": "no-schema-nor-content",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        }
-      },
       "post": {
         "operationId": "unsupported-content-type",
         "parameters": [


### PR DESCRIPTION
The reader checks all parameters contain Schemas xor Content now. 

Membrane core no longer needs to check this