### PR TITLE
Fix String\Length Validator for multibyte chararacters

### DIFF
--- a/src/Validator/String/Length.php
+++ b/src/Validator/String/Length.php
@@ -47,7 +47,7 @@ class Length implements Validator
             return Result::invalid($value, new MessageSet(null, $message));
         }
 
-        $length = strlen($value);
+        $length = mb_strlen($value);
 
         if ($length < $this->min) {
             $message = new Message('String is expected to be a minimum of %d characters', [$this->min]);

--- a/tests/Validator/String/LengthTest.php
+++ b/tests/Validator/String/LengthTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Membrane\Tests\Validator\String;
 
+use Generator;
 use Membrane\Result\Message;
 use Membrane\Result\MessageSet;
 use Membrane\Result\Result;
@@ -20,34 +21,8 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(Message::class)]
 class LengthTest extends TestCase
 {
-    public static function dataSetsToConvertToString(): array
-    {
-        return [
-            'no conditions' => [
-                0,
-                null,
-                'will return valid',
-            ],
-            'non-zero minimum provided' => [
-                1,
-                null,
-                'is 1 characters or more',
-            ],
-            'maximum provided' => [
-                0,
-                5,
-                'is 5 characters or less',
-            ],
-            'minimum and maximum provided' => [
-                2,
-                4,
-                'is 2 characters or more and is 4 characters or less',
-            ],
-        ];
-    }
-
-    #[DataProvider('dataSetsToConvertToString')]
     #[Test]
+    #[DataProvider('provideToStringCases')]
     public function toStringTest(int $min, ?int $max, string $expected): void
     {
         $sut = new Length($min, $max);
@@ -57,16 +32,8 @@ class LengthTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public static function dataSetsToConvertToPHPString(): array
-    {
-        return [
-            'default arguments' => [new Length()],
-            'assigned arguments' => [new Length(1, 5)],
-        ];
-    }
-
-    #[DataProvider('dataSetsToConvertToPHPString')]
     #[Test]
+    #[DataProvider('provideToPHPCases')]
     public function toPHPTest(Length $sut): void
     {
         $actual = $sut->__toPHP();
@@ -74,27 +41,19 @@ class LengthTest extends TestCase
         self::assertEquals($sut, eval('return ' . $actual . ';'));
     }
 
-    public static function dataSetsWithIncorrectTypes(): array
-    {
-        return [
-            [123, 'integer'],
-            [1.23, 'double'],
-            [[], 'array'],
-            [true, 'boolean'],
-            [null, 'NULL'],
-        ];
-    }
-
-    #[DataProvider('dataSetsWithIncorrectTypes')]
     #[Test]
-    public function incorrectTypesReturnInvalidResults($input, $expectedVars): void
+    #[DataProvider('provideNonStringTypes')]
+    public function itInvalidatesNonStringTypes(mixed $input): void
     {
         $length = new Length();
         $expected = Result::invalid(
             $input,
             new MessageSet(
                 null,
-                new Message('Length Validator requires a string, %s given', [$expectedVars])
+                new Message(
+                    'Length Validator requires a string, %s given',
+                    [gettype($input)]
+                )
             )
         );
 
@@ -103,51 +62,183 @@ class LengthTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public static function dataSetsThatPass(): array
-    {
-        return [
-            ['', 0, 0],
-            ['', 0, null],
-            ['', 0, 5],
-            ['short', 0, 5],
-            ['longer string', 5, 100],
-        ];
-    }
-
-    #[DataProvider('dataSetsThatPass')]
     #[Test]
-    public function stringLengthWithinMinAndMaxReturnsValid(mixed $input, int $min, ?int $max): void
-    {
-        $expected = Result::valid($input);
-        $length = new Length($min, $max);
-
-        $result = $length->validate($input);
-
-        self::assertEquals($expected, $result);
-    }
-
-    public static function dataSetsThatFail(): array
-    {
-        return [
-            ['', 1, 5, new Message('String is expected to be a minimum of %d characters', [1])],
-            ['short', 6, 10, new Message('String is expected to be a minimum of %d characters', [6])],
-            ['longer string.', 6, 10, new Message('String is expected to be a maximum of %d characters', [10])],
-        ];
-    }
-
-    #[DataProvider('dataSetsThatFail')]
-    #[Test]
-    public function stringLengthOutsideMinOrMaxReturnsInvalid(
-        mixed $input,
+    #[DataProvider('provideStringsToValidate')]
+    public function itValidatesStringLengths(
+        Result $expected,
         int $min,
         ?int $max,
-        Message $expectedMessage
+        string $input
     ): void {
-        $expected = Result::invalid($input, new MessageSet(null, $expectedMessage));
-        $length = new Length($min, $max);
+        $sut = new Length($min, $max);
 
-        $result = $length->validate($input);
+        $actual = $sut->validate($input);
 
-        self::assertEquals($expected, $result);
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * @return array<array{
+     *     0: int,
+     *     1: ?int,
+     *     2: string,
+     * }>
+     */
+    public static function provideToStringCases(): array
+    {
+        return [
+            'no conditions' => [
+                0,
+                null,
+                'will return valid',
+            ],
+            'non-zero min' => [
+                1,
+                null,
+                'is 1 characters or more',
+            ],
+            'non-null max' => [
+                0,
+                5,
+                'is 5 characters or less',
+            ],
+            'non-zero min and non-null max' => [
+                2,
+                4,
+                'is 2 characters or more and is 4 characters or less',
+            ],
+        ];
+    }
+
+
+    public static function provideToPHPCases(): array
+    {
+        return [
+            'default arguments' => [new Length()],
+            'assigned arguments' => [new Length(1, 5)],
+        ];
+    }
+
+    public static function provideNonStringTypes(): array
+    {
+        return [
+            [123],
+            [1.23],
+            [[]],
+            [true],
+            [null],
+        ];
+    }
+
+    /**
+     * @return Generator<array{
+     *     0: Result,
+     *     1: int,
+     *     2: ?int,
+     *     3: string,
+     * }>
+     */
+    public static function provideStringsToValidate(): Generator
+    {
+        $invalidCase = fn($input, $min, $max, $message) => [
+            Result::invalid($input, new MessageSet(null, $message)),
+            $min,
+            $max,
+            $input,
+        ];
+
+        $validCase = fn($input, $min, $max) => [
+            Result::valid($input),
+            $min,
+            $max,
+            $input,
+        ];
+
+        yield 'empty string below min' => $invalidCase(
+            '',
+            1,
+            null,
+            new Message('String is expected to be a minimum of %d characters', [1])
+        );
+
+        yield 'empty string within range (inclusive min)' => $validCase(
+            '',
+            0,
+            null
+        );
+
+        yield 'empty string within range (inclusive min and max)' => $validCase(
+            '',
+            0,
+            0,
+        );
+
+        yield '"string" with min of zero and no max' => $validCase(
+          'string',
+          0,
+          null,
+        );
+
+        yield '"string" within range' => $validCase(
+          'string',
+          5,
+          7,
+        );
+
+        yield '"string" within range (inclusive min)' => $validCase(
+            'string',
+            6,
+            7,
+        );
+
+        yield '"string" within range (inclusive max)' => $validCase(
+            'string',
+            5,
+            6,
+        );
+
+        yield '"string" within range (inclusive min and max)' => $validCase(
+            'string',
+            6,
+            6,
+        );
+
+        yield '"short" below min' => $invalidCase(
+            'short',
+            6,
+            null,
+            new Message('String is expected to be a minimum of %d characters', [6])
+        );
+
+        yield '"long" above max' => $invalidCase(
+            'long',
+            0,
+            3,
+            new Message('String is expected to be a maximum of %d characters', [3])
+        );
+
+        yield '"äöü" within range' => $validCase(
+            'äöü',
+            2,
+            4,
+        );
+
+        yield '"äöü" within range (inclusive min)' => $validCase(
+            'äöü',
+            3,
+            4,
+        );
+
+        yield '"äöü" within range (inclusive max)' => $validCase(
+            'äöü',
+            2,
+            5,
+        );
+
+        yield '"äöü" within range (inclusive min and max)' => $validCase(
+            'äöü',
+            3,
+            3,
+        );
     }
 }


### PR DESCRIPTION
Closes #171

Use mb_strlen instead of strlen to avoid multibyte characters being considered as more than 1.