### PR TITLE
Remove strict flag from DateString Validator

### DIFF
--- a/src/OpenAPI/Builder/Strings.php
+++ b/src/OpenAPI/Builder/Strings.php
@@ -31,11 +31,11 @@ class Strings extends APIBuilder
         }
 
         if ($specification->format === 'date') {
-            $chain[] = new DateString('Y-m-d', true);
+            $chain[] = new DateString('Y-m-d');
         }
 
         if ($specification->format === 'date-time') {
-            $chain[] = new DateString('Y-m-d\TH:i:sP', true);
+            $chain[] = new DateString('Y-m-d\TH:i:sP');
         }
 
         if ($specification->minLength > 0 || $specification->maxLength !== null) {

--- a/src/Validator/String/DateString.php
+++ b/src/Validator/String/DateString.php
@@ -12,8 +12,9 @@ use Membrane\Validator;
 
 class DateString implements Validator
 {
-    public function __construct(private readonly string $format, private readonly bool $strict = false)
-    {
+    public function __construct(
+        private readonly string $format,
+    ) {
     }
 
     public function __toString(): string
@@ -23,7 +24,7 @@ class DateString implements Validator
 
     public function __toPHP(): string
     {
-        return sprintf('new %s("%s", %s)', self::class, $this->format, $this->strict ? 'true' : 'false');
+        return sprintf('new %s("%s")', self::class, $this->format);
     }
 
     public function validate(mixed $value): Result
@@ -37,11 +38,6 @@ class DateString implements Validator
 
         if ($dateTime === false) {
             $message = new Message('String does not match the required format %s', [$this->format]);
-            return Result::invalid($value, new MessageSet(null, $message));
-        }
-
-        if ($this->strict && $value !== $dateTime->format($this->format)) {
-            $message = new Message('String does not represent a valid date in format %s', [$this->format]);
             return Result::invalid($value, new MessageSet(null, $message));
         }
 

--- a/tests/Validator/String/DateStringTest.php
+++ b/tests/Validator/String/DateStringTest.php
@@ -77,6 +77,7 @@ class DateStringTest extends TestCase
             ['', ''],
             ['Y-m-d', '1970-01-01'],
             ['d-M-y', '20-feb-22'],
+            [DATE_RFC3339, '2019-08-24T14:15:22Z']
         ];
     }
 
@@ -112,28 +113,5 @@ class DateStringTest extends TestCase
         $result = $dateString->validate($input);
 
         self::assertEquals($expected, $result);
-    }
-
-    #[Test, TestDox('Tests that a date which matches the format string but is otherwise invalid fails validation')]
-    public function testInvalidDateFailsValidationInStrictMode(): void
-    {
-        $format = 'Y-m-d';
-        $value = '2022-13-05';
-
-        $expectedMessage = new Message('String does not represent a valid date in format %s', [$format]);
-        $expected = Result::invalid($value, new MessageSet(null, $expectedMessage));
-
-        $sut = new DateString($format, true);
-
-        $result = $sut->validate($value);
-        self::assertEquals($expected, $result);
-    }
-
-    #[Test, TestDox('Tests a format which cannot be used in strict mode still validates properly in non-strict mode')]
-    public function testDatesPassInNonStrictMode(): void
-    {
-        $sut = new DateString('Y-m-d|', false);
-
-        self::assertTrue($sut->validate('2022-05-13')->isValid());
     }
 }


### PR DESCRIPTION
Removes the strict flag from DateString.

Setting the strict flag to true erroneously invalidated date strings in valid [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) formats (The RFC [followed by OpenAPI for dates and date-time formats](https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.0.3.md#data-types)).

I may be mistaken but it did not seem to serve much purpose, so I have removed it to avoid it causing further error.