### PR TITLE
Membrane without default (merge first)

### DIFF
--- a/src/Membrane.php
+++ b/src/Membrane.php
@@ -6,7 +6,6 @@ namespace Membrane;
 
 use Membrane\Attribute\Builder as AttributeBuilder;
 use Membrane\Builder\Builder;
-use Membrane\Builder\Builder as BuilderInterface;
 use Membrane\Builder\Specification;
 use Membrane\OpenAPI\Builder\RequestBuilder;
 use Membrane\OpenAPI\Builder\ResponseBuilder;
@@ -16,15 +15,29 @@ use RuntimeException;
 
 final class Membrane
 {
-    /** @var BuilderInterface[] */
-    private array $builders = [];
+    private bool $allowDefaults = true;
+
+    /** @var Builder[] */
+    private readonly array $builders;
+    /** @var Builder[] */
+    private readonly array $defaultBuilders;
 
     public function __construct(Builder ...$builders)
     {
         $this->builders = $builders;
-        $this->builders[] = new AttributeBuilder();
-        $this->builders[] = new RequestBuilder();
-        $this->builders[] = new ResponseBuilder();
+
+        $this->defaultBuilders = [
+            new AttributeBuilder(),
+            new RequestBuilder(),
+            new ResponseBuilder(),
+        ];
+    }
+
+    public static function withoutDefaults(Builder ...$builders): self
+    {
+        $membrane = new Membrane(...$builders);
+        $membrane->allowDefaults = false;
+        return $membrane;
     }
 
     public function process(mixed $data, Specification ...$against): Result
@@ -47,7 +60,12 @@ final class Membrane
 
     private function getProcessorFor(Specification $specification): Processor
     {
-        foreach ($this->builders as $builder) {
+        $allowedBuilders = $this->builders;
+        if ($this->allowDefaults) {
+            array_push($allowedBuilders, ...$this->defaultBuilders);
+        }
+
+        foreach ($allowedBuilders as $builder) {
             if ($builder->supports($specification)) {
                 return $builder->build($specification);
             }

--- a/tests/MembraneTest.php
+++ b/tests/MembraneTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Tests;
+
+use Generator;
+use Membrane\Attribute\ClassWithAttributes;
+use Membrane\Builder\Specification;
+use Membrane\Membrane;
+use Membrane\OpenAPI\Specification\Request;
+use Membrane\OpenAPI\Specification\Response;
+use Membrane\OpenAPIReader\Method;
+use Membrane\Result\Result;
+use Membrane\Tests\Fixtures\Attribute\EmptyClass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(Membrane::class)]
+class MembraneTest extends TestCase
+{
+    private const __FIXTURES__ = __DIR__ . '/fixtures/';
+
+    public static function provideSpecifications(): Generator
+    {
+        yield 'Attributes' => [
+            new class {
+            },
+            new ClassWithAttributes(EmptyClass::class),
+        ];
+        yield 'Request' => [
+            new \GuzzleHttp\Psr7\Request('get', ''),
+            new Request(self::__FIXTURES__ . 'OpenAPI/hatstore.json', '/hats', Method::GET),
+        ];
+        yield 'Response' => [
+            new \GuzzleHttp\Psr7\Response(),
+            new Response(self::__FIXTURES__ . 'OpenAPI/hatstore.json', '/hats', Method::GET, '200'),
+        ];
+    }
+
+    #[Test, DataProvider('provideSpecifications')]
+    public function itMayAllowDefaultBuilders(
+        mixed $value,
+        Specification $specification
+    ): void {
+        $sut = new Membrane();
+
+        self::assertInstanceOf(
+            Result::class,
+            $sut->process($value, $specification)
+        );
+    }
+
+    #[Test, DataProvider('provideSpecifications')]
+    public function itMayDisallowDefaultBuilders(
+        mixed $value,
+        Specification $specification
+    ): void {
+        $sut = Membrane::withoutDefaults();
+
+        self::expectException(RuntimeException::class);
+
+        $sut->process($value, $specification);
+    }
+}


### PR DESCRIPTION
close #128 

Provides static constructor to Membrane to avoid using default builders.

```php
Membrane::withoutDefaults(Builder ...$builders);
```

Behaviour of Membrane via standard construction remains unchanged.