### PR TITLE
Add NullOr Filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^10.1",
-    "phpstan/phpstan": "^1.10.19",
+    "phpstan/phpstan": "^1.12.5",
     "squizlabs/php_codesniffer": "^3.7",
     "guzzlehttp/psr7": "^2.4",
     "mikey179/vfsstream": "^1.6.7"

--- a/src/Filter/Type/NullOr.php
+++ b/src/Filter/Type/NullOr.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Filter\Type;
+
+use Membrane\Filter;
+use Membrane\Result\Result;
+
+final class NullOr implements Filter
+{
+    public function __construct(
+        private readonly Filter $alternativeFilter,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('Accept null or %s', $this->alternativeFilter);
+    }
+
+    public function __toPHP(): string
+    {
+        return sprintf(
+            'new %s(%s)',
+            self::class,
+            $this->alternativeFilter->__toPHP(),
+        );
+    }
+
+    public function filter(mixed $value): Result
+    {
+        return $value === null ?
+            Result::noResult(null) :
+            $this->alternativeFilter->filter($value);
+    }
+}

--- a/tests/Filter/Type/NullOrTest.php
+++ b/tests/Filter/Type/NullOrTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Tests\Filter\Type;
+
+use Generator;
+use Membrane\Filter;
+use Membrane\Result\Message;
+use Membrane\Result\MessageSet;
+use Membrane\Result\Result;
+use Membrane\Tests\Fixtures\Filter\ToThis;
+use Membrane\Tests\MembraneTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+
+#[CoversClass(Filter\Type\NullOr::class)]
+#[UsesClass(Result::class)]
+#[UsesClass(MessageSet::class)]
+#[UsesClass(Message::class)]
+class NullOrTest extends MembraneTestCase
+{
+    #[Test]
+    public function itFiltersNull(): void
+    {
+        $sut = new Filter\Type\NullOr(new ToThis());
+
+        self::assertResultEquals(Result::noResult(null), $sut->filter(null));
+    }
+
+    #[Test]
+    public function itDefersNonNulls(): void
+    {
+        $alternativeFilter = new ToThis();
+
+        $sut = new Filter\Type\NullOr($alternativeFilter);
+
+        self::assertResultEquals(
+            Result::noResult($alternativeFilter),
+            $sut->filter('Hello, World!')
+        );
+    }
+
+    #[Test, DataProvider('provideAlternativeFilters')]
+    public function itIsStringable(Filter $alternativeFilter,): void
+    {
+        $expected = "Accept null or $alternativeFilter";
+
+        $sut = new Filter\Type\NullOr($alternativeFilter);
+
+        self::assertSame($expected, $sut->__toString());
+    }
+
+    #[Test, DataProvider('provideAlternativeFilters')]
+    public function itIsPHPStringable(Filter $alternativeFilter): void
+    {
+        $sut = new Filter\Type\NullOr($alternativeFilter);
+
+        $actual = $sut->__toPHP();
+
+        self::assertEquals($sut, eval('return ' . $actual . ';'));
+    }
+
+    public static function provideAlternativeFilters(): Generator
+    {
+        yield [new Filter\Type\ToBool()];
+        yield [new Filter\String\ToPascalCase()];
+        yield [new Filter\Type\NullOr(new Filter\Type\ToBool())];
+    }
+}

--- a/tests/fixtures/Filter/ToThis.php
+++ b/tests/fixtures/Filter/ToThis.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Membrane\Tests\Fixtures\Filter;
+
+use Membrane\Filter;
+use Membrane\Result\Result;
+
+final class ToThis implements Filter
+{
+    public function filter(mixed $value): Result
+    {
+        return Result::noResult($this);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('Return %s', self::class);
+    }
+
+    public function __toPHP(): string
+    {
+        return sprintf('new %s()', self::class);
+    }
+}


### PR DESCRIPTION
Wraps another filter, accepts null or defers to wrapped filter. 
Useful for nullable properties.

Also adds `ToThis` filter for testing purposes. Ignores whatever value it is passed and returns itself as the `Result` `value`.