### PR TITLE
Complex schema message branches

### DIFF
--- a/src/OpenAPI/Builder/APIBuilder.php
+++ b/src/OpenAPI/Builder/APIBuilder.php
@@ -100,6 +100,10 @@ abstract class APIBuilder implements Builder
         array $subSchemas,
         bool $convertFromString
     ): Processor {
+        if (empty($subSchemas)) {
+            throw OpenAPI\Exception\CannotProcessOpenAPI::pointlessComplexSchema($fieldName);
+        }
+
         if (count($subSchemas) < 2) {
             assert($subSchemas[0] instanceof Schema);
             return $this->fromSchema($subSchemas[0], $fieldName, $convertFromString);
@@ -109,9 +113,15 @@ abstract class APIBuilder implements Builder
 
         foreach ($subSchemas as $index => $subSchema) {
             assert($subSchema instanceof Schema);
+
+            $title = null;
+            if (isset($subSchema->title) && $subSchema->title !== '') {
+                $title = $subSchema->title;
+            }
+
             $subProcessors[] = $this->fromSchema(
                 $subSchema,
-                sprintf('Branch-%s', $index + 1),
+                $title ?? sprintf('Branch-%s', $index + 1),
                 $convertFromString
             );
         }

--- a/src/OpenAPI/Builder/APIBuilder.php
+++ b/src/OpenAPI/Builder/APIBuilder.php
@@ -8,7 +8,9 @@ use cebe\openapi\spec\Reference;
 use cebe\openapi\spec\Schema;
 use Membrane\Builder\Builder;
 use Membrane\OpenAPI;
+use Membrane\OpenAPI\Processor\AllOf;
 use Membrane\OpenAPI\Processor\AnyOf;
+use Membrane\OpenAPI\Processor\OneOf;
 use Membrane\Processor;
 use Membrane\Processor\Field;
 use Membrane\Validator\Type\IsNull;
@@ -33,15 +35,30 @@ abstract class APIBuilder implements Builder
         }
 
         if ($schema->allOf !== null) {
-            return $this->handleAllOf($schema->allOf, $fieldName, $convertFromString);
+            return $this->fromComplexSchema(
+                AllOf::class,
+                $fieldName,
+                $schema->allOf,
+                $convertFromString
+            );
         }
 
         if ($schema->anyOf !== null) {
-            return $this->handleAnyOf($schema->anyOf, $fieldName, $convertFromString);
+            return $this->fromComplexSchema(
+                AnyOf::class,
+                $fieldName,
+                $schema->anyOf,
+                $convertFromString
+            );
         }
 
         if ($schema->oneOf !== null) {
-            return $this->handleOneOf($schema->oneOf, $fieldName, $convertFromString);
+            return $this->fromComplexSchema(
+                OneOf::class,
+                $fieldName,
+                $schema->oneOf,
+                $convertFromString
+            );
         }
 
         return match ($schema->type) {
@@ -71,6 +88,35 @@ abstract class APIBuilder implements Builder
             new Field($fieldName, new IsNull()),
             $processor
         );
+    }
+
+    /**
+     * @param class-string<AllOf|AnyOf|OneOf> $complexSchemaClass
+     * @param Reference[]|Schema[] $subSchemas
+     */
+    private function fromComplexSchema(
+        string $complexSchemaClass,
+        string $fieldName,
+        array $subSchemas,
+        bool $convertFromString
+    ): Processor {
+        if (count($subSchemas) < 2) {
+            assert($subSchemas[0] instanceof Schema);
+            return $this->fromSchema($subSchemas[0], $fieldName, $convertFromString);
+        }
+
+        $subProcessors = [];
+
+        foreach ($subSchemas as $index => $subSchema) {
+            assert($subSchema instanceof Schema);
+            $subProcessors[] = $this->fromSchema(
+                $subSchema,
+                sprintf('Branch-%s', $index + 1),
+                $convertFromString
+            );
+        }
+
+        return new $complexSchemaClass($fieldName, ...$subProcessors);
     }
 
     private function getArrayBuilder(): Arrays
@@ -107,63 +153,6 @@ abstract class APIBuilder implements Builder
         }
 
         return $this->numericBuilder;
-    }
-
-    /** @param Reference[]|Schema[] $allOf */
-    private function handleAllOf(array $allOf, string $fieldName, bool $convertFromString): Processor
-    {
-        if (count($allOf) < 2) {
-            assert($allOf[0] instanceof Schema);
-            return $this->fromSchema($allOf[0], $fieldName, $convertFromString);
-        }
-
-        $fieldSets = [];
-
-        // @TODO add key to messages in a useful format
-        foreach ($allOf as $key => $objectSchema) {
-            assert($objectSchema instanceof Schema);
-            $fieldSets[] = $this->fromSchema($objectSchema, $fieldName, $convertFromString);
-        }
-
-        return new OpenAPI\Processor\AllOf($fieldName, ...$fieldSets);
-    }
-
-    /** @param Reference[]|Schema[] $anyOf */
-    private function handleAnyOf(array $anyOf, string $fieldName, bool $convertFromString): Processor
-    {
-        if (count($anyOf) < 2) {
-            assert($anyOf[0] instanceof Schema);
-            return $this->fromSchema($anyOf[0], $fieldName, $convertFromString);
-        }
-
-        $fieldSets = [];
-
-        // @TODO add key to messages in a useful format
-        foreach ($anyOf as $objectSchema) {
-            assert($objectSchema instanceof Schema);
-            $fieldSets[] = $this->fromSchema($objectSchema, $fieldName, $convertFromString);
-        }
-
-        return new OpenAPI\Processor\AnyOf($fieldName, ...$fieldSets);
-    }
-
-    /** @param Reference[]|Schema[] $oneOf */
-    private function handleOneOf(array $oneOf, string $fieldName, bool $convertFromString): Processor
-    {
-        if (count($oneOf) < 2) {
-            assert($oneOf[0] instanceof Schema);
-            return $this->fromSchema($oneOf[0], $fieldName, $convertFromString);
-        }
-
-        $fieldSets = [];
-
-        // @TODO add key to messages in a useful format
-        foreach ($oneOf as $objectSchema) {
-            assert($objectSchema instanceof Schema);
-            $fieldSets[] = $this->fromSchema($objectSchema, $fieldName, $convertFromString);
-        }
-
-        return new OpenAPI\Processor\OneOf($fieldName, ...$fieldSets);
     }
 
     private function getStringBuilder(): Strings

--- a/src/OpenAPI/Exception/CannotProcessOpenAPI.php
+++ b/src/OpenAPI/Exception/CannotProcessOpenAPI.php
@@ -23,6 +23,7 @@ class CannotProcessOpenAPI extends RuntimeException
     public const UNSUPPORTED_STYLE = 3;
     public const REFERENCES_NOT_RESOLVED = 4;
     public const MISSING_OPERATION_ID = 5;
+    public const REDUNDANT_COMPLEX_SCHEMA = 6;
 
     public static function invalidOpenAPI(string $fileName, string ...$errors): self
     {
@@ -86,5 +87,11 @@ class CannotProcessOpenAPI extends RuntimeException
             $method->value
         );
         return new self($message, self::MISSING_OPERATION_ID);
+    }
+
+    public static function pointlessComplexSchema(string $fieldName): self
+    {
+        $message = sprintf('"%s" has a redundant complex schema as it has no subschemas', $fieldName);
+        return new self($message, self::REDUNDANT_COMPLEX_SCHEMA);
     }
 }

--- a/tests/OpenAPI/Builder/ObjectsTest.php
+++ b/tests/OpenAPI/Builder/ObjectsTest.php
@@ -108,8 +108,8 @@ class ObjectsTest extends TestCase
                     new DefaultProcessor(
                         new OneOf(
                             '',
-                            new Field('', new IsBool()),
-                            new Field('', new IsInt()),
+                            new Field('Branch-1', new IsBool()),
+                            new Field('Branch-2', new IsInt()),
                         )
                     )
                 ),

--- a/tests/OpenAPI/Builder/OpenAPIRequestBuilderTest.php
+++ b/tests/OpenAPI/Builder/OpenAPIRequestBuilderTest.php
@@ -544,8 +544,13 @@ class OpenAPIRequestBuilderTest extends TestCase
                                     'in' => 'query',
                                     'schema' => [
                                         $xOf => [
-                                            ['type' => 'boolean'],
-                                            ['type' => 'integer'],
+                                            [
+                                                'title' => 'Uno',
+                                                'type' => 'boolean',
+                                            ],
+                                            [
+                                                'type' => 'integer',
+                                            ],
                                         ],
                                     ],
                                 ],
@@ -587,7 +592,7 @@ class OpenAPIRequestBuilderTest extends TestCase
             $complexProcessor(
                 new OneOf(
                     'complexity',
-                    new Field('Branch-1', new BoolString(), new ToBool()),
+                    new Field('Uno', new BoolString(), new ToBool()),
                     new Field('Branch-2', new IntString(), new ToInt())
                 )
             ),
@@ -602,7 +607,7 @@ class OpenAPIRequestBuilderTest extends TestCase
             $complexProcessor(
                 new AnyOf(
                     'complexity',
-                    new Field('Branch-1', new BoolString(), new ToBool()),
+                    new Field('Uno', new BoolString(), new ToBool()),
                     new Field('Branch-2', new IntString(), new ToInt())
                 )
             ),
@@ -617,7 +622,7 @@ class OpenAPIRequestBuilderTest extends TestCase
             $complexProcessor(
                 new AllOf(
                     'complexity',
-                    new Field('Branch-1', new BoolString(), new ToBool()),
+                    new Field('Uno', new BoolString(), new ToBool()),
                     new Field('Branch-2', new IntString(), new ToInt())
                 )
             ),

--- a/tests/OpenAPI/Builder/OpenAPIRequestBuilderTest.php
+++ b/tests/OpenAPI/Builder/OpenAPIRequestBuilderTest.php
@@ -587,8 +587,8 @@ class OpenAPIRequestBuilderTest extends TestCase
             $complexProcessor(
                 new OneOf(
                     'complexity',
-                    new Field('complexity', new BoolString(), new ToBool()),
-                    new Field('complexity', new IntString(), new ToInt())
+                    new Field('Branch-1', new BoolString(), new ToBool()),
+                    new Field('Branch-2', new IntString(), new ToInt())
                 )
             ),
         ];
@@ -602,8 +602,8 @@ class OpenAPIRequestBuilderTest extends TestCase
             $complexProcessor(
                 new AnyOf(
                     'complexity',
-                    new Field('complexity', new BoolString(), new ToBool()),
-                    new Field('complexity', new IntString(), new ToInt())
+                    new Field('Branch-1', new BoolString(), new ToBool()),
+                    new Field('Branch-2', new IntString(), new ToInt())
                 )
             ),
         ];
@@ -617,8 +617,8 @@ class OpenAPIRequestBuilderTest extends TestCase
             $complexProcessor(
                 new AllOf(
                     'complexity',
-                    new Field('complexity', new BoolString(), new ToBool()),
-                    new Field('complexity', new IntString(), new ToInt())
+                    new Field('Branch-1', new BoolString(), new ToBool()),
+                    new Field('Branch-2', new IntString(), new ToInt())
                 )
             ),
         ];

--- a/tests/OpenAPI/Builder/OpenAPIResponseBuilderTest.php
+++ b/tests/OpenAPI/Builder/OpenAPIResponseBuilderTest.php
@@ -599,8 +599,8 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new AllOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
                 ),
             ],
             'allOf, two objects, one unique parameters' => [
@@ -611,8 +611,8 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new AllOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('name', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'allOf, two objects, conflicting parameter' => [
@@ -623,8 +623,8 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new AllOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'allOf, two objects, unique parameters, one requiredField' => [
@@ -635,9 +635,9 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new AllOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new BeforeSet(new IsArray(), new RequiredFields('name')),
                         new Field('name', new IsString())
                     )
@@ -652,12 +652,12 @@ class OpenAPIResponseBuilderTest extends TestCase
                 new AllOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -672,12 +672,12 @@ class OpenAPIResponseBuilderTest extends TestCase
                 new AllOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     )
@@ -699,8 +699,8 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new AnyOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
                 ),
             ],
             'anyOf, two objects, one unique parameters' => [
@@ -711,8 +711,8 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new AnyOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('name', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'anyOf, two objects, conflicting parameter' => [
@@ -723,8 +723,8 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new AnyOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'anyOf, two objects, unique parameters, one requiredField' => [
@@ -735,9 +735,9 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new AnyOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -752,12 +752,12 @@ class OpenAPIResponseBuilderTest extends TestCase
                 new AnyOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -772,12 +772,12 @@ class OpenAPIResponseBuilderTest extends TestCase
                 new AnyOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     )
@@ -799,8 +799,8 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new OneOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
                 ),
             ],
             'oneOf, two objects, one unique parameters' => [
@@ -811,8 +811,8 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new OneOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('name', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'oneOf, two objects, conflicting parameter' => [
@@ -823,8 +823,8 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new OneOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'oneOf, two objects, unique parameters, one requiredField' => [
@@ -835,9 +835,9 @@ class OpenAPIResponseBuilderTest extends TestCase
                 ),
                 new OneOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -852,12 +852,12 @@ class OpenAPIResponseBuilderTest extends TestCase
                 new OneOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -872,12 +872,12 @@ class OpenAPIResponseBuilderTest extends TestCase
                 new OneOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     )

--- a/tests/OpenAPI/Builder/ResponseBuilderTest.php
+++ b/tests/OpenAPI/Builder/ResponseBuilderTest.php
@@ -617,8 +617,8 @@ class ResponseBuilderTest extends TestCase
                 ),
                 new AllOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
                 ),
             ],
             'allOf, two objects, one unique parameters' => [
@@ -630,8 +630,8 @@ class ResponseBuilderTest extends TestCase
                 ),
                 new AllOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('name', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'allOf, two objects, conflicting parameter' => [
@@ -643,17 +643,17 @@ class ResponseBuilderTest extends TestCase
                 ),
                 new AllOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'allOf, two objects, unique parameters, one requiredField' => [
                 new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '304'),
                 new AllOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new BeforeSet(new IsArray(), new RequiredFields('name')),
                         new Field('name', new IsString())
                     )
@@ -664,12 +664,12 @@ class ResponseBuilderTest extends TestCase
                 new AllOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -680,12 +680,12 @@ class ResponseBuilderTest extends TestCase
                 new AllOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     )
@@ -704,8 +704,8 @@ class ResponseBuilderTest extends TestCase
                 new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '321'),
                 new AnyOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
                 ),
             ],
             'anyOf, two objects, one unique parameters' => [
@@ -717,8 +717,8 @@ class ResponseBuilderTest extends TestCase
                 ),
                 new AnyOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('name', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'anyOf, two objects, conflicting parameter' => [
@@ -730,17 +730,17 @@ class ResponseBuilderTest extends TestCase
                 ),
                 new AnyOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'anyOf, two objects, unique parameters, one requiredField' => [
                 new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '324'),
                 new AnyOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -756,12 +756,12 @@ class ResponseBuilderTest extends TestCase
                 new AnyOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -777,12 +777,12 @@ class ResponseBuilderTest extends TestCase
                 new AnyOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     )
@@ -796,16 +796,16 @@ class ResponseBuilderTest extends TestCase
                 new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '341'),
                 new OneOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsInt()), new BeforeSet(new IsArray()))
                 ),
             ],
             'oneOf, two objects, one unique parameters' => [
                 new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '342'),
                 new OneOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('name', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('name', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'oneOf, two objects, conflicting parameter' => [
@@ -817,17 +817,17 @@ class ResponseBuilderTest extends TestCase
                 ),
                 new OneOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
-                    new FieldSet('', new Field('id', new IsString()), new BeforeSet(new IsArray()))
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-2', new Field('id', new IsString()), new BeforeSet(new IsArray()))
                 ),
             ],
             'oneOf, two objects, unique parameters, one requiredField' => [
                 new Response(self::DIR . 'noReferences.json', '/responsepath', Method::GET, '344'),
                 new OneOf(
                     '',
-                    new FieldSet('', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
+                    new FieldSet('Branch-1', new Field('id', new IsInt()), new BeforeSet(new IsArray())),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -843,12 +843,12 @@ class ResponseBuilderTest extends TestCase
                 new OneOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     )
@@ -864,12 +864,12 @@ class ResponseBuilderTest extends TestCase
                 new OneOf(
                     '',
                     new FieldSet(
-                        '',
+                        'Branch-1',
                         new Field('id', new IsInt()),
                         new BeforeSet(new IsArray(), new RequiredFields('name'))
                     ),
                     new FieldSet(
-                        '',
+                        'Branch-2',
                         new Field('name', new IsString()),
                         new BeforeSet(new IsArray(), new RequiredFields('id'))
                     )


### PR DESCRIPTION
close #135 

subschemas within AnyOf|AllOf|OneOf will have the sub-schema's title if available or fallback to 'Branch 1', 'Branch 2' etc.

Refactors all complex schemas to use same method.

Adds a conditional check for empty complex schemas which are technically valid but completely pointless.